### PR TITLE
Session types and hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Tenant name must pass validation before tenant is created (#19, PLUM Sprint 220325)
 - Validate usernames, roles and resources before creation (#22, PLUM Sprint 220325)
 - Batman uses resources for access control instead of roles (#21, PLUM Sprint 220408)
+- Introduce session types (#16, PLUM Sprint 220408)
 
 ---
 

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -10,7 +10,6 @@ from .login_session import LoginSession
 from ..audit import AuditCode
 
 from ..session import (
-	session_type_builder,
 	credentials_session_builder,
 	authz_session_builder,
 	cookie_session_builder,
@@ -249,7 +248,6 @@ class AuthenticationService(asab.Service):
 	async def login(self, login_session, from_info: list = None):
 		# TODO: Move this to LoginService
 		builders = [
-			session_type_builder("root"),
 			credentials_session_builder(login_session.CredentialsId),
 			await authz_session_builder(
 				tenant_service=self.TenantService,
@@ -261,15 +259,10 @@ class AuthenticationService(asab.Service):
 			await available_factors_session_builder(self, login_session.CredentialsId)
 		]
 
-		# TODO: if 'openid' in scope
-		oauth2_data = {
-			"scope": ["openid"]  # TODO: Get actual scope
-		}
-		builders.append(oauth2_session_builder(oauth2_data))
-
 		session = await self.SessionService.create_session(
-			builders,
-			expiration=login_session.Data.get('requested_session_expiration'),
+			session_type="root",
+			expiration=login_session.Data.get("requested_session_expiration"),
+			session_builders=builders,
 		)
 		L.log(
 			asab.LOG_NOTICE,

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -313,15 +313,10 @@ class AuthenticationService(asab.Service):
 			await available_factors_session_builder(self, credentials_id)
 		]
 
-		# TODO: if 'openid' in scope
-		oauth2_data = {
-			"scope": ["openid"]  # TODO: Get actual scope
-		}
-		builders.append(oauth2_session_builder(oauth2_data))
-
 		session = await self.SessionService.create_session(
-			builders,
+			session_type="m2m",
 			expiration=session_expiration,
+			session_builders=builders,
 		)
 		L.log(
 			asab.LOG_NOTICE,

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -6,13 +6,17 @@ import asab
 
 from .login_descriptor import LoginDescriptor
 from .login_factors import login_factor_builder
-from ..audit import AuditCode
-from ..session import credentials_session_builder
-from ..session import authz_session_builder
-from ..session import cookie_session_builder
-from ..session import login_descriptor_session_builder
-from ..session import available_factors_session_builder
 from .login_session import LoginSession
+from ..audit import AuditCode
+
+from ..session import (
+	session_type_builder,
+	credentials_session_builder,
+	authz_session_builder,
+	cookie_session_builder,
+	login_descriptor_session_builder,
+	available_factors_session_builder,
+)
 from ..openidconnect.session import oauth2_session_builder
 
 #
@@ -245,6 +249,7 @@ class AuthenticationService(asab.Service):
 	async def login(self, login_session, from_info: list = None):
 		# TODO: Move this to LoginService
 		builders = [
+			session_type_builder("root"),
 			credentials_session_builder(login_session.CredentialsId),
 			await authz_session_builder(
 				tenant_service=self.TenantService,

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -16,7 +16,6 @@ from ..session import (
 	login_descriptor_session_builder,
 	available_factors_session_builder,
 )
-from ..openidconnect.session import oauth2_session_builder
 
 #
 

--- a/seacatauth/batman/elk.py
+++ b/seacatauth/batman/elk.py
@@ -128,7 +128,7 @@ class ELKIntegration(asab.config.Configurable):
 		username = cred.get('username')
 		if username is None:
 			# Be defensive
-			L.warning("Cannot create user: No username", struct_data={"cid": cred["_id"]})
+			L.info("Cannot create user: No username", struct_data={"cid": cred["_id"]})
 			return
 
 		if username in self.LocalUsers:

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -89,7 +89,7 @@ class GrafanaIntegration(asab.config.Configurable):
 		username = cred.get('username')
 		if username is None:
 			# Be defensive
-			L.warning("Cannot create Grafana user: No username", struct_data={
+			L.info("Cannot create Grafana user: No username", struct_data={
 				"cid": cred["_id"]
 			})
 			return

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -107,9 +107,8 @@ class CookieHandler(object):
 		Exchange authorization code for cookie and redirect afterwards.
 		"""
 		grant_type = request.query.get("grant_type")
-
 		if grant_type != "authorization_code":
-			L.warning("Grant type not supported", struct_data={"grant_type": grant_type})
+			L.error("Grant type not supported", struct_data={"grant_type": grant_type})
 			return aiohttp.web.HTTPBadRequest()
 
 		# Use the code to get session ID
@@ -130,10 +129,11 @@ class CookieHandler(object):
 			cookie_session_builder(),
 		]
 
-		# TODO: if 'openid' in scope
+		# TODO: Temporary solution. Root session should have no OAuth2 data.
+		#   Remove once ID token support is fully implemented.
 		oauth2_data = {
-			"scope": ["openid", "cookie"],
-			"client_id": request.query.get("client_id"),
+			"scope": None,
+			"client_id": None,
 		}
 		session_builders.append(oauth2_session_builder(oauth2_data))
 
@@ -142,7 +142,7 @@ class CookieHandler(object):
 			requested_expiration = int(requested_expiration)
 
 		session = await self.SessionService.create_session(
-			session_type="openidconnect",
+			session_type="cookie",
 			parent_session=root_session,
 			expiration=requested_expiration,
 			session_builders=session_builders,

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -7,6 +7,15 @@ import aiohttp.web
 from ..generic import nginx_introspection
 from .utils import set_cookie, delete_cookie
 
+from ..openidconnect.session import oauth2_session_builder
+
+from ..session import (
+	credentials_session_builder,
+	authz_session_builder,
+	cookie_session_builder,
+	login_descriptor_session_builder,
+)
+
 #
 
 L = logging.getLogger(__name__)
@@ -105,9 +114,39 @@ class CookieHandler(object):
 
 		# Use the code to get session ID
 		code = request.query.get("code")
-		session = await self.CookieService.get_session_by_authorization_code(code)
-		if session is None:
+		root_session = await self.CookieService.get_session_by_authorization_code(code)
+		if root_session is None:
 			return aiohttp.web.HTTPBadRequest()
+
+		# TODO: Choose builders based on scope
+		session_builders = [
+			credentials_session_builder(root_session.CredentialsId),
+			await authz_session_builder(
+				tenant_service=self.CookieService.TenantService,
+				role_service=self.CookieService.RoleService,
+				credentials_id=root_session.CredentialsId
+			),
+			login_descriptor_session_builder(root_session.LoginDescriptor),
+			cookie_session_builder(),
+		]
+
+		# TODO: if 'openid' in scope
+		oauth2_data = {
+			"scope": ["openid", "cookie"],
+			"client_id": request.query.get("client_id"),
+		}
+		session_builders.append(oauth2_session_builder(oauth2_data))
+
+		requested_expiration = request.query.get("expiration")
+		if requested_expiration is not None:
+			requested_expiration = int(requested_expiration)
+
+		session = await self.SessionService.create_session(
+			session_type="openidconnect",
+			parent_session=root_session,
+			expiration=requested_expiration,
+			session_builders=session_builders,
+		)
 
 		# Construct the response
 		# TODO: Dynamic redirect (instead of static URL from config)

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -24,6 +24,8 @@ class CookieService(asab.Service):
 		super().__init__(app, service_name)
 		self.SessionService = app.get_service("seacatauth.SessionService")
 		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
+		self.RoleService = app.get_service("seacatauth.RoleService")
+		self.TenantService = app.get_service("seacatauth.TenantService")
 
 		# Configure root cookie
 		self.CookieName = asab.Config.get("seacatauth:cookie", "name")

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -85,7 +85,6 @@ def private_auth_middleware_factory(app):
 
 
 def public_auth_middleware_factory(app):
-	oidc_service = app.get_service("seacatauth.OpenIdConnectService")
 	cookie_service = app.get_service("seacatauth.CookieService")
 
 	@aiohttp.web.middleware
@@ -93,15 +92,9 @@ def public_auth_middleware_factory(app):
 		"""
 		Try to authenticate before accessing public endpoints.
 		"""
-		# Authorize by OAuth Bearer token
-		try:
-			request.Session = await oidc_service.get_session_from_authorization_header(request)
-		except KeyError:
-			request.Session = None
 
-		# Use cookie if Bearer token auth fails
-		if request.Session is None:
-			request.Session = await cookie_service.get_session_by_sci(request)
+		# Cookie-based authentication
+		request.Session = await cookie_service.get_session_by_sci(request)
 
 		return await handler(request)
 

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -216,8 +216,11 @@ class AuthorizeHandler(object):
 				request, scope, request_parameters, root_session, factors_to_setup
 			)
 
-		# TODO: Create a new child session with the requested scope
 		requested_expiration = request_parameters.get("expiration")
+		if requested_expiration is not None:
+			requested_expiration = int(requested_expiration)
+
+		# TODO: Create a new child session with the requested scope
 		session = await self.OpenIdConnectService.create_oidc_session(root_session, client_id, scope, requested_expiration)
 
 		return await self.reply_with_successful_response(request, session, scope, redirect_uri, request_parameters)

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -220,10 +220,12 @@ class AuthorizeHandler(object):
 		if requested_expiration is not None:
 			requested_expiration = int(requested_expiration)
 
+		state = request_parameters.get("state")
+
 		# TODO: Create a new child session with the requested scope
 		session = await self.OpenIdConnectService.create_oidc_session(root_session, client_id, scope, requested_expiration)
 
-		return await self.reply_with_successful_response(request, session, scope, redirect_uri, request_parameters)
+		return await self.reply_with_successful_response(request, session, scope, redirect_uri, state)
 
 
 	async def _get_factors_to_setup(self, session):

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -142,7 +142,12 @@ class AuthorizeHandler(object):
 
 		# TODO: Validate the client's permission to requested scope and redirect_uri
 
-		session = request.Session
+		root_session = request.Session
+
+		# Only root sessions can be used to obtain auth code
+		if root_session is not None and root_session.Type != "root":
+			L.warning("Session type must be 'root'", struct_data={"session_type": root_session.Type})
+			root_session = None
 
 		prompt = request_parameters.get("prompt")
 		if prompt not in frozenset([None, "none", "login", "select_account"]):
@@ -160,11 +165,11 @@ class AuthorizeHandler(object):
 				"url": request.url
 			})
 			# If 'login' prompt is requested, delete the active session and re-authenticate anyway
-			if session is not None:
-				await self.SessionService.delete(session.SessionId)
-				session = None
+			if root_session is not None:
+				await self.SessionService.delete(root_session.SessionId)
+				root_session = None
 
-		if session is None and prompt == "none":
+		if root_session is None and prompt == "none":
 			# We are NOT authenticated, but login prompt is unwanted
 			# TODO: The Authorization Server MUST NOT display any authentication or consent user interface pages.
 			# An error is returned if an End-User is not already authenticated or the Client does not have
@@ -176,7 +181,7 @@ class AuthorizeHandler(object):
 			})
 			return self.reply_with_authentication_error(request, request_parameters, "login_required")
 
-		if session is None or prompt == "select_account":
+		if root_session is None or prompt == "select_account":
 			# We are NOT authenticated or the user is switching accounts
 			#   >> Redirect to login and then back to this endpoint
 
@@ -189,53 +194,9 @@ class AuthorizeHandler(object):
 				})
 
 			# We are not authenticated, show 404 and provide the link to the login form
-
-			# Gather params which will be passed to the login page
-			login_query_params = []
-
-			# Gather params which will be passed to the after-login oidc/authorize call
-			authorize_query_params = []
-
-			for param, value in request_parameters.items():
-				if param in {"ldid", "expiration"}:
-					# Add session expiration
-					# Add login descriptors (there may be multiple)
-					login_query_params.append((param, value))
-				if param in {"response_type", "scope", "client_id", "redirect_uri", "state"}:
-					# Include all mandatory oidc/authorize params
-					authorize_query_params.append((param, value))
-
-			# Build the redirect URI back to this endpoint and add it to login params
-			authorize_redirect_uri = "{}{}?{}".format(
-				self.PublicApiBaseUrl,
-				request.path,
-				urllib.parse.urlencode(authorize_query_params)
-			)
-
-			login_query_params.append(("redirect_uri", authorize_redirect_uri))
-
-			login_url = "{}{}?{}".format(
-				self.AuthWebuiBaseUrl,
-				self.LoginPath,
-				urllib.parse.urlencode(login_query_params)
-			)
-			response = aiohttp.web.HTTPNotFound(
-				headers={
-					"Location": login_url,
-					"Refresh": '0;url=' + login_url,
-				},
-				content_type="text/html",
-				text="""<!doctype html>\n<html lang="en">\n<head></head><body>...</body>\n</html>\n"""
-			)
-			delete_cookie(self.App, response)
-			return response
+			return await self.reply_with_redirect_to_login(request, request_parameters)
 
 		# We are authenticated!
-		# TODO: Create a new child session with the requested scope
-
-		if session.OAuth2 is None:
-			L.warning("The session has not been created with OpenId/OAuth2 in scope.")
-			return self.reply_with_authentication_error(request, request_parameters, "access_denied")
 
 		# TODO: Authorize the access to a given resource (specified by redirect_uri and scope )
 
@@ -243,18 +204,23 @@ class AuthorizeHandler(object):
 		#  (the policies can use oidc client-id and scope)
 
 		# Redirect to factor management page if (re)set of any factor is required
-		factors_to_setup = await self._get_factors_to_setup(session)
+		# TODO: Move this check to AuthenticationService.login, add "restricted" flag
+		factors_to_setup = await self._get_factors_to_setup(root_session)
 
 		if len(factors_to_setup) > 0:
 			L.warning(
 				"Auth factor setup required. Redirecting to setup.",
-				struct_data={"missing_factors": " ".join(factors_to_setup), "cid": session.CredentialsId}
+				struct_data={"missing_factors": " ".join(factors_to_setup), "cid": root_session.CredentialsId}
 			)
 			return await self.reply_with_factor_setup_redirect(
-				request, scope, request_parameters, session, factors_to_setup
+				request, scope, request_parameters, root_session, factors_to_setup
 			)
 
-		return await self.reply_with_successful_response(request, scope, request_parameters, session)
+		# TODO: Create a new child session with the requested scope
+		requested_expiration = request_parameters.get("expiration")
+		session = await self.OpenIdConnectService.create_oidc_session(root_session, client_id, scope, requested_expiration)
+
+		return await self.reply_with_successful_response(request, session, scope, redirect_uri, request_parameters)
 
 
 	async def _get_factors_to_setup(self, session):
@@ -277,7 +243,7 @@ class AuthorizeHandler(object):
 		return factors_to_setup
 
 
-	async def reply_with_successful_response(self, request, scope, request_parameters, session):
+	async def reply_with_successful_response(self, request, session, scope, redirect_uri, state=None):
 		"""
 		https://openid.net/specs/openid-connect-core-1_0.html
 		3.1.2.5.  Successful Authentication Response
@@ -288,14 +254,14 @@ class AuthorizeHandler(object):
 		"""
 
 		# Prepare the redirect URL
-		url = urllib.parse.urlparse(request_parameters['redirect_uri'])
+		url = urllib.parse.urlparse(redirect_uri)
 		url_qs = urllib.parse.parse_qs(url.query)
 
-		if len(request_parameters.get('state', [])) > 0:
+		if state is not None:
 			# The OAuth 2.0 Authorization Framework, 4.1.2.  Authorization Response
 			# If the "state" parameter was present in the client authorization request,
 			# then use the exact value received from the client.
-			url_qs["state"] = request_parameters['state']
+			url_qs["state"] = state
 
 		# Add the Authorization Code into the session ...
 		if "cookie" not in scope:
@@ -322,9 +288,56 @@ class AuthorizeHandler(object):
 			text="""<!doctype html>\n<html lang="en">\n<head></head><body>...</body>\n</html>\n"""
 		)
 
-		if 'cookie' in request_parameters['scope']:
+		if 'cookie' in scope:
 			set_cookie(self.App, response, session)
 
+		return response
+
+
+	async def reply_with_redirect_to_login(self, request, request_parameters):
+		"""
+		Reply with 404 and provide a link to the login form with a loopback to OIDC/authorize.
+		Pass on the query parameters.
+		"""
+
+		# Gather params which will be passed to the login page
+		login_query_params = []
+
+		# Gather params which will be passed to the after-login oidc/authorize call
+		authorize_query_params = []
+
+		for param, value in request_parameters.items():
+			if param in {"ldid", "expiration"}:
+				# Add session expiration
+				# Add login descriptors (there may be multiple)
+				login_query_params.append((param, value))
+			if param in {"response_type", "scope", "client_id", "redirect_uri", "state"}:
+				# Include all mandatory oidc/authorize params
+				authorize_query_params.append((param, value))
+
+		# Build the redirect URI back to this endpoint and add it to login params
+		authorize_redirect_uri = "{}{}?{}".format(
+			self.PublicApiBaseUrl,
+			request.path,
+			urllib.parse.urlencode(authorize_query_params)
+		)
+
+		login_query_params.append(("redirect_uri", authorize_redirect_uri))
+
+		login_url = "{}{}?{}".format(
+			self.AuthWebuiBaseUrl,
+			self.LoginPath,
+			urllib.parse.urlencode(login_query_params)
+		)
+		response = aiohttp.web.HTTPNotFound(
+			headers={
+				"Location": login_url,
+				"Refresh": '0;url=' + login_url,
+			},
+			content_type="text/html",
+			text="""<!doctype html>\n<html lang="en">\n<head></head><body>...</body>\n</html>\n"""
+		)
+		delete_cookie(self.App, response)
 		return response
 
 

--- a/seacatauth/openidconnect/handler/session.py
+++ b/seacatauth/openidconnect/handler/session.py
@@ -32,5 +32,23 @@ class SessionHandler(object):
 		if session is None:
 			return aiohttp.web.HTTPNotFound()
 
-		await self.SessionService.delete(session.SessionId)
+		if session.ParentSessionId is not None:
+			try:
+				parent_session = await self.SessionService.get(session.ParentSessionId)
+			except KeyError:
+				parent_session = None
+		else:
+			parent_session = None
+
+		if parent_session is not None:
+			# Delete the root session which will also remove this session
+			await self.SessionService.delete(parent_session.SessionId)
+		else:
+			# Back compat: This can occur with old sessions
+			L.warning("OIDC session has no parent session", struct_data={
+				"sid": session.SessionId,
+				"parent_sid": session.ParentSessionId,
+			})
+			await self.SessionService.delete(session.SessionId)
+
 		return aiohttp.web.Response(text="", content_type="text/html")

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -35,7 +35,16 @@ class UserInfoHandler(object):
 		OpenID Connect Core 1.0, chapter 5.3. UserInfo Endpoint
 		"""
 
-		session = request.Session
+		if request.Session is not None:
+			# Use the session that was authenticated via SCI
+			session = request.Session
+		else:
+			# Authenticate via OAuth2 Bearer token
+			try:
+				session = await self.OpenIdConnectService.get_session_from_authorization_header(request)
+			except KeyError:
+				session = None
+
 		if session is None:
 			L.warning("Request for invalid/expired session")
 			return self.error_response("invalid_session", "The access token is invalid/expired.")

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -16,7 +16,6 @@ from ..session import (
 	authz_session_builder,
 	cookie_session_builder,
 	login_descriptor_session_builder,
-	available_factors_session_builder,
 )
 from .session import oauth2_session_builder
 

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -11,6 +11,14 @@ import aiohttp.web
 import urllib.parse
 
 from ..session import SessionAdapter
+from ..session import (
+	credentials_session_builder,
+	authz_session_builder,
+	cookie_session_builder,
+	login_descriptor_session_builder,
+	available_factors_session_builder,
+)
+from .session import oauth2_session_builder
 
 #
 
@@ -39,6 +47,7 @@ class OpenIdConnectService(asab.Service):
 		self.SessionService = app.get_service("seacatauth.SessionService")
 		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
 		self.TenantService = app.get_service("seacatauth.TenantService")
+		self.RoleService = app.get_service("seacatauth.RoleService")
 		self.AuditService = app.get_service("seacatauth.AuditService")
 
 		self.BearerRealm = asab.Config.get("openidconnect", "bearer_realm")
@@ -105,15 +114,47 @@ class OpenIdConnectService(asab.Service):
 
 		return await self.get_session_from_bearer_token(authorization_bytes)
 
+
 	def refresh_token(self, refresh_token, client_id, client_secret, scope):
 		# TODO: this is not implemented
 		L.error("refresh_token is not implemented", struct_data=[refresh_token, client_id, client_secret, scope])
 		raise aiohttp.web.HTTPNotImplemented()
 
+
 	def check_access_token(self, bearer_token):
 		# TODO: this is not implemented
 		L.error("check_access_token is not implemented", struct_data={"bearer": bearer_token})
 		raise aiohttp.web.HTTPNotImplemented()
+
+
+	async def create_oidc_session(self, root_session, client_id, scope, requested_expiration=None):
+		# TODO: Choose builders based on scope
+		session_builders = [
+			credentials_session_builder(root_session.CredentialsId),
+			await authz_session_builder(
+				tenant_service=self.TenantService,
+				role_service=self.RoleService,
+				credentials_id=root_session.CredentialsId
+			),
+			login_descriptor_session_builder(root_session.LoginDescriptor),
+			cookie_session_builder(),
+		]
+
+		# TODO: if 'openid' in scope
+		oauth2_data = {
+			"scope": scope,
+			"client_id": client_id,
+		}
+		session_builders.append(oauth2_session_builder(oauth2_data))
+		session = await self.SessionService.create_session(
+			session_type="openidconnect",
+			parent_session=root_session,
+			expiration=requested_expiration,
+			session_builders=session_builders,
+		)
+
+		return session
+
 
 	async def build_userinfo(self, session, tenant=None):
 		userinfo = {

--- a/seacatauth/openidconnect/session.py
+++ b/seacatauth/openidconnect/session.py
@@ -7,9 +7,8 @@ def oauth2_session_builder(oauth2_data):
 	# Token length must be a multiple of AES block size (= 16 bytes)
 	token_length = 16 + 32  # The first part is AES CBC init vector, the second is the actual token
 
-	# Session scope defaults to "openid"
-	scope = " ".join(oauth2_data.get("scope", ["openid"]))
-	yield (SessionAdapter.FNOAuth2Scope, scope)
+	yield (SessionAdapter.FNOAuth2Scope, " ".join(oauth2_data["scope"]))
+	yield (SessionAdapter.FNOAuth2ClientId, oauth2_data["client_id"])
 	yield (SessionAdapter.FNOAuth2AccessToken, secrets.token_bytes(token_length))
 	yield (SessionAdapter.FNOAuth2RefreshToken, secrets.token_bytes(token_length))
 	yield (SessionAdapter.FNOAuth2IdToken, secrets.token_bytes(token_length))

--- a/seacatauth/openidconnect/session.py
+++ b/seacatauth/openidconnect/session.py
@@ -7,7 +7,12 @@ def oauth2_session_builder(oauth2_data):
 	# Token length must be a multiple of AES block size (= 16 bytes)
 	token_length = 16 + 32  # The first part is AES CBC init vector, the second is the actual token
 
-	yield (SessionAdapter.FNOAuth2Scope, " ".join(oauth2_data["scope"]))
+	# TODO: Scope should be always present
+	scope = oauth2_data.get("scope")
+	if scope is not None:
+		scope = list(scope)
+
+	yield (SessionAdapter.FNOAuth2Scope, scope)
 	yield (SessionAdapter.FNOAuth2ClientId, oauth2_data["client_id"])
 	yield (SessionAdapter.FNOAuth2AccessToken, secrets.token_bytes(token_length))
 	yield (SessionAdapter.FNOAuth2RefreshToken, secrets.token_bytes(token_length))

--- a/seacatauth/session/__init__.py
+++ b/seacatauth/session/__init__.py
@@ -2,6 +2,7 @@ from .service import SessionService
 from .handler import SessionHandler
 from .adapter import SessionAdapter
 
+from .builders import session_type_builder
 from .builders import credentials_session_builder
 from .builders import authz_session_builder
 from .builders import cookie_session_builder
@@ -12,6 +13,7 @@ __all__ = [
 	"SessionService",
 	"SessionHandler",
 	"SessionAdapter",
+	"session_type_builder",
 	"credentials_session_builder",
 	"authz_session_builder",
 	"cookie_session_builder",

--- a/seacatauth/session/__init__.py
+++ b/seacatauth/session/__init__.py
@@ -2,7 +2,6 @@ from .service import SessionService
 from .handler import SessionHandler
 from .adapter import SessionAdapter
 
-from .builders import session_type_builder
 from .builders import credentials_session_builder
 from .builders import authz_session_builder
 from .builders import cookie_session_builder
@@ -13,7 +12,6 @@ __all__ = [
 	"SessionService",
 	"SessionHandler",
 	"SessionAdapter",
-	"session_type_builder",
 	"credentials_session_builder",
 	"authz_session_builder",
 	"cookie_session_builder",

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -10,9 +10,11 @@ L = logging.getLogger(__name__)
 
 
 class SessionAdapter:
-	'''
+	"""
 	Light object that represent a momentary view on the persisted session
-	'''
+	"""
+
+	FNSessionType = "t"
 
 	FNTenants = 'Tn'
 	FNRoles = 'Rl'
@@ -48,6 +50,7 @@ class SessionAdapter:
 		self.Expiration = session_dict.pop('exp')
 		self.MaxExpiration = session_dict.pop('max_exp', None)
 		self.TouchExtension = session_dict.pop('touch_ext', None)
+		self.Type = session_dict.pop(self.FNSessionType)
 
 		self.CredentialsId = session_dict.pop(self.FNCredentialsId, None)
 		self.Authz = session_dict.pop(self.FNAuthz, None)
@@ -105,12 +108,13 @@ class SessionAdapter:
 
 	def get_rest(self):
 		d = {
-			'_id': self.SessionId,
-			'_v': self.Version,
-			'_c': "{}Z".format(self.CreatedAt.isoformat()),
-			'_m': "{}Z".format(self.ModifiedAt.isoformat()),
-			'expiration': "{}Z".format(self.Expiration.isoformat()),
-			'login_descriptor': self.LoginDescriptor,
+			"_id": self.SessionId,
+			"_v": self.Version,
+			"_c": "{}Z".format(self.CreatedAt.isoformat()),
+			"_m": "{}Z".format(self.ModifiedAt.isoformat()),
+			"expiration": "{}Z".format(self.Expiration.isoformat()),
+			"login_descriptor": self.LoginDescriptor,
+			"type": self.Type,
 		}
 
 		# TODO: Backward compatibility. Remove once WebUI adapts to the "_fields" above.
@@ -139,9 +143,10 @@ class SessionAdapter:
 
 
 	def __repr__(self):
-		return("<{} sid:{} c:{} m:{} exp:{} cred:{} authz:{} ld:{} sci:{} {} {}>".format(
+		return("<{} sid:{} t:{} c:{} m:{} exp:{} cred:{} authz:{} ld:{} sci:{} {} {}>".format(
 			self.__class__.__name__,
 			self.SessionId,
+			self.Type,
 			self.CreatedAt,
 			self.ModifiedAt,
 			self.Expiration,

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -14,7 +14,11 @@ class SessionAdapter:
 	Light object that represent a momentary view on the persisted session
 	"""
 
-	FNSessionType = "t"
+	FNSessionType = "T"
+	FNParentSessionId = "PS"
+	FNExpiration = "exp"
+	FNMaxExpiration = "max_exp"
+	FNTouchExtension = "touch_ext"
 
 	FNTenants = 'Tn'
 	FNRoles = 'Rl'
@@ -30,6 +34,7 @@ class SessionAdapter:
 	FNOAuth2IdToken = 'oa.Ti'
 	FNOAuth2RefreshToken = 'oa.Tr'
 	FNOAuth2Scope = 'oa.S'
+	FNOAuth2ClientId = 'oa.Ci'
 
 	# Fields that are stored encrypted
 	SensitiveFields = frozenset([
@@ -47,10 +52,12 @@ class SessionAdapter:
 		self.Version = session_dict.pop('_v')
 		self.CreatedAt = session_dict.pop('_c')
 		self.ModifiedAt = session_dict.pop('_m')
-		self.Expiration = session_dict.pop('exp')
-		self.MaxExpiration = session_dict.pop('max_exp', None)
-		self.TouchExtension = session_dict.pop('touch_ext', None)
+
 		self.Type = session_dict.pop(self.FNSessionType)
+		self.ParentSession = session_dict.pop(self.FNParentSessionId, None)
+		self.Expiration = session_dict.pop(self.FNExpiration)
+		self.MaxExpiration = session_dict.pop(self.FNMaxExpiration, None)
+		self.TouchExtension = session_dict.pop(self.FNTouchExtension, None)
 
 		self.CredentialsId = session_dict.pop(self.FNCredentialsId, None)
 		self.Authz = session_dict.pop(self.FNAuthz, None)

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -54,7 +54,7 @@ class SessionAdapter:
 		self.ModifiedAt = session_dict.pop('_m')
 
 		self.Type = session_dict.pop(self.FNSessionType)
-		self.ParentSession = session_dict.pop(self.FNParentSessionId, None)
+		self.ParentSessionId = session_dict.pop(self.FNParentSessionId, None)
 		self.Expiration = session_dict.pop(self.FNExpiration)
 		self.MaxExpiration = session_dict.pop(self.FNMaxExpiration, None)
 		self.TouchExtension = session_dict.pop(self.FNTouchExtension, None)

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -10,6 +10,11 @@ L = logging.getLogger(__name__)
 #
 
 
+def session_type_builder(session_type):
+	assert session_type in frozenset(["root", "openidconnect", "m2m"])
+	yield (SessionAdapter.FNSessionType, session_type)
+
+
 def credentials_session_builder(identity_id):
 	# TODO: Include username, email, phone, maybe _c and _m
 	yield (SessionAdapter.FNCredentialsId, identity_id)

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -10,11 +10,6 @@ L = logging.getLogger(__name__)
 #
 
 
-def session_type_builder(session_type):
-	assert session_type in frozenset(["root", "openidconnect", "m2m"])
-	yield (SessionAdapter.FNSessionType, session_type)
-
-
 def credentials_session_builder(identity_id):
 	# TODO: Include username, email, phone, maybe _c and _m
 	yield (SessionAdapter.FNCredentialsId, identity_id)
@@ -66,7 +61,7 @@ async def available_factors_session_builder(authentication_service, credentials_
 	for factor in authentication_service.LoginFactors.values():
 		if await factor.is_eligible({"credentials_id": credentials_id}):
 			factors.append(factor.ID)
-	return ((SessionAdapter.FNAvailableFactors, factors), )
+	return ((SessionAdapter.FNAvailableFactors, factors),)
 
 
 def cookie_session_builder():

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -117,7 +117,7 @@ class SessionService(asab.Service):
 		upsertor = self.StorageService.upsertor(self.SessionCollection)
 
 		# Set up required fields
-		if session_type not in frozenset(["root", "openidconnect", "m2m"]):
+		if session_type not in frozenset(["root", "openidconnect", "m2m", "cookie"]):
 			L.error("Unsupported session type", struct_data={"type": session_type})
 			return None
 		upsertor.set(SessionAdapter.FNSessionType, session_type)
@@ -157,7 +157,7 @@ class SessionService(asab.Service):
 		L.log(asab.LOG_NOTICE, "Session created", struct_data={
 			"sid": session_id,
 			"type": session_type,
-			"parent": parent_session,
+			"parent_sid": parent_session.SessionId,
 		})
 		return await self.get(session_id)
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -107,16 +107,24 @@ class SessionService(asab.Service):
 			await self.delete(session_id=sid)
 
 
-	async def create_session(self, session_builders=None, *, expiration: float = None):
+	async def create_session(
+		self,
+		session_type: str,
+		parent_session: SessionAdapter = None,
+		expiration: float = None,
+		session_builders: list = None
+	):
 		upsertor = self.StorageService.upsertor(self.SessionCollection)
-		if session_builders is None:
-			session_builders = list()
-		for session_builder in session_builders:
-			for key, value in session_builder:
-				if key in SessionAdapter.SensitiveFields:
-					value = SessionAdapter.EncryptedPrefix + self.aes_encrypt(value)
-				upsertor.set(key, value)
 
+		# Set up required fields
+		if session_type not in frozenset(["root", "openidconnect", "m2m"]):
+			L.error("Unsupported session type", struct_data={"type": session_type})
+			return None
+		upsertor.set(SessionAdapter.FNSessionType, session_type)
+		if parent_session is not None:
+			upsertor.set(SessionAdapter.FNParentSessionId, parent_session.SessionId)
+
+		# Set up expiration variables
 		if expiration is not None:
 			expiration = datetime.timedelta(seconds=expiration)
 			if expiration > self.MaximumAge:
@@ -131,20 +139,30 @@ class SessionService(asab.Service):
 		else:
 			touch_extension_seconds = self.TouchExtensionRatio * expiration.total_seconds()
 
-		upsertor.set("exp", expires)
-		upsertor.set("max_exp", max_expiration)
-		upsertor.set("touch_ext", touch_extension_seconds)
+		upsertor.set(SessionAdapter.FNExpiration, expires)
+		upsertor.set(SessionAdapter.FNMaxExpiration, max_expiration)
+		upsertor.set(SessionAdapter.FNTouchExtension, touch_extension_seconds)
+
+		# Add builder fields
+		if session_builders is None:
+			session_builders = list()
+		for session_builder in session_builders:
+			for key, value in session_builder:
+				if key in SessionAdapter.SensitiveFields:
+					value = SessionAdapter.EncryptedPrefix + self.aes_encrypt(value)
+				upsertor.set(key, value)
 
 		session_id = await upsertor.execute()
 
 		L.log(asab.LOG_NOTICE, "Session created", struct_data={
-			'sid': session_id,
-			'exp': expires
+			"sid": session_id,
+			"type": session_type,
+			"parent": parent_session,
 		})
 		return await self.get(session_id)
 
 
-	async def update_session(self, session_id, session_builders=[]):
+	async def update_session(self, session_id: str, session_builders: list):
 		if isinstance(session_id, str):
 			session_id = bson.ObjectId(session_id)
 		session_dict = await self.StorageService.get(self.SessionCollection, session_id)

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -154,11 +154,13 @@ class SessionService(asab.Service):
 
 		session_id = await upsertor.execute()
 
-		L.log(asab.LOG_NOTICE, "Session created", struct_data={
+		struct_data = {
 			"sid": session_id,
 			"type": session_type,
-			"parent_sid": parent_session.SessionId,
-		})
+		}
+		if parent_session is not None:
+			struct_data["parent_sid"] = parent_session.SessionId
+		L.log(asab.LOG_NOTICE, "Session created", struct_data=struct_data)
 		return await self.get(session_id)
 
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -289,7 +289,6 @@ class SessionService(asab.Service):
 
 	async def delete(self, session_id):
 		# Delete all child sessions first
-		# TODO: Prevent recursion
 		query_filter = {SessionAdapter.FNParentSessionId: session_id}
 		sessions = (await self.list(query_filter=query_filter))["data"]
 		for session in sessions:

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -288,6 +288,14 @@ class SessionService(asab.Service):
 
 
 	async def delete(self, session_id):
+		# Delete all child sessions first
+		# TODO: Prevent recursion
+		query_filter = {SessionAdapter.FNParentSessionId: session_id}
+		sessions = (await self.list(query_filter=query_filter))["data"]
+		for session in sessions:
+			await self.StorageService.delete(self.SessionCollection, bson.ObjectId(session.SessionId))
+
+		# Delete the session itself
 		await self.StorageService.delete(self.SessionCollection, bson.ObjectId(session_id))
 		L.log(asab.LOG_NOTICE, "Session deleted", struct_data={'sid': session_id})
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -292,7 +292,7 @@ class SessionService(asab.Service):
 		query_filter = {SessionAdapter.FNParentSessionId: session_id}
 		sessions = (await self.list(query_filter=query_filter))["data"]
 		for session in sessions:
-			await self.StorageService.delete(self.SessionCollection, bson.ObjectId(session.SessionId))
+			await self.StorageService.delete(self.SessionCollection, bson.ObjectId(session["_id"]))
 
 		# Delete the session itself
 		await self.StorageService.delete(self.SessionCollection, bson.ObjectId(session_id))

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -95,12 +95,12 @@ class SessionService(asab.Service):
 	async def delete_expired_sessions(self):
 		expired = []
 		sessions = await self.list()
-		for s in sessions["data"]:
+		for session in sessions["data"]:
 			try:
-				if datetime.datetime.utcnow() > s["exp"]:
-					expired.append(s["_id"])
+				if datetime.datetime.utcnow() > session.get(SessionAdapter.FNExpiration):
+					expired.append(session["_id"])
 			except KeyError:
-				L.info("Session '{}' is missing exp.".format(s["_id"]))
+				L.error("Session is missing expiration", struct_data={"sid": session["_id"]})
 				continue
 
 		for sid in expired:
@@ -278,7 +278,7 @@ class SessionService(asab.Service):
 			session.SessionId,
 			version=version
 		)
-		upsertor.set("exp", expires)
+		upsertor.set(SessionAdapter.FNExpiration, expires)
 
 		try:
 			await upsertor.execute()


### PR DESCRIPTION
Successful login creates a `root` session, under which `openidconnnect` sessions are later created on demand.
These child sessions can (and should) have specific scopes.

# Session types

## `root` session
- created immediately after successful login
- cookie-based
- usage
  - required by `/openidconnect/authorize` to create child `openidconnect` sessions
  - account management in Seacat Auth Web UI
  - cookie-based client apps and nginx cookie introspection (this is likely temporary and will be replaced by dedicated `cookie` sessions)

## `openidconnect` session
- created by `/openidconnect/authorize`
- no cookie, only OAuth2 tokens and OIDC data
- always has a `root` session as a parent
  - deleting this parent session causes the deletion of this session as well
- usage
  - nginx oauth2 introspection
  - cookie-based client apps

## `m2m` session
- created at m2m introspection
- it is at the root level and has no parent
- short expiration
- usage
  - nginx m2m introspection

## `cookie` session
- created at cookie entry point
- usage
  - cookie introspection in multi-domain environments

---

# TODOs before merge

- [x] Fix logout calls
- [x] Deleting a root session must remove all its child sessions
- [x] Verify that multi-domain cookies work
- [x] Verify that m2m introspection works
- [x] Verify that cookie introspection works
- [x] Verify that oauth introspection works

# Future TODOs

- Structured session listing
- Authn+z via ID token
- Scoped cookie-based client sessions
- Implement different scopes
- Client ID management, with redirect_uri and scope permissions