### PR TITLE
Resource description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## Release candidate
 
+### Breaking changes
+- Resource creation endpoint now accepts POST requests (#1, PLUM Sprint 210114)
+
 ### Fixes
 - Fixed permissions for tenant assignment (#2, PLUM Sprint 210114)
 
 ### Features
 - Cookie authentication in multi-domain setting (!219, PLUM Sprint 211217)
+- Resource description (#1, PLUM Sprint 210114)
 - Endpoints for simple tenant un/assignment (#2, PLUM Sprint 210114)
 
 ---

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import typing
 
 import asab.storage.exceptions
 


### PR DESCRIPTION
Add `description` property to resource objects.

**`BREAKING`** The **Create resource** call is now `POST` instead of `PUT`, i.e. `POST /resource/{resource_id}`.
It CAN have an optional JSON body containing the `description` property.

Added **Update resource description** endpoint:

```json
PUT /resource/{resource_id}
{
    "description": "<resource_description_here>"
}
```