### PR TITLE
Fix login session data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - After-provisioning cleanup (#33, PLUM Sprint 220506)
 - Fix session expiration for back-compat (#34, PLUM Sprint 220506)
 - ~~Import ASAB web container (#36, PLUM Sprint 220520)~~(4ade2c60)
+- Store login session data in database (#37, PLUM Sprint 220520)
+
+### Features
+- Mock mode in SMS provider (#37, PLUM Sprint 220520)
 
 ### Refactoring
 - Persistent OIDC authorization codes (#25, PLUM Sprint 220408)

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -114,10 +114,10 @@ class AuthenticationHandler(object):
 		login_session = await self.AuthenticationService.create_login_session(
 			credentials_id=credentials_id,
 			client_public_key=key.get_op_key("encrypt"),  # extract EC public key from JWT
-			login_descriptors=login_descriptors
+			login_descriptors=login_descriptors,
+			ident=ident,
+			requested_session_expiration=expiration,
 		)
-		login_session.Data["requested_session_expiration"] = expiration
-		login_session.Data["ident"] = ident
 
 		key = jwcrypto.jwk.JWK.from_pyca(login_session.PublicKey)
 
@@ -148,7 +148,7 @@ class AuthenticationHandler(object):
 			await self.AuthenticationService.delete_login_session(lsid)
 			L.warning("Login failed: no more attempts", struct_data={
 				"lsid": lsid,
-				"ident": login_session.Data["ident"],
+				"ident": login_session.Ident,
 				"cid": login_session.CredentialsId
 			})
 			return asab.web.rest.json_response(
@@ -184,7 +184,7 @@ class AuthenticationHandler(object):
 
 			L.warning("Login failed: authentication failed", struct_data={
 				"lsid": lsid,
-				"ident": login_session.Data["ident"],
+				"ident": login_session.Ident,
 				"cid": login_session.CredentialsId
 			})
 

--- a/seacatauth/authn/login_factors/smscode.py
+++ b/seacatauth/authn/login_factors/smscode.py
@@ -41,6 +41,7 @@ class SMSCodeFactor(LoginFactorABC):
 				"token": generate_ergonomic_token(length=6)
 			}
 		token = login_session.Data[self.Type]["token"]
+		await self.AuthenticationService.update_login_session(login_session.Id, data=login_session.Data)
 
 		# Get phone number
 		cred_svc = self.AuthenticationService.CredentialsService

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -126,15 +126,21 @@ class AuthenticationService(asab.Service):
 		self,
 		credentials_id,
 		client_public_key,
-		login_descriptors=None
+		ident,
+		login_descriptors=None,
+		requested_session_expiration=None,
+		data=None,
 	):
 		# Prepare the login session
 		login_session = LoginSession.build(
 			client_login_key=client_public_key,
 			credentials_id=credentials_id,
+			ident=ident,
 			login_descriptors=login_descriptors,
 			login_attempts=self.LoginAttempts,
-			timeout=self.LoginSessionExpiration
+			timeout=self.LoginSessionExpiration,
+			requested_session_expiration=requested_session_expiration,
+			data=data,
 		)
 
 		upsertor = self.StorageService.upsertor(self.LoginSessionCollection, login_session.Id)
@@ -317,7 +323,7 @@ class AuthenticationService(asab.Service):
 
 		session = await self.SessionService.create_session(
 			session_type="root",
-			expiration=login_session.Data.get("requested_session_expiration"),
+			expiration=login_session.RequestedSessionExpiration,
 			session_builders=session_builders,
 		)
 		L.log(

--- a/seacatauth/communication/sms_smsbranacz.py
+++ b/seacatauth/communication/sms_smsbranacz.py
@@ -32,6 +32,7 @@ class SMSBranaCZProvider(CommunicationProviderABC):
 	Channel = "sms"
 
 	ConfigDefaults = {
+		"mock": False,  # If True, messages are not sent, but rather printed to the log
 		"login": "",
 		"password": "",
 		"url": "https://api.smsbrana.cz/smsconnect/http.php",
@@ -45,6 +46,7 @@ class SMSBranaCZProvider(CommunicationProviderABC):
 		self.Password = self.Config.get("password")
 		self.TimestampFormat = self.Config.get("timestamp_format")
 		self.URL = self.Config.get("url")
+		self.Mock = self.Config.getboolean("mock")
 
 	def _init_template_provider(self):
 		pass
@@ -77,6 +79,13 @@ class SMSBranaCZProvider(CommunicationProviderABC):
 			url_params["time"] = time
 			url_params["salt"] = salt
 			url_params["auth"] = auth
+
+			if self.Mock:
+				L.log(
+					asab.LOG_NOTICE, "SMSBrana.cz provider is in mock mode. Message will not be sent.",
+					struct_data=url_params
+				)
+				return True
 
 			async with aiohttp.ClientSession() as session:
 				async with session.get(self.URL, params=url_params) as resp:


### PR DESCRIPTION
- Fix storing ident, session expiration and SMS login data in the login session
- Introduce mock mode in SMS provider (SMS messages are not sent but rather printed to log). Configure by `mock=yes`.