### PR TITLE
Enable resource check in introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 - Metrics counting failed and successful logins added (#6, PLUM Sprint 210128)
 - Resource description (#1, PLUM Sprint 210114)
+- Resource check in introspection (#8, PLUM Sprint 210128)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 - Resource creation endpoint now accepts POST requests (#1, PLUM Sprint 210114)
+- Tenant check disabled in introspection (#8, PLUM Sprint 210114)
 
 ### Refactoring
 - Detailed error messages for cookie domain and session AES key config (#7, PLUM Sprint 210128)

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -1,8 +1,6 @@
 import base64
 import logging
 
-import aiohttp.web
-
 from ..generic import nginx_introspection
 from ..session import SessionAdapter
 
@@ -112,7 +110,6 @@ class M2MIntrospectHandler(object):
 		location = /_m2m_introspect {
 			internal;
 			proxy_method          POST;
-			proxy_set_header      X-Request-URI "$request_uri";
 			proxy_set_body        "$http_authorization";
 			proxy_pass            http://seacat-auth-svc:8081/m2m/nginx;
 		}

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -45,6 +45,7 @@ class CookieHandler(object):
 	async def nginx(self, request):
 		"""
 		Validate the session cookie and exchange it for a Bearer token.
+		Optionally check for resource access.
 		Add requested user info to headers.
 
 		Example Nginx setup:
@@ -61,9 +62,8 @@ class CookieHandler(object):
 		location = /_cookie_introspect {
 			internal;
 			proxy_method          POST;
-			proxy_set_header      X-Request-URI "$request_uri";
 			proxy_set_body        "$http_authorization";
-			proxy_pass            http://seacat-auth-svc:8081/cookie/nginx?add=credentials;
+			proxy_pass            http://seacat-auth-svc:8081/cookie/nginx?add=credentials&resource=my-app:access;
 		}
 		```
 		"""
@@ -76,6 +76,7 @@ class CookieHandler(object):
 			self.RBACService
 		)
 		if response.status_code != 200:
+			delete_cookie(self.App, response)
 			return response
 
 		# Delete SeaCat cookie from Cookie header unless "keepcookie" param is passed in query

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -64,6 +64,9 @@ class CookieHandler(object):
 		```
 		"""
 
+		attributes_to_add = request.query.getall("add", [])
+		attributes_to_verify = request.query.getall("verify", [])
+
 		# Authorize request
 		# Use custom authorization since it must use cookie, not the authn header
 		session = await self.CookieService.get_session_by_sci(request)
@@ -75,14 +78,11 @@ class CookieHandler(object):
 		# Check tenant+resource access
 		requested_tenant = None
 		requested_resources = set()
-		verify = request.query.get("verify")
-		if verify is not None:
-			verify = verify.split(" ")
-
-			if "resources" in verify:
+		if len(attributes_to_verify) > 0:
+			if "resources" in attributes_to_verify:
 				requested_resources.update(request.headers.get("X-Resources").split(" "))
 
-			if "tenant" in verify:
+			if "tenant" in attributes_to_verify:
 				requested_tenant = request.headers.get("X-Tenant")
 				requested_resources.add("tenant:access")
 
@@ -114,7 +114,7 @@ class CookieHandler(object):
 		# Add requested X-Headers
 		headers = await add_to_header(
 			headers,
-			request.query.getall('add', []),
+			attributes_to_add,
 			session,
 			self.CredentialsService,
 			requested_tenant=requested_tenant

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -66,6 +66,7 @@ class CookieHandler(object):
 
 		attributes_to_add = request.query.getall("add", [])
 		attributes_to_verify = request.query.getall("verify", [])
+		requested_resources = set(request.query.getall("resource", []))
 
 		# Authorize request
 		# Use custom authorization since it must use cookie, not the authn header
@@ -77,15 +78,12 @@ class CookieHandler(object):
 
 		# Check tenant+resource access
 		requested_tenant = None
-		requested_resources = set()
-		if len(attributes_to_verify) > 0:
-			if "resources" in attributes_to_verify:
-				requested_resources.update(request.headers.get("X-Resources").split(" "))
 
-			if "tenant" in attributes_to_verify:
-				requested_tenant = request.headers.get("X-Tenant")
-				requested_resources.add("tenant:access")
+		if "tenant" in attributes_to_verify:
+			requested_tenant = request.headers.get("X-Tenant")
+			requested_resources.add("tenant:access")
 
+		if len(requested_resources) > 0:
 			if self.RBACService.has_resource_access(session.Authz, requested_tenant, requested_resources) != "OK":
 				L.warning("Credentials not authorized for tenant or resource.", struct_data={
 					"cid": session.CredentialsId,

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -1,6 +1,9 @@
 import random
 import logging
+import typing
+
 import aiohttp.web
+import asab
 
 #
 
@@ -68,10 +71,19 @@ async def add_to_header(headers, attributes_to_add, session, credentials_service
 	return headers
 
 
-async def nginx_introspection(request, authenticate, credentials_service, session_service, rbac_service):
+async def nginx_introspection(
+	request: aiohttp.web.Request,
+	authenticate: typing.Callable,
+	credentials_service: asab.Service,
+	session_service: asab.Service,
+	rbac_service: asab.Service
+):
+	"""
+	Authenticates the introspection request and responds with 200 if successful or with 401 if not.
+	Optionally checks for resources. Missing resource access results in 403 response.
+	Optionally adds session attributes (username, tenants etc.) to X-headers.
 	"""
 
-	"""
 	# Authenticate request, get session
 	session = await authenticate(request)
 	if session is None:

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -79,6 +79,8 @@ async def nginx_introspection(
 	rbac_service: asab.Service
 ):
 	"""
+	Helper function for different types of nginx introspection (Cookie, OAuth token, Basic auth).
+
 	Authenticates the introspection request and responds with 200 if successful or with 401 if not.
 	Optionally checks for resources. Missing resource access results in 403 response.
 	Optionally adds session attributes (username, tenants etc.) to X-headers.

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -1,18 +1,26 @@
 import random
+import logging
+import aiohttp.web
+
+#
+
+L = logging.getLogger(__name__)
+
+#
 
 
-async def add_to_header(headers, what, session, credentials_service, requested_tenant=None):
-	'''
+async def add_to_header(headers, attributes_to_add, session, credentials_service, requested_tenant=None):
+	"""
 	Prepare a common header with:
 	* X-Credentials: htpasswd:id:foobar
 	* X-Username: foobar
 	* X-Tenants: tenant1 tenant2 tenant3
 	* X-Roles: role1 role2 role3
 	* X-Resources: resource1 resource2 resource3
-	'''
+	"""
 
 	# obtain username to append add in headers
-	if "credentials" in what:
+	if "credentials" in attributes_to_add:
 		credentials = await credentials_service.get(session.CredentialsId)
 		headers["X-Credentials"] = credentials["_id"]
 		v = credentials.get("username")
@@ -20,13 +28,13 @@ async def add_to_header(headers, what, session, credentials_service, requested_t
 			headers["X-Username"] = v
 
 	# Obtain assigned tenants from session object
-	if "tenants" in what:
+	if "tenants" in attributes_to_add:
 		tenants = [tenant for tenant in session.Authz.keys() if tenant != "*"]
 		if len(tenants) > 0:
 			headers["X-Tenants"] = " ".join(tenants)
 
 	# Obtain assigned roles from session object
-	if "roles" in what:
+	if "roles" in attributes_to_add:
 		# Add only global roles if no tenant was requested
 		if requested_tenant is None:
 			roles = session.Authz["*"].keys()
@@ -35,7 +43,7 @@ async def add_to_header(headers, what, session, credentials_service, requested_t
 		headers["X-Roles"] = " ".join(roles)
 
 	# Obtain assigned resources from session object
-	if "resources" in what:
+	if "resources" in attributes_to_add:
 		if requested_tenant is None:
 			resources = session.Authz["*"].values()
 		else:
@@ -43,7 +51,7 @@ async def add_to_header(headers, what, session, credentials_service, requested_t
 		headers["X-Resources"] = " ".join(set(sum(resources, [])))
 
 	# Obtain login factors from session object
-	if "factors" in what:
+	if "factors" in attributes_to_add:
 		if session.LoginDescriptor is not None:
 			factors = [
 				factor["id"]
@@ -53,11 +61,60 @@ async def add_to_header(headers, what, session, credentials_service, requested_t
 			headers["X-Login-Factors"] = " ".join(factors)
 
 	# Obtain login descriptor IDs from session object
-	if "ldid" in what:
+	if "ldid" in attributes_to_add:
 		if session.LoginDescriptor is not None:
 			headers["X-Login-Descriptor"] = session.LoginDescriptor["id"]
 
 	return headers
+
+
+async def nginx_introspection(request, authenticate, credentials_service, session_service, rbac_service):
+	"""
+
+	"""
+	# Authenticate request, get session
+	session = await authenticate(request)
+	if session is None:
+		return aiohttp.web.HTTPUnauthorized()
+
+	# TODO: Check if the session is "restricted" (for setting up 2nd factor only)
+	#   if so: fail
+
+	attributes_to_add = request.query.getall("add", [])
+	attributes_to_verify = request.query.getall("verify", [])
+	requested_resources = set(request.query.getall("resource", []))
+
+	requested_tenant = None
+	if "tenant" in attributes_to_verify:
+		raise NotImplementedError("Tenant check not implemented in introspection")
+
+	if len(requested_resources) > 0:
+		if rbac_service.has_resource_access(session.Authz, requested_tenant, requested_resources) != "OK":
+			L.warning("Credentials not authorized for tenant or resource.", struct_data={
+				"cid": session.CredentialsId,
+				"tenant": requested_tenant,
+				"resources": " ".join(requested_resources),
+			})
+			return aiohttp.web.HTTPForbidden()
+
+	# Extend session expiration
+	await session_service.touch(session)
+
+	# Set the authorization header
+	headers = {
+		aiohttp.hdrs.AUTHORIZATION: "Bearer {}".format(session.OAuth2['access_token'])
+	}
+
+	# Add headers
+	headers = await add_to_header(
+		headers=headers,
+		attributes_to_add=attributes_to_add,
+		session=session,
+		credentials_service=credentials_service,
+		requested_tenant=requested_tenant
+	)
+
+	return aiohttp.web.HTTPOk(headers=headers)
 
 
 def generate_ergonomic_token(length: int):

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -31,7 +31,7 @@ def api_auth_middleware_factory(app):
 		try:
 			# Authorize by OAuth Bearer token
 			# (Authorization by cookie is not allowed for API access)
-			request.Session = await oidc_service.get_session_from_authorization(request)
+			request.Session = await oidc_service.get_session_from_authorization_header(request)
 		except KeyError:
 			request.Session = None
 
@@ -78,7 +78,7 @@ def public_auth_middleware_factory(app):
 		"""
 		# Authorize by OAuth Bearer token
 		try:
-			request.Session = await oidc_service.get_session_from_authorization(request)
+			request.Session = await oidc_service.get_session_from_authorization_header(request)
 		except KeyError:
 			request.Session = None
 

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -1,4 +1,3 @@
-import base64
 import urllib
 import logging
 

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -115,7 +115,8 @@ class TokenIntrospectionHandler(object):
 
 		}
 		"""
-		fields_to_add = request.query.getall("add", [])
+		attributes_to_add = request.query.getall("add", [])
+		attributes_to_verify = request.query.getall("verify", [])
 
 		headers = {}
 
@@ -132,14 +133,11 @@ class TokenIntrospectionHandler(object):
 
 		requested_tenant = None
 		requested_resources = set()
-		verify = request.query.get("verify")
-		if verify is not None:
-			verify = verify.split(" ")
-
-			if "resources" in verify:
+		if len(attributes_to_verify) > 0:
+			if "resources" in attributes_to_verify:
 				requested_resources.update(request.headers.get("X-Resources").split(" "))
 
-			if "tenant" in verify:
+			if "tenant" in attributes_to_verify:
 				requested_tenant = request.headers.get("X-Tenant")
 				requested_resources.add("tenant:access")
 
@@ -158,7 +156,7 @@ class TokenIntrospectionHandler(object):
 		# add headers
 		headers = await add_to_header(
 			headers=headers,
-			what=fields_to_add,
+			what=attributes_to_add,
 			session=session,
 			credentials_service=self.CredentialsService,
 			requested_tenant=requested_tenant

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -117,6 +117,7 @@ class TokenIntrospectionHandler(object):
 		"""
 		attributes_to_add = request.query.getall("add", [])
 		attributes_to_verify = request.query.getall("verify", [])
+		requested_resources = set(request.query.getall("resource", []))
 
 		headers = {}
 
@@ -132,15 +133,11 @@ class TokenIntrospectionHandler(object):
 		#   if so: fail
 
 		requested_tenant = None
-		requested_resources = set()
-		if len(attributes_to_verify) > 0:
-			if "resources" in attributes_to_verify:
-				requested_resources.update(request.headers.get("X-Resources").split(" "))
+		if "tenant" in attributes_to_verify:
+			requested_tenant = request.headers.get("X-Tenant")
+			requested_resources.add("tenant:access")
 
-			if "tenant" in attributes_to_verify:
-				requested_tenant = request.headers.get("X-Tenant")
-				requested_resources.add("tenant:access")
-
+		if len(requested_resources) > 0:
 			if self.RBACService.has_resource_access(session.Authz, requested_tenant, requested_resources) != "OK":
 				L.warning("Credentials not authorized for tenant or resource.", struct_data={
 					"cid": session.CredentialsId,

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -1,9 +1,6 @@
 import urllib
 import logging
 
-import aiohttp
-import aiohttp.web
-
 import asab
 import asab.web.rest
 
@@ -110,7 +107,6 @@ class TokenIntrospectionHandler(object):
 					internal;
 					proxy_method          POST;
 					proxy_set_body        "$http_authorization";
-					proxy_set_header      X-Request-URI "$request_uri";
 					proxy_pass            http://localhost:8080/openidconnect/introspect/nginx;
 
 					proxy_cache           token_responses;     # Enable caching

--- a/seacatauth/openidconnect/handler/session.py
+++ b/seacatauth/openidconnect/handler/session.py
@@ -28,7 +28,7 @@ class SessionHandler(object):
 
 
 	async def session_logout(self, request):
-		session = await self.OpenIdConnectService.get_session_from_authorization(request)
+		session = await self.OpenIdConnectService.get_session_from_authorization_header(request)
 		if session is None:
 			return aiohttp.web.HTTPNotFound()
 

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -59,18 +59,9 @@ class OpenIdConnectService(asab.Service):
 		return session_id
 
 
-	async def get_session_from_authorization(self, request):
-		"""
-		Find session by token in the authorization header
-		"""
-		# Get authorization header
-		authorization = request.headers.get(aiohttp.hdrs.AUTHORIZATION, None)
-		if authorization is None:
-			L.info("Access Token not provided in the header")
-			return None
-
+	async def get_session_from_bearer_token(self, bearer_token: str):
 		# Extract the access token
-		am = self.AuthorizationHeaderRg.match(authorization)
+		am = self.AuthorizationHeaderRg.match(bearer_token)
 		if am is None:
 			L.warning("Access Token is invalid")
 			return None
@@ -90,6 +81,19 @@ class OpenIdConnectService(asab.Service):
 			return None
 
 		return session
+
+
+	async def get_session_from_authorization_header(self, request):
+		"""
+		Find session by token in the authorization header
+		"""
+		# Get authorization header
+		authorization_bytes = request.headers.get(aiohttp.hdrs.AUTHORIZATION, None)
+		if authorization_bytes is None:
+			L.info("Access Token not provided in the header")
+			return None
+
+		return await self.get_session_from_bearer_token(authorization_bytes)
 
 	def refresh_token(self, refresh_token, client_id, client_secret, scope):
 		# TODO: this is not implemented

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -11,6 +11,7 @@ L = logging.getLogger(__name__)
 
 
 def credentials_session_builder(identity_id):
+	# TODO: Include username, email, phone, maybe _c and _m
 	yield (SessionAdapter.FNCredentialsId, identity_id)
 
 


### PR DESCRIPTION
All introspection endpoints can now perform resource checks. To do so, add `resource=<REQUIRED_RESOURCE>` as query parameter. Multiple such parameters can be added (e.g. `resource=my-app:access&resource=my-app:admin`). The check must pass on all the resources in order to result in 200.

**`BREAKING`** Checking tenant access with `verify=tenant` and `X-Tenant` header has been disabled.


Nginx introspection endpoint examples:
```nginx
location = /_cookie_introspect {
  internal;
  proxy_method          POST;
  proxy_set_body        "$http_authorization";
  proxy_pass            http://seacatauth:8081/seacat_auth/api/cookie/nginx?resource=my-app:access;
  proxy_ignore_headers  Cache-Control Expires Set-Cookie;
}

location = /_oauth2_introspect {
  internal;
  proxy_method          POST;
  proxy_set_body        "$http_authorization";
  proxy_pass            http://seacatauth:8081/openidconnect/introspect/nginx?resource=another-app:access&resource=another-app:admin;
  proxy_ignore_headers  Cache-Control Expires Set-Cookie;
}
```