### PR TITLE
Always update the expiration of the whole session group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix TOTP status in userinfo (#43, PLUM Sprint 220520)
 - Session from ID token bug (82d6787, PLUM Sprint 220520)
 - OIDC scope format in token response (b5a18c2, PLUM Sprint 220520)
+- Always update the expiration of the whole session group (#44, PLUM Sprint 220520)
 
 ### Features
 - Structured session list (#30, PLUM Sprint 220520)


### PR DESCRIPTION
- The `SessionService.touch(session)` method updates the expiration of `session`'s parent session and all its child sessions.