### PR TITLE
Custom credentials data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Release candidate
 
+### Features
+- Custom credentials data (#40, PLUM Sprint 220520)
+
+---
+
 
 ## v22.21
 

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -231,7 +231,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 		)
 
 		# Update basic credentials
-		for field in ("username", "email", "phone"):
+		for field in ("username", "email", "phone", "data"):
 			value = update.pop(field, None)
 			if value is not None:
 				u.set(field, value)

--- a/seacatauth/credentials/schemas.py
+++ b/seacatauth/credentials/schemas.py
@@ -25,6 +25,19 @@ _FIELDS = {
 			{"const": ""},
 		],
 	},
+	"data": {
+		"type": "object",
+		"description": "Custom data",
+		"patternProperties": {
+			"^[a-zA-Z][a-zA-Z0-9_-]{0,126}[a-zA-Z0-9]$": {"anyOf": [
+				{"type": "string"},
+				{"type": "number"},
+				{"type": "boolean"},
+				{"type": "null"},
+			]}
+		},
+		"additionalProperties": False,
+	},
 	"suspended": {
 		"type": "boolean",
 		"description": "Is suspended?"
@@ -65,6 +78,7 @@ UPDATE_CREDENTIALS = {
 			"email",
 			"phone",
 			"suspended",
+			"data",
 		])
 	},
 }

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -400,7 +400,8 @@ class CredentialsService(asab.Service):
 				"message": "Data does not comply with update policy",
 			}
 
-		validated_data["data"] = custom_data
+		if custom_data is not None:
+			validated_data["data"] = custom_data
 
 		# Update in provider
 		result = await provider.update(credentials_id, validated_data)

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -379,6 +379,10 @@ class CredentialsService(asab.Service):
 				"message": "Provider does not support editing",
 			}
 
+		# Custom data is not validated with policy
+		# TODO: Configurable policy/schema for custom data
+		custom_data = update_dict.pop("data", None)
+
 		# Check credentials policy
 		if session is not None:
 			authz = session.Authorization.Authz
@@ -395,6 +399,8 @@ class CredentialsService(asab.Service):
 				"status": "FAILED",
 				"message": "Data does not comply with update policy",
 			}
+
+		validated_data["data"] = custom_data
 
 		# Update in provider
 		result = await provider.update(credentials_id, validated_data)

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -105,7 +105,7 @@ class TenantHandler(object):
 	@asab.web.rest.json_schema_handler({
 		"type": "object",
 		"patternProperties": {
-			"^.+$": {"anyOf": [
+			"^[a-zA-Z][a-zA-Z0-9_-]{0,126}[a-zA-Z0-9]$": {"anyOf": [
 				{"type": "string"},
 				{"type": "number"},
 				{"type": "boolean"},


### PR DESCRIPTION
Credentials update endpoint `PUT /credentials/{credentials_id}` accepts custom `data` object, e.g.:

```json
PUT /credentials/mongodb:default:abc123def456
{
  "phone": "123456789",
  "data": {
    "country": "CZ",
    "likes_raccoons": true,
    "spoons_owned": 6.1e8
  }
}
```

Validation schema for the `data` object:
```json
"data": {
	"type": "object",
	"description": "Custom data",
	"patternProperties": {
		"^[a-zA-Z][a-zA-Z0-9_-]{0,126}[a-zA-Z0-9]$": {"anyOf": [
			{"type": "string"},
			{"type": "number"},
			{"type": "boolean"},
			{"type": "null"}
		]}
	},
	"additionalProperties": false
}
```