### PR TITLE
Remove authz:credentials:admin resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release candidate
 
+### Breaking changes
+
+- Remove `authz:credentials:admin` resource (#5, PLUM Sprint 210114)
+
 ### Fixes
 - Fixed permissions for tenant assignment (#2, PLUM Sprint 210114)
 - Remove default list limits for roles and resources (#4, PLUM Sprint 210114)
@@ -10,6 +14,9 @@
 ### Features
 - Cookie authentication in multi-domain setting (!219, PLUM Sprint 211217)
 - Endpoints for simple tenant un/assignment (#2, PLUM Sprint 210114)
+
+### Refactoring
+- Remove `authz:credentials:admin` resource (#5, PLUM Sprint 210114)
 
 ---
 

--- a/doc/credentials-policy.md
+++ b/doc/credentials-policy.md
@@ -39,7 +39,7 @@ Their **policy** options are:
 The fields `email` and `phone` have an additional **context**: `editable_by`.
 Its **policy** options are:
 - `nobody`: The field is not editable, not even by a superuser.
-- `admin_only`: The field is editable only by credentials admin (i.e. a user with `authz:credentials:admin` resource).
+- `admin_only`: The field is editable only by a superuser.
 - `anybody`: The field is editable by anyone. This also makes it possible to update the field in one's own credentials.
 
 

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -274,7 +274,7 @@ class CredentialsHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(CREATE_CREDENTIALS)
-	@access_control("authz:credentials:admin")
+	@access_control("authz:tenant:admin")
 	async def create_credentials(self, request, *, json_data):
 		"""
 		Create new credentials.
@@ -306,7 +306,7 @@ class CredentialsHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(UPDATE_CREDENTIALS)
-	@access_control("authz:credentials:admin")
+	@access_control("authz:superuser")
 	async def update_credentials(self, request, *, json_data):
 		"""
 		Update credentials.
@@ -562,7 +562,7 @@ class CredentialsHandler(object):
 			'expiration': {'type': 'number'},
 		}
 	})
-	@access_control("authz:credentials:admin")
+	@access_control("authz:tenant:admin")
 	async def init_password_change(self, request, *, json_data):
 		"""
 		Directly creates a password reset request. This should be called by admin only.

--- a/seacatauth/credentials/policy.py
+++ b/seacatauth/credentials/policy.py
@@ -150,7 +150,7 @@ class CredentialsPolicy:
 			return self.RBACService.has_resource_access(
 				authz,
 				tenant="*",
-				requested_resources=["authz:credentials:admin"],
+				requested_resources=["authz:superuser"],
 			) == "OK"
 
 		policy = self.UpdatePolicy.get(attribute)
@@ -167,7 +167,7 @@ class CredentialsPolicy:
 			return self.RBACService.has_resource_access(
 				authz,
 				tenant="*",
-				requested_resources=["authz:credentials:admin"],
+				requested_resources=["authz:superuser"],
 			) == "OK"
 
 		# TODO: Check configurable resource-based policy


### PR DESCRIPTION
Removes `authz:credentials:admin` resource.

Credentials can be created by users with `authz:tenant:admin`.

Credentials can be updated/suspended only by users with `authz:superuser`.