### PR TITLE
Metrics endpoint access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ etc/
 
 docker/log/*.log
 docker/mongo-data
+.vscode

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -127,7 +127,7 @@ class SeaCatAuthApplication(asab.Application):
 		self.add_module(OpenIdConnectModule)
 
 		# Depends on: OpenIDService
-		self.WebContainer.WebApp.middlewares.append(middleware.api_auth_middleware_factory(self))
+		self.WebContainer.WebApp.middlewares.append(middleware.private_auth_middleware_factory(self))
 		self.PublicWebContainer.WebApp.middlewares.append(middleware.public_auth_middleware_factory(self))
 
 		from .otp import OTPHandler, OTPService

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -1,8 +1,5 @@
 import aiohttp.web
 import asab
-import logging
-
-L = logging.getLogger(__name__)
 
 
 def app_middleware_factory(app):

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -77,7 +77,6 @@ class OpenIdConnectService(asab.Service):
 		try:
 			session = await self.SessionService.get_by(SessionAdapter.FNOAuth2AccessToken, access_token)
 		except KeyError:
-			L.warning("Access Token not found", struct_data={'at': access_token})
 			return None
 
 		return session


### PR DESCRIPTION
Eventually, I decided for rather "additive" approach. Removing authentication and authorization from private_auth_middleware_factory made these endpoints inaccessible from the frontend.