### PR TITLE
Simple tenant un/assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Release candidate
 
+### Fixes
+- Fixed permissions for tenant assignment (#2, PLUM Sprint 210114)
+
 ### Features
 - Cookie authentication in multi-domain setting (!219, PLUM Sprint 211217)
+- Endpoints for simple tenant un/assignment (#2, PLUM Sprint 210114)
 
 ---
 

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -31,8 +31,8 @@ class TenantHandler(object):
 
 		web_app.router.add_get('/tenant_assign/{credentials_id}', self.get_tenants_by_credentials)
 		web_app.router.add_put('/tenant_assign/{credentials_id}', self.set_tenants)
-		web_app.router.add_put('/tenant_assign/{tenant}/{credentials_id}', self.assign_tenant)
-		web_app.router.add_delete('/tenant_assign/{tenant}/{credentials_id}', self.unassign_tenant)
+		web_app.router.add_post('/tenant_assign/{credentials_id}/{tenant}', self.assign_tenant)
+		web_app.router.add_delete('/tenant_assign/{credentials_id}/{tenant}', self.unassign_tenant)
 
 		web_app.router.add_get('/public/tenant_propose', self.propose_tenant)
 
@@ -174,28 +174,35 @@ class TenantHandler(object):
 
 
 	@asab.web.rest.json_schema_handler({
-		'type': 'object',
-		'properties': {
-			'tenants': {
-				'type': 'array',
+		"type": "object",
+		"required": [
+			"tenants",
+		],
+		"properties": {
+			"tenants": {
+				"type": "array",
 				"items": {
 					"type": "string",
 				},
 			},
 		}
 	})
-	@access_control("authz:tenant:admin")
+	@access_control()
 	async def set_tenants(self, request, *, json_data):
-		await self.TenantService.set_tenants(
-			request.match_info["credentials_id"],
-			json_data['tenants'],
+		"""
+		Helper method for bulk tenant un/assignment
+		"""
+		credentials_id = request.match_info["credentials_id"]
+		data = await self.TenantService.set_tenants(
+			session=request.Session,
+			credentials_id=credentials_id,
+			tenants=json_data["tenants"]
 		)
 
-		resp_data = {"result": "OK"}
 		return asab.web.rest.json_response(
 			request,
-			data=resp_data,
-			status=200
+			data=data,
+			status=200 if data["result"] == "OK" else 400
 		)
 
 

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -31,6 +31,8 @@ class TenantHandler(object):
 
 		web_app.router.add_get('/tenant_assign/{credentials_id}', self.get_tenants_by_credentials)
 		web_app.router.add_put('/tenant_assign/{credentials_id}', self.set_tenants)
+		web_app.router.add_put('/tenant_assign/{tenant}/{credentials_id}', self.assign_tenant)
+		web_app.router.add_delete('/tenant_assign/{tenant}/{credentials_id}', self.unassign_tenant)
 
 		web_app.router.add_get('/public/tenant_propose', self.propose_tenant)
 
@@ -194,6 +196,34 @@ class TenantHandler(object):
 			request,
 			data=resp_data,
 			status=200
+		)
+
+
+	@access_control("authz:tenant:admin")
+	async def assign_tenant(self, request, *, tenant):
+		data = await self.TenantService.assign_tenant(
+			request.match_info["credentials_id"],
+			tenant,
+		)
+
+		return asab.web.rest.json_response(
+			request,
+			data=data,
+			status=200 if data["result"] == "OK" else 400
+		)
+
+
+	@access_control("authz:tenant:admin")
+	async def unassign_tenant(self, request, *, tenant):
+		data = await self.TenantService.unassign_tenant(
+			request.match_info["credentials_id"],
+			tenant,
+		)
+
+		return asab.web.rest.json_response(
+			request,
+			data=data,
+			status=200 if data["result"] == "OK" else 400
 		)
 
 

--- a/seacatauth/tenant/providers/mongodb.py
+++ b/seacatauth/tenant/providers/mongodb.py
@@ -248,17 +248,6 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 		"""
 		Assign tenant to credentials
 		"""
-		# Check if credentials exist
-		try:
-			cred_svc = self.App.get_service("seacatauth.CredentialsService")
-			await cred_svc.detail(credentials_id)
-		except KeyError:
-			message = "Credentials not found"
-			L.error(message, struct_data={"cid": credentials_id})
-			return {
-				"result": "NOT-FOUND",
-				"message": message,
-			}
 
 		# Check if tenant exists
 		try:

--- a/seacatauth/tenant/providers/mongodb.py
+++ b/seacatauth/tenant/providers/mongodb.py
@@ -244,6 +244,86 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 		return True
 
 
+	async def assign_tenant(self, credentials_id: str, tenant: str):
+		"""
+		Assign tenant to credentials
+		"""
+		# Check if credentials exist
+		try:
+			cred_svc = self.App.get_service("seacatauth.CredentialsService")
+			await cred_svc.detail(credentials_id)
+		except KeyError:
+			message = "Credentials not found"
+			L.error(message, struct_data={"cid": credentials_id})
+			return {
+				"result": "NOT-FOUND",
+				"message": message,
+			}
+
+		# Check if tenant exists
+		try:
+			await self.get(tenant)
+		except KeyError:
+			message = "Tenant not found"
+			L.error(message, struct_data={"tenant": tenant})
+			return {
+				"result": "NOT-FOUND",
+				"message": message,
+			}
+
+		assignment_id = "{} {}".format(credentials_id, tenant)
+		upsertor = self.MongoDBStorageService.upsertor(self.AssignCollection, obj_id=assignment_id)
+		upsertor.set("c", credentials_id)
+		upsertor.set("t", tenant)
+
+		try:
+			await upsertor.execute()
+		except asab.storage.exceptions.DuplicateError:
+			message = "Credentials is already assigned to this tenant"
+			L.error(message, struct_data={"cid": credentials_id, "tenant": tenant})
+			return {
+				"result": "ALREADY-EXISTS",
+				"message": message,
+			}
+
+		L.log(asab.LOG_NOTICE, "Tenant successfully assigned to credentials", struct_data={
+			"cid": credentials_id,
+			"tenant": tenant,
+		})
+		return {"result": "OK"}
+
+
+	async def unassign_tenant(self, credentials_id: str, tenant: str):
+		"""
+		Unassign credentials from tenant
+		"""
+		# Unassign tenant roles
+		role_svc = self.App.get_service("seacatauth.RoleService")
+		await role_svc.set_roles(
+			credentials_id,
+			tenant_scope={tenant},
+			roles=[]
+		)
+
+		# Unassign the tenant
+		assignment_id = "{} {}".format(credentials_id, tenant)
+		try:
+			await self.MongoDBStorageService.delete(self.AssignCollection, obj_id=assignment_id)
+		except KeyError:
+			message = "Credentials is not assigned to this tenant"
+			L.error(message, struct_data={"cid": credentials_id, "tenant": tenant})
+			return {
+				"result": "NOT-FOUND",
+				"message": message,
+			}
+
+		L.log(asab.LOG_NOTICE, "Tenant successfully unassigned from credentials", struct_data={
+			"cid": credentials_id,
+			"tenant": tenant,
+		})
+		return {"result": "OK"}
+
+
 	async def list_tenant_assignments(self, tenant, page: int = 0, limit: int = None):
 		query_filter = {'t': tenant}
 		collection = await self.MongoDBStorageService.collection(self.AssignCollection)

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -47,10 +47,67 @@ class TenantService(asab.Service):
 		return result
 
 
-	# TODO: Refactor this using new assign_tenant and unassign_tenant methods
-	async def set_tenants(self, credentials_id: str, tenant_ids: list):
+	async def set_tenants(self, session, credentials_id: str, tenants: list):
 		assert(self.is_enabled())  # TODO: Replace this by a L.warning("Tenants are not configured.") & raise RuntimeError()
-		return await self.TenantsProvider.set_tenants(credentials_id, tenant_ids)
+		cred_svc = self.App.get_service("seacatauth.CredentialsService")
+		rbac_svc = self.App.get_service("seacatauth.RBACService")
+
+		# Check if credentials exist
+		try:
+			await cred_svc.detail(credentials_id)
+		except KeyError:
+			message = "Credentials not found"
+			L.error(message, struct_data={"cid": credentials_id})
+			return {
+				"result": "NOT-FOUND",
+				"message": message,
+			}
+
+		existing_tenants = set(await self.get_tenants(credentials_id))
+		new_tenants = set(tenants)
+		tenants_to_assign = new_tenants.difference(existing_tenants)
+		tenants_to_unassign = existing_tenants.difference(new_tenants)
+
+		for tenant in tenants_to_assign.union(tenants_to_unassign):
+			# Check if tenant exists
+			try:
+				await self.TenantsProvider.get(tenant)
+			except KeyError:
+				message = "Tenant not found"
+				L.error(message, struct_data={"tenant": tenant})
+				return {
+					"result": "NOT-FOUND",
+					"message": message,
+				}
+			# Check permission
+			if rbac_svc.has_resource_access(session.Authz, tenant, ["authz:tenant:admin"]) != "OK":
+				message = "Not authorized for tenant un/assignment"
+				L.error(message, struct_data={
+					"cid": session.CredentialsID,
+					"tenant": tenant
+				})
+				return {
+					"result": "NOT-AUTHORIZED",
+					"message": message,
+				}
+
+		failed_count = 0
+		for tenant in tenants_to_assign:
+			data = await self.TenantsProvider.assign_tenant(credentials_id, tenant)
+			if data["result"] != "OK":
+				failed_count += 1
+		for tenant in tenants_to_unassign:
+			data = await self.TenantsProvider.unassign_tenant(credentials_id, tenant)
+			if data["result"] != "OK":
+				failed_count += 1
+
+		L.log(asab.LOG_NOTICE, "Tenants successfully assigned to credentials", struct_data={
+			"cid": credentials_id,
+			"assigned_count": len(tenants_to_assign),
+			"unassigned_count": len(tenants_to_unassign),
+			"failed_count": failed_count,
+		})
+		return {"result": "OK"}
 
 
 	async def assign_tenant(self, credentials_id: str, tenant: list):

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -47,9 +47,21 @@ class TenantService(asab.Service):
 		return result
 
 
+	# TODO: Refactor this using new assign_tenant and unassign_tenant methods
 	async def set_tenants(self, credentials_id: str, tenant_ids: list):
 		assert(self.is_enabled())  # TODO: Replace this by a L.warning("Tenants are not configured.") & raise RuntimeError()
 		return await self.TenantsProvider.set_tenants(credentials_id, tenant_ids)
+
+
+	async def assign_tenant(self, credentials_id: str, tenant: list):
+		assert (self.is_enabled())
+		# TODO: Possibly validate tenant and credentials here
+		return await self.TenantsProvider.assign_tenant(credentials_id, tenant)
+
+
+	async def unassign_tenant(self, credentials_id: str, tenant: list):
+		assert (self.is_enabled())
+		return await self.TenantsProvider.unassign_tenant(credentials_id, tenant)
 
 
 	def is_enabled(self):

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -83,12 +83,13 @@ class TenantService(asab.Service):
 			if rbac_svc.has_resource_access(session.Authz, tenant, ["authz:tenant:admin"]) != "OK":
 				message = "Not authorized for tenant un/assignment"
 				L.error(message, struct_data={
-					"cid": session.CredentialsID,
+					"cid": session.CredentialsId,
 					"tenant": tenant
 				})
 				return {
 					"result": "NOT-AUTHORIZED",
 					"message": message,
+					"error_data": {"tenant": tenant},
 				}
 
 		failed_count = 0


### PR DESCRIPTION
Assign a single tenant to credentials using `POST /tenant_assign/{credentials_id}/{tenant}`.

Unassign a single tenant from credentials using `DELETE /tenant_assign/{credentials_id}/{tenant}`.

The old **set tenants** method has been refactored to use the new assign and unassign methods.

Fixes a bug where tenants can be assigned only by superuser. 
Now they can be assigned also by **tenant admin**.