### PR TITLE
Simple un/assign role methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Features
 - Cookie authentication in multi-domain setting (!219, PLUM Sprint 211217)
-- Endpoints for simple tenant un/assignment (#2, PLUM Sprint 210114)
+- Endpoints for single tenant un/assignment (#2, PLUM Sprint 210114)
+- Endpoints for single role un/assignment (#3, PLUM Sprint 210114)
 
 ### Refactoring
 - Remove `authz:credentials:admin` resource (#5, PLUM Sprint 210114)

--- a/seacatauth/authz/rbac/service.py
+++ b/seacatauth/authz/rbac/service.py
@@ -15,15 +15,17 @@ class RBACService(asab.Service):
 	def __init__(self, app, service_name="seacatauth.RBACService"):
 		super().__init__(app, service_name)
 
-	@staticmethod
-	def has_resource_access(authz: dict, tenant: typing.Union[str, None], requested_resources: list):
-		# Superuser passes without further checks
+	def is_superuser(self, authz: dict):
 		global_resources = set(
 			resource
-			for resources in authz["*"].values()
-			for resource in resources
+			for role in authz["*"].values()
+			for resource in role
 		)
-		if "authz:superuser" in global_resources:
+		return "authz:superuser" in global_resources
+
+	def has_resource_access(self, authz: dict, tenant: typing.Union[str, None], requested_resources: list):
+		# Superuser passes without further checks
+		if self.is_superuser(authz):
 			return "OK"
 
 		if tenant == "*":

--- a/seacatauth/authz/rbac/service.py
+++ b/seacatauth/authz/rbac/service.py
@@ -15,7 +15,8 @@ class RBACService(asab.Service):
 	def __init__(self, app, service_name="seacatauth.RBACService"):
 		super().__init__(app, service_name)
 
-	def is_superuser(self, authz: dict):
+	@staticmethod
+	def is_superuser(authz: dict):
 		global_resources = set(
 			resource
 			for role in authz["*"].values()
@@ -23,9 +24,10 @@ class RBACService(asab.Service):
 		)
 		return "authz:superuser" in global_resources
 
-	def has_resource_access(self, authz: dict, tenant: typing.Union[str, None], requested_resources: list):
+	@staticmethod
+	def has_resource_access(authz: dict, tenant: typing.Union[str, None], requested_resources: list):
 		# Superuser passes without further checks
-		if self.is_superuser(authz):
+		if RBACService.is_superuser(authz):
 			return "OK"
 
 		if tenant == "*":

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -17,10 +17,9 @@ L = logging.getLogger(__name__)
 
 
 class RoleHandler(object):
-	def __init__(self, app, rbac_svc):
-		self.RBACService = rbac_svc
-		self.RoleService = app.get_service("seacatauth.RoleService")
+	def __init__(self, app, role_svc):
 		self.App = app
+		self.RoleService = role_svc
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/role", self.list_all)

--- a/seacatauth/authz/role/handler/roles.py
+++ b/seacatauth/authz/role/handler/roles.py
@@ -16,10 +16,10 @@ L = logging.getLogger(__name__)
 
 
 class RolesHandler(object):
-	def __init__(self, app, rbac_svc):
+	def __init__(self, app, role_svc):
 		self.App = app
-		self.RBACService = rbac_svc
-		self.RoleService = app.get_service("seacatauth.RoleService")
+		self.RoleService = role_svc
+		self.RBACService = app.get_service("seacatauth.RBACService")
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get('/roles/{tenant}/{credentials_id}', self.get_roles_by_credentials)
@@ -153,7 +153,7 @@ class RolesHandler(object):
 					status=403
 				)
 
-		data = await self.RoleService.assign_role(
+		data = await self.RoleService.unassign_role(
 			credentials_id=request.match_info["credentials_id"],
 			role_id=role_id
 		)

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -102,10 +102,10 @@ class RoleService(asab.Service):
 		return "OK"
 
 	async def update_resources(
-			self, role_id: str,
-			resources_to_set: Optional[list] = None,
-			resources_to_add: Optional[list] = None,
-			resources_to_remove: Optional[list] = None
+		self, role_id: str,
+		resources_to_set: Optional[list] = None,
+		resources_to_add: Optional[list] = None,
+		resources_to_remove: Optional[list] = None
 	):
 		match = self.RoleIdRegex.match(role_id)
 		if match is None:


### PR DESCRIPTION
Introducing two new endpoints for un/assigning a single role (as an alternative to the bulk **set roles** call):

- `POST /role_assign/{credentials_id}/{role_id}` assigns a role to credentials.
- `DELETE /role_assign/{credentials_id}/{role_id}` unassigns a role from credentials.