### PR TITLE
Set reasonable config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Release candidate
+
+### Refactoring
+- Detailed error messages for cookie domain and session AES key config (#7, PLUM Sprint 210128)
+
+---
+
+
 ## v22.1.1
 
 ### Breaking changes
@@ -21,6 +29,7 @@
 
 ---
 
+
 ## v22.1
 
 ### Breaking changes
@@ -41,6 +50,7 @@
 
 ---
 
+
 ## v21.12.1
 
 ### Features
@@ -50,6 +60,7 @@
 - Remove default limit from tenant search (!210, PLUM Sprint 211203)
 
 ---
+
 
 ## v21.12
 
@@ -77,6 +88,7 @@
 
 ---
 
+
 ## v21.11
 
 ### Breaking changes
@@ -101,6 +113,7 @@
 - Separate web container for public endpoints (!190, PLUM Sprint 211011)
 
 ---
+
 
 ## v21.10
 
@@ -130,6 +143,7 @@
 - Last login and available factors now in userinfo response (!181, PLUM Sprint 210910)
 
 ---
+
 
 ## 21.08.00
 
@@ -164,6 +178,7 @@
 - Allow session touch extension to be either a ratio or absolute duration (!171, PLUM Sprint 210827)
 
 ---
+
 
 ## 21.07.00
 

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -33,8 +33,8 @@ class CookieService(asab.Service):
 		if self.RootCookieDomain is None:
 			fragments = urllib.parse.urlparse(asab.Config.get("general", "auth_webui_base_url"))
 			self.RootCookieDomain = ".{}".format(fragments.netloc)
-			L.warning("""Cookie domain is not specified. 
-				Assuming your cookie domain is '{}' (inferred from Auth WebUI base URL). 
+			L.warning("""Cookie domain is not specified.
+				Assuming your cookie domain is '{}' (inferred from Auth WebUI base URL).
 				It is recommended to specify cookie domain explicitly in your Seacat Auth configuration file.
 			""".replace("\t", "").format(self.RootCookieDomain))
 

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -33,8 +33,10 @@ class CookieService(asab.Service):
 		if self.RootCookieDomain is None:
 			fragments = urllib.parse.urlparse(asab.Config.get("general", "auth_webui_base_url"))
 			self.RootCookieDomain = ".{}".format(fragments.netloc)
-			L.warning("""Cookie domain is not specified. Assuming '{}' (inferred from Auth WebUI base URL). 
-			It is recommended to specify cookie domain explicitly in Seacat Auth configuration.""".replace("\t", ""))
+			L.warning("""Cookie domain is not specified. 
+				Assuming your cookie domain is '{}' (inferred from Auth WebUI base URL). 
+				It is recommended to specify cookie domain explicitly in your Seacat Auth configuration file.
+			""".replace("\t", "").format(self.RootCookieDomain))
 
 		# Configure cookies for application domains
 		# TODO: Allow different cookie name for each domain
@@ -63,10 +65,10 @@ class CookieService(asab.Service):
 	@staticmethod
 	def _validate_cookie_domain(domain):
 		if domain in ("", None):
-			L.error("Cookie domain not specified or empty")
+			L.warning("Cookie domain not specified or empty")
 			return None
 		if not domain.isascii():
-			L.error("Cookie domain can contain only ASCII characters.", struct_data={"domain": domain})
+			L.warning("Cookie domain can contain only ASCII characters.", struct_data={"domain": domain})
 			return None
 		return domain
 

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -1,6 +1,7 @@
 import base64
 import http.cookies
 import re
+import urllib.parse
 
 import aiohttp
 import logging
@@ -29,6 +30,11 @@ class CookieService(asab.Service):
 		self.RootCookieDomain = self._validate_cookie_domain(
 			asab.Config.get("seacatauth:cookie", "domain", fallback=None)
 		)
+		if self.RootCookieDomain is None:
+			fragments = urllib.parse.urlparse(asab.Config.get("general", "auth_webui_base_url"))
+			self.RootCookieDomain = ".{}".format(fragments.netloc)
+			L.warning("""Cookie domain is not specified. Assuming '{}' (inferred from Auth WebUI base URL). 
+			It is recommended to specify cookie domain explicitly in Seacat Auth configuration.""".replace("\t", ""))
 
 		# Configure cookies for application domains
 		# TODO: Allow different cookie name for each domain
@@ -44,6 +50,8 @@ class CookieService(asab.Service):
 
 			redirect_uri = section.get("redirect_uri", asab.Config.get("general", "auth_webui_base_url"))
 			domain = self._validate_cookie_domain(section.get("domain"))
+			if domain is None:
+				raise ValueError("Application cookie domain must be specified.")
 
 			self.ApplicationCookies[domain_id] = {
 				"redirect_uri": redirect_uri,
@@ -55,9 +63,11 @@ class CookieService(asab.Service):
 	@staticmethod
 	def _validate_cookie_domain(domain):
 		if domain in ("", None):
-			raise ValueError("Cookie domain not specified or empty")
+			L.error("Cookie domain not specified or empty")
+			return None
 		if not domain.isascii():
-			raise ValueError("Cookie domain can contain only ASCII characters. Got '{}'".format(domain))
+			L.error("Cookie domain can contain only ASCII characters.", struct_data={"domain": domain})
+			return None
 		return domain
 
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -32,14 +32,13 @@ class SessionService(asab.Service):
 
 		aes_key = asab.Config.get("seacatauth:session", "aes_key")
 		if len(aes_key) == 0:
-			raise ValueError("""
-				Session AES key must not be empty. 
+			raise ValueError("""Session AES key must not be empty. 
 				Please specify it in the [seacatauth:session] section of your Seacat Auth configuration file.
 				You may use the following randomly generated example:
 				
 				[seacatauth:session]
 				aes_key={}
-			""".replace("\t", "").format(secrets.token_urlsafe(24)))
+			""".replace("\t", "").format(secrets.token_urlsafe(16)))
 		self.AESKey = hashlib.sha256(aes_key.encode("utf-8")).digest()
 		# Block size is used for determining the size of CBC initialization vector
 		self.AESBlockSize = cryptography.hazmat.primitives.ciphers.algorithms.AES.block_size // 8

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -32,12 +32,13 @@ class SessionService(asab.Service):
 
 		aes_key = asab.Config.get("seacatauth:session", "aes_key")
 		if len(aes_key) == 0:
-			raise ValueError("""Session AES key must not be empty. 
+			raise ValueError("""Session AES key must not be empty.
 				Please specify it in the [seacatauth:session] section of your Seacat Auth configuration file.
 				You may use the following randomly generated example:
-				
+				```
 				[seacatauth:session]
 				aes_key={}
+				```
 			""".replace("\t", "").format(secrets.token_urlsafe(16)))
 		self.AESKey = hashlib.sha256(aes_key.encode("utf-8")).digest()
 		# Block size is used for determining the size of CBC initialization vector

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import secrets
 
 import bson
 
@@ -31,7 +32,14 @@ class SessionService(asab.Service):
 
 		aes_key = asab.Config.get("seacatauth:session", "aes_key")
 		if len(aes_key) == 0:
-			raise ValueError("Authentication aes_key must not be empty.")
+			raise ValueError("""
+				Session AES key must not be empty. 
+				Please specify it in the [seacatauth:session] section of your Seacat Auth configuration file.
+				You may use the following randomly generated example:
+				
+				[seacatauth:session]
+				aes_key={}
+			""".replace("\t", "").format(secrets.token_urlsafe(24)))
 		self.AESKey = hashlib.sha256(aes_key.encode("utf-8")).digest()
 		# Block size is used for determining the size of CBC initialization vector
 		self.AESBlockSize = cryptography.hazmat.primitives.ciphers.algorithms.AES.block_size // 8


### PR DESCRIPTION
Root cookie domain is now inferred from Auth WebUI base URL.

Missing session AES key now logs a message with config instructions.