### PR TITLE
Batman: Use resources instead of roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 
 ### Features
 - Generate MANIFEST.json (#20, PLUM Sprint 220325)
+- List resources call now accepts filter string (#21, PLUM Sprint 220408)
 
 ### Refactoring
 - Fallback values in ident translation response (#18, PLUM Sprint 220325)
 - Tenant name must pass validation before tenant is created (#19, PLUM Sprint 220325)
+- Batman uses resources for access control instead of roles (#21, PLUM Sprint 220408)
 
 ---
 

--- a/seacatauth/authz/__init__.py
+++ b/seacatauth/authz/__init__.py
@@ -8,6 +8,8 @@ from .rbac.handler import RBACHandler
 from .resource.service import ResourceService
 from .resource.handler import ResourceHandler
 
+from .utils import get_credentials_authz
+
 __all__ = [
 	"RolesHandler",
 	"RoleService",
@@ -16,4 +18,5 @@ __all__ = [
 	"RBACHandler",
 	"ResourceService",
 	"ResourceHandler",
+	"get_credentials_authz",
 ]

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from json import JSONDecodeError
 
 import asab
@@ -25,13 +26,21 @@ class ResourceHandler(object):
 		web_app.router.add_put("/resource/{resource_id}", self.update)
 
 	async def list(self, request):
-		# TODO: filtering by module
-		page = int(request.query.get('p', 1)) - 1
-		limit = request.query.get('i', None)
+		page = int(request.query.get("p", 1)) - 1
+		limit = request.query.get("i", None)
 		if limit is not None:
 			limit = int(limit)
 
-		resources = await self.ResourceService.list(page, limit)
+		# Filter by ID.startswith()
+		query_filter = request.query.get("f", None)
+		if query_filter is not None:
+			query_filter = {
+				"_id": re.compile("^{}".format(
+					re.escape(query_filter)
+				))
+			}
+
+		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)
 
 	async def get(self, request):

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -70,10 +70,11 @@ class ResourceService(asab.Service):
 				await self.update_description(resource_id, resource_description)
 
 
-	async def list(self, page: int = 0, limit: int = None):
+	async def list(self, page: int = 0, limit: int = None, query_filter: dict = None):
 		collection = self.StorageService.Database[self.ResourceCollection]
 
-		query_filter = {}
+		if query_filter is None:
+			query_filter = {}
 		cursor = collection.find(query_filter)
 
 		cursor.sort("_c", -1)

--- a/seacatauth/authz/utils.py
+++ b/seacatauth/authz/utils.py
@@ -1,0 +1,34 @@
+async def get_credentials_authz(credentials_id, tenant_service, role_service):
+	"""
+	Creates a nested 'authz' dict with tenant:role:resource structure:
+	{
+		'*': {
+			'*/roleB': ['resourceA', 'resourceB'],
+		},
+		'tenantA': {
+			'tenantA/roleA': ['resourceA', 'resourceB'],
+			'*/roleB': ['resourceA', 'resourceB'],
+		},
+		'tenantB': {
+			'tenantB/roleB': ['resourceA', 'resourceB'],
+			'tenantB/roleC': ['resourceE', 'resourceD'],
+			'*/roleB': ['resourceA', 'resourceB'],
+		},
+	}
+	"""
+
+	# Add global roles and resources under "*"
+	authz = {}
+	tenant = "*"
+	authz[tenant] = {}
+	for role in await role_service.get_roles_by_credentials(credentials_id, tenant):
+		authz[tenant][role] = await role_service.get_role_resources(role)
+
+	# Add tenant-specific roles and resources if tenant service is enabled
+	if tenant_service.is_enabled():
+		for tenant in await tenant_service.get_tenants(credentials_id):
+			authz[tenant] = {}
+			for role in await role_service.get_roles_by_credentials(credentials_id, tenant):
+				authz[tenant][role] = await role_service.get_role_resources(role)
+
+	return authz

--- a/seacatauth/batman/elk.py
+++ b/seacatauth/batman/elk.py
@@ -1,8 +1,11 @@
 import re
 import logging
+import typing
 
 import aiohttp
 import asab.config
+
+from ..authz import get_credentials_authz
 
 #
 
@@ -18,9 +21,9 @@ L = logging.getLogger(__name__)
 
 
 class ELKIntegration(asab.config.Configurable):
-	'''
+	"""
 	Kibana / ElasticSearch user push compomnent
-	'''
+	"""
 
 	ConfigDefaults = {
 		'url': 'http://localhost:9200/',
@@ -31,6 +34,10 @@ class ELKIntegration(asab.config.Configurable):
 
 		'mapped_roles_prefixes': '*/elk:',  # Prefix of roles that will be transfered to Kibana
 
+		# Resources with this prefix will be mapped to Kibana users as roles
+		# E.g.: Resource "elk:kibana-analyst" will be mapped to role "kibana-analyst"
+		"resource_prefix": "elk:",
+
 		'managed_role': 'seacat_managed',  # 'flags' users in ElasticSearch/Kibana that is managed by us,
 		# There should be a role created in the ElasticSearch that grants no rights
 	}
@@ -39,12 +46,25 @@ class ELKIntegration(asab.config.Configurable):
 	def __init__(self, batman_svc, config_section_name="batman:elk", config=None):
 		super().__init__(config_section_name=config_section_name, config=config)
 		self.BatmanService = batman_svc
+		self.CredentialsService = self.BatmanService.App.get_service("seacatauth.CredentialsService")
+		self.TenantService = self.BatmanService.App.get_service("seacatauth.TenantService")
+		self.RoleService = self.BatmanService.App.get_service("seacatauth.RoleService")
+		self.ResourceService = self.BatmanService.App.get_service("seacatauth.ResourceService")
 
 		username = self.Config.get('username')
 		password = self.Config.get('password')
 		self.BasicAuth = aiohttp.BasicAuth(username, password)
 
 		self.URL = self.Config.get('url').rstrip('/')
+		self.ResourcePrefix = self.Config.get("resource_prefix")
+		self.ELKResourceRegex = re.compile("^{}".format(
+			re.escape(self.Config.get("resource_prefix"))
+		))
+		self.ELKSeacatFlagRole = self.Config.get("managed_role")
+
+		# TODO: Obsolete, back compat only. Use resources instead of roles.
+		#
+		self.RolePrefixes = re.split(r"\s+", self.Config.get("mapped_roles_prefixes"))
 
 		lu = re.split(r'\s+', self.Config.get('local_users'), flags=re.MULTILINE)
 		lu.append(username)
@@ -60,25 +80,25 @@ class ELKIntegration(asab.config.Configurable):
 		await self.sync_all()
 
 	async def sync_all(self):
-		cred_svc = self.BatmanService.App.get_service('seacatauth.CredentialsService')
-		async for cred in cred_svc.iterate():
-			await self.sync(cred)
+		elk_resources = await self.ResourceService.list(query_filter={"_id": self.ELKResourceRegex})
+		elk_resources = set(
+			resource["_id"]
+			for resource in elk_resources["data"]
+		)
+		async for cred in self.CredentialsService.iterate():
+			await self.sync(cred, elk_resources)
 
 
-	async def sync(self, cred: dict):
+	async def sync(self, cred: dict, elk_resources: typing.Iterable):
 		username = cred.get('username')
 		if username is None:
 			# Be defensive
-			L.warning("Cannot create user '{}', no username".format(cred))
+			L.warning("Cannot create user: No username", struct_data={"cid": cred["_id"]})
 			return
 
 		if username in self.LocalUsers:
 			# Ignore users that are specified as local
 			return
-
-		# Get roles
-		roles_svc = self.BatmanService.App.get_service('seacatauth.RoleService')
-		roles = await roles_svc.get_roles_by_credentials(cred['_id'])
 
 		json = {
 			'enabled': cred.get('suspended', False) is not True,
@@ -101,31 +121,42 @@ class ELKIntegration(asab.config.Configurable):
 		if v is not None:
 			json['full_name'] = v
 
-		elk_roles = [
-			self.Config.get('managed_role'),  # Add a role that marks the user managed by us
-		]
+		elk_roles = set(
+			self.ELKSeacatFlagRole,  # Add a role that marks users managed by Seacat Auth
+		)
 
-		roles_prefixes = re.split(r'\s+', self.Config.get('mapped_roles_prefixes'), flags=re.MULTILINE)
-		for role in roles:
-			match = None
-			for rp in roles_prefixes:
-				if role.startswith(rp):
-					match = role[len(rp):]
+		# Get authz dict
+		authz = await get_credentials_authz(cred["_id"], self.TenantService, self.RoleService)
+
+		# ELK roles from SCA resources
+		# Use only global "*" roles for now
+		user_resources = set().union(*authz.get("*", {}).values())
+		if "authz:superuser" in user_resources:
+			elk_roles.update(
+				resource[len(self.ResourcePrefix):]
+				for resource in elk_resources
+			)
+		else:
+			elk_roles.update(
+				resource[len(self.ResourcePrefix):]
+				for resource in user_resources.intersection(elk_resources)
+			)
+
+		# Map roles to ELK roles
+		# TODO: Obsolete, use resources.
+		for role in authz.get("*", {}):
+			for prefix in self.RolePrefixes:
+				if role.startswith(prefix):
+					elk_roles.add(role[len(prefix):])
 					break
-			if match is None:
+
+		# ELK roles from tenants
+		for tenant in authz:
+			if tenant == "*":
 				continue
+			elk_roles.add("tenant_{}".format(tenant))
 
-			elk_roles.append(match)
-
-
-		# Roles by tenant
-		tenant_svc = self.BatmanService.App.get_service('seacatauth.TenantService')
-		if tenant_svc.is_enabled():
-			tenants = await tenant_svc.get_tenants(cred['_id'])
-			for tenant in tenants:
-				elk_roles.append('tenant_{}'.format(tenant))
-
-		json['roles'] = elk_roles
+		json["roles"] = list(elk_roles)
 
 		try:
 			async with aiohttp.ClientSession(auth=self.BasicAuth) as session:
@@ -135,7 +166,12 @@ class ELKIntegration(asab.config.Configurable):
 						pass
 					else:
 						text = await resp.text()
-						L.warning("Failed to create/upadate the user in ElasticSearch:\n{}".format(text[:1000]))
-
-		except Exception:
-			L.exception("Error when communicating with ElasticSearch")
+						L.warning(
+							"Failed to create/update user in ElasticSearch:\n{}".format(text[:1000]),
+							struct_data={"cid": cred["_id"]}
+						)
+		except Exception as e:
+			L.error(
+				"Communication with ElasticSearch produced {}: {}".format(type(e).__name__, str(e)),
+				struct_data={"cid": cred["_id"]}
+			)

--- a/seacatauth/batman/elk.py
+++ b/seacatauth/batman/elk.py
@@ -74,14 +74,14 @@ class ELKIntegration(asab.config.Configurable):
 		batman_svc.App.PubSub.subscribe("Application.tick/60!", self._on_tick)
 
 	async def _on_tick(self, event_name):
-		await self._initialize_elk_resources()
+		await self._initialize_resources()
 		await self.sync_all()
 
 	async def initialize(self):
-		await self._initialize_elk_resources()
+		await self._initialize_resources()
 		await self.sync_all()
 
-	async def _initialize_elk_resources(self):
+	async def _initialize_resources(self):
 		"""
 		Fetches roles from ELK and creates a Seacat Auth resource for each one of them.
 		"""

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -136,10 +136,13 @@ class GrafanaIntegration(asab.config.Configurable):
 		if v is not None:
 			json['name'] = v
 
+		# TODO: Check if user exists
 		try:
 			async with aiohttp.ClientSession(auth=self.BasicAuth) as session:
 				async with session.post('{}/api/admin/users'.format(self.URL), json=json) as resp:
-					if resp.status != 200:
+					if resp.status == 200:
+						pass
+					else:
 						text = await resp.text()
 						L.warning(
 							"Failed to create user in Grafana:\n{}".format(text[:1000]),

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -40,6 +40,7 @@ class GrafanaIntegration(asab.config.Configurable):
 		self.TenantService = self.BatmanService.App.get_service("seacatauth.TenantService")
 		self.RoleService = self.BatmanService.App.get_service("seacatauth.RoleService")
 		self.RBACService = self.BatmanService.App.get_service("seacatauth.RBACService")
+		self.ResourceService = self.BatmanService.App.get_service("seacatauth.ResourceService")
 
 		username = self.Config.get('username')
 		password = self.Config.get('password')
@@ -57,7 +58,24 @@ class GrafanaIntegration(asab.config.Configurable):
 	async def _on_tick(self, event_name):
 		await self.sync_all()
 
+	async def _initialize_resources(self):
+		try:
+			await self.ResourceService.get(_GRAFANA_ADMIN_RESOURCE)
+		except KeyError:
+			await self.ResourceService.create(
+				_GRAFANA_ADMIN_RESOURCE,
+				description="Grants admin access to Grafana."
+			)
+		try:
+			await self.ResourceService.get(_GRAFANA_USER_RESOURCE)
+		except KeyError:
+			await self.ResourceService.create(
+				_GRAFANA_USER_RESOURCE,
+				description="Grants user access to Grafana."
+			)
+
 	async def initialize(self):
+		await self._initialize_resources()
 		await self.sync_all()
 
 

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -103,8 +103,8 @@ class GrafanaIntegration(asab.config.Configurable):
 
 		# Grafana roles from SCA resources
 		# Use only global "*" roles for now
-		if not self.RBACService.has_resource_access(authz, "*", [_GRAFANA_ADMIN_RESOURCE]) \
-			and not self.RBACService.has_resource_access(authz, "*", [_GRAFANA_USER_RESOURCE]):
+		if self.RBACService.has_resource_access(authz, "*", [_GRAFANA_ADMIN_RESOURCE]) != "OK" \
+			and not self.RBACService.has_resource_access(authz, "*", [_GRAFANA_USER_RESOURCE]) != "OK":
 			# TODO: BACK COMPAT
 			#   Use resources instead of roles! This will be removed
 			# >>>>>>>>>>>>>>
@@ -151,7 +151,7 @@ class GrafanaIntegration(asab.config.Configurable):
 						return
 
 					# Set admin role if Grafana admin resource is present
-					if self.RBACService.has_resource_access(authz, "*", [_GRAFANA_ADMIN_RESOURCE]) \
+					if self.RBACService.has_resource_access(authz, "*", [_GRAFANA_ADMIN_RESOURCE]) == "OK" \
 						or "*/grafana:grafana_admin" in authz.get("*", {}):  # TODO: BACK COMPAT, Use resources instead
 						response = await resp.json()
 						_id = response["id"]

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -104,7 +104,7 @@ class GrafanaIntegration(asab.config.Configurable):
 		# Grafana roles from SCA resources
 		# Use only global "*" roles for now
 		if self.RBACService.has_resource_access(authz, "*", [_GRAFANA_ADMIN_RESOURCE]) != "OK" \
-			and not self.RBACService.has_resource_access(authz, "*", [_GRAFANA_USER_RESOURCE]) != "OK":
+			and self.RBACService.has_resource_access(authz, "*", [_GRAFANA_USER_RESOURCE]) != "OK":
 			# TODO: BACK COMPAT
 			#   Use resources instead of roles! This will be removed
 			# >>>>>>>>>>>>>>

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -111,9 +111,6 @@ class GrafanaIntegration(asab.config.Configurable):
 			if "*/grafana:grafana_admin" not in authz.get("*", {}) \
 				and "*/grafana:grafana_user" not in authz.get("*", {}):
 				# <<<<<<<<<<<<<<<<<<<<<<<
-				L.warning("Cannot create Grafana user: User has no Grafana resources", struct_data={
-					"cid": cred["_id"]
-				})
 				return
 
 		json = {

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -142,6 +142,9 @@ class GrafanaIntegration(asab.config.Configurable):
 				async with session.post('{}/api/admin/users'.format(self.URL), json=json) as resp:
 					if resp.status == 200:
 						pass
+					elif resp.status == 412:
+						# User already exists
+						return
 					else:
 						text = await resp.text()
 						L.warning(

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -2,6 +2,7 @@ import logging
 import secrets
 
 from .adapter import SessionAdapter
+from ..authz import get_credentials_authz
 
 #
 
@@ -17,38 +18,9 @@ def credentials_session_builder(identity_id):
 
 async def authz_session_builder(tenant_service, role_service, credentials_id):
 	"""
-	Creates a "authz" attribute with the following structure:
-	'authz': {
-		'*': {
-			'*/roleB': ['resourceA', 'resourceB'],
-		},
-		'tenantA': {
-			'tenantA/roleA': ['resourceA', 'resourceB'],
-			'*/roleB': ['resourceA', 'resourceB'],
-		},
-		'tenantB': {
-			'tenantB/roleB': ['resourceA', 'resourceB'],
-			'tenantB/roleC': ['resourceE', 'resourceD'],
-			'*/roleB': ['resourceA', 'resourceB'],
-		},
-	}
+	Add 'authz' dict with complete information about credentials' tenants, roles and resources
 	"""
-
-	# Add global roles and resources under "*"
-	authz = {}
-	tenant = "*"
-	authz[tenant] = {}
-	for role in await role_service.get_roles_by_credentials(credentials_id, tenant):
-		authz[tenant][role] = await role_service.get_role_resources(role)
-
-	# Add tenant-specific roles and resources if tenant service is enabled
-	if tenant_service.is_enabled():
-		for tenant in await tenant_service.get_tenants(credentials_id):
-			authz[tenant] = {}
-			for role in await role_service.get_roles_by_credentials(credentials_id, tenant):
-				authz[tenant][role] = await role_service.get_role_resources(role)
-
-	return ((SessionAdapter.FNAuthz, authz),)
+	return ((SessionAdapter.FNAuthz, await get_credentials_authz(credentials_id, tenant_service, role_service)),)
 
 
 def login_descriptor_session_builder(login_descriptor):


### PR DESCRIPTION
- Batman for ELK uses resources prefixed with `elk:` (configurable) as a proxy for ELK roles.
- Proxying with SCA roles is supported for backwards compatibility, but will soon be removed.
- ELK resources are initialized automatically in SCA.
- `GET /resource` now accepts filter query parameter `f=`