### PR TITLE
Credentials: Fallback values in ident translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Features
 
 ### Refactoring
+- Fallback values in ident translation response (#18, PLUM Sprint 220325)
 
 ---
 


### PR DESCRIPTION
Rename `PUT /usernames` to `PUT /idents`. Keep the old endpoint for backward compatibility (until UI adapts).

If a user has no username, provide fallback ident (username > email > phone > credentials ID).