### PR TITLE
M2M credentials policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Breaking changes
 
 ### Fixes
+- Handle nonexisting provider in M2M introspection (#15, PLUM Sprint 220225)
+- Fixed creation policy for M2M provider (#15, PLUM Sprint 220225)
 
 ### Features
 

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -43,6 +43,9 @@ class M2MIntrospectHandler(object):
 
 		# Locate credentials
 		credentials_id = await self.CredentialsService.locate(username, stop_at_first=True)
+		if credentials_id is None:
+			L.warning("Credentials not found", struct_data={"username": username})
+			return None
 		provider = self.CredentialsService.get_provider(credentials_id)
 
 		# Check if machine credentials

--- a/seacatauth/credentials/policy.py
+++ b/seacatauth/credentials/policy.py
@@ -81,6 +81,10 @@ class CredentialsPolicy:
 		self.CreationPolicy = {}
 		self.RegistrationPolicy = {}
 		self.UpdatePolicy = {}
+		self.M2MCreationPolicy = {
+			"username": {"creation": "required"},
+			"password": {"creation": "required"},  # At this moment password is the only login option
+		}
 
 		self._load_policy(policy_file)
 
@@ -138,6 +142,9 @@ class CredentialsPolicy:
 
 	def validate_creation_data(self, creation_data: dict):
 		return self._validate_credentials_data(creation_data, self.CreationPolicy)
+
+	def validate_m2m_creation_data(self, creation_data: dict):
+		return self._validate_credentials_data(creation_data, self.M2MCreationPolicy)
 
 	def validate_registration_data(self, registration_data: dict):
 		return self._validate_credentials_data(registration_data, self.RegistrationPolicy)

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -336,7 +336,7 @@ class CredentialsService(asab.Service):
 			"credentials_id": credentials_id,
 		}
 
-
+	# TODO: Implement editing for M2M credentials
 	async def update_credentials(self, credentials_id: str, update_dict: dict, session: SessionAdapter = None):
 		"""
 		Validate the input data in the update dict according to active policies

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -302,7 +302,10 @@ class CredentialsService(asab.Service):
 			}
 
 		# Only update fields allowed by creation policy
-		validated_data = self.Policy.validate_creation_data(credentials_data)
+		if provider.Type == "m2m":
+			validated_data = self.Policy.validate_m2m_creation_data(credentials_data)
+		else:
+			validated_data = self.Policy.validate_creation_data(credentials_data)
 		if validated_data is None:
 			L.error("Update failed: Data does not comply with update policy", struct_data={
 				"provider_id": provider.ProviderID,
@@ -362,7 +365,10 @@ class CredentialsService(asab.Service):
 
 		# Get provider
 		provider = self.get_provider(credentials_id)
-		if not isinstance(provider, EditableCredentialsProviderABC):
+		if (
+			not isinstance(provider, EditableCredentialsProviderABC)
+			or provider.Type == "m2m"  # M2M credentials do not support editing for now
+		):
 			L.error("Update failed: Provider does not support editing", struct_data={
 				"provider_id": provider.ProviderID,
 				"cid": credentials_id,
@@ -410,6 +416,17 @@ class CredentialsService(asab.Service):
 		info = provider.get_info()
 
 		if not provider.Editable:
+			return info
+
+		# Use different policy for M2M providers
+		# TODO: Systematic solution
+		if provider.Type == "m2m":
+			info["creation"] = [
+				{
+					"type": field,
+					"policy": policy,
+				} for field, policy in self.Policy.M2MCreationPolicy.items()
+			]
 			return info
 
 		# Add edit/creation policies if provider is editable


### PR DESCRIPTION
- Handle nonexisting provider in M2M introspection
- Hardcoded creation policy for M2M provider - only username and password is required for M2M credentials creation
- Editing disabled for M2M credentials