### PR TITLE
Remove default list limits for roles and resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 - Fixed permissions for tenant assignment (#2, PLUM Sprint 210114)
 - Remove default list limits for roles and resources (#4, PLUM Sprint 210114)
+- Fix access check in create tenant (#4, PLUM Sprint 210114)
 
 ### Features
 - Cookie authentication in multi-domain setting (!219, PLUM Sprint 211217)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Fixed permissions for tenant assignment (#2, PLUM Sprint 210114)
+- Remove default list limits for roles and resources (#4, PLUM Sprint 210114)
 
 ### Features
 - Cookie authentication in multi-domain setting (!219, PLUM Sprint 211217)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -25,7 +25,7 @@ class ResourceHandler(object):
 	async def list(self, request):
 		# TODO: filtering by module
 		page = int(request.query.get('p', 1)) - 1
-		limit = int(request.query.get('i', 10))
+		limit = int(request.query.get('i', None))
 		resources = await self.ResourceService.list(page, limit)
 		return asab.web.rest.json_response(request, resources)
 

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -25,7 +25,10 @@ class ResourceHandler(object):
 	async def list(self, request):
 		# TODO: filtering by module
 		page = int(request.query.get('p', 1)) - 1
-		limit = int(request.query.get('i', None))
+		limit = request.query.get('i', None)
+		if limit is not None:
+			limit = int(limit)
+
 		resources = await self.ResourceService.list(page, limit)
 		return asab.web.rest.json_response(request, resources)
 

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -30,8 +30,8 @@ class RoleHandler(object):
 		web_app.router.add_delete("/role/{tenant}/{role_name}", self.delete)
 		web_app.router.add_put("/role/{tenant}/{role_name}", self.update_resources)
 
+	@access_control("authz:superuser")
 	async def list_all(self, request):
-		# TODO: global superuser only
 		page = int(request.query.get('p', 1)) - 1
 		limit = request.query.get('i', None)
 		if limit is not None:
@@ -45,7 +45,10 @@ class RoleHandler(object):
 	@access_control()
 	async def list(self, request, *, tenant):
 		page = int(request.query.get('p', 1)) - 1
-		limit = int(request.query.get('i', 10))
+		limit = request.query.get('i', None)
+		if limit is not None:
+			limit = int(limit)
+
 		result = await self.RoleService.list(tenant, page, limit)
 		return asab.web.rest.json_response(request, result)
 

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -33,7 +33,10 @@ class RoleHandler(object):
 	async def list_all(self, request):
 		# TODO: global superuser only
 		page = int(request.query.get('p', 1)) - 1
-		limit = int(request.query.get('i', None))
+		limit = request.query.get('i', None)
+		if limit is not None:
+			limit = int(limit)
+
 		result = await self.RoleService.list(None, page, limit)
 		return asab.web.rest.json_response(
 			request, result

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -33,7 +33,7 @@ class RoleHandler(object):
 	async def list_all(self, request):
 		# TODO: global superuser only
 		page = int(request.query.get('p', 1)) - 1
-		limit = int(request.query.get('i', 10))
+		limit = int(request.query.get('i', None))
 		result = await self.RoleService.list(None, page, limit)
 		return asab.web.rest.json_response(
 			request, result

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -46,12 +46,14 @@ class RoleService(asab.Service):
 			cursor.limit(limit)
 
 		roles = []
+		count = await collection.count_documents(query_filter)
 		async for role_dict in cursor:
 			roles.append(role_dict)
 
 		return {
+			"result": "OK",
+			"count": count,
 			"data": roles,
-			"count": await collection.count_documents(query_filter)
 		}
 
 	async def get(self, role_id: str):

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -81,7 +81,7 @@ class TenantHandler(object):
 		tenant = await provider.get(tenant_id)
 		return asab.web.rest.json_response(request, data=tenant)
 
-	access_control("authz:superuser")
+	@access_control("authz:superuser")
 	async def create(self, request, *, credentials_id):
 		tenant = await request.json()
 		provider = self.TenantService.get_provider()


### PR DESCRIPTION
Default limits for `GET /role` and `GET /resource` are now set to `None` so it will fetch the whole list.

Also fixed critical typo in tenant creation method.