### PR TITLE
Remove role info from Authz

### DIFF
--- a/seacatauth/authz/rbac/service.py
+++ b/seacatauth/authz/rbac/service.py
@@ -1,9 +1,9 @@
 import logging
+import typing
 
 import asab
 
 #
-import typing
 
 L = logging.getLogger(__name__)
 
@@ -19,8 +19,7 @@ class RBACService(asab.Service):
 	def is_superuser(authz: dict):
 		global_resources = set(
 			resource
-			for role in authz["*"].values()
-			for resource in role
+			for resource in authz["*"]
 		)
 		return "authz:superuser" in global_resources
 
@@ -35,23 +34,20 @@ class RBACService(asab.Service):
 			# Gather resources from all tenants
 			resources = set(
 				resource
-				for roles in authz.values()
-				for resources in roles.values()
+				for resources in authz.values()
 				for resource in resources
 			)
 		elif tenant is None:
 			# If the tenant is None, we check only global roles
 			resources = set(
 				resource
-				for resources in authz["*"].values()
-				for resource in resources
+				for resource in authz["*"]
 			)
 		elif tenant in authz:
 			# We are checking resources under a specific tenant
 			resources = set(
 				resource
-				for resources in authz[tenant].values()
-				for resource in resources
+				for resource in authz[tenant]
 			)
 		else:
 			# Inaccessible tenant

--- a/seacatauth/authz/utils.py
+++ b/seacatauth/authz/utils.py
@@ -1,18 +1,15 @@
 async def get_credentials_authz(credentials_id, tenant_service, role_service):
 	"""
-	Creates a nested 'authz' dict with tenant:role:resource structure:
+	Creates a nested 'authz' dict with tenant:resource structure:
 	{
 		'*': {
-			'*/roleB': ['resourceA', 'resourceB'],
+			['resourceA', 'resourceB'],
 		},
 		'tenantA': {
-			'tenantA/roleA': ['resourceA', 'resourceB'],
-			'*/roleB': ['resourceA', 'resourceB'],
+			['resourceA', 'resourceB', 'resourceC'],
 		},
 		'tenantB': {
-			'tenantB/roleB': ['resourceA', 'resourceB'],
-			'tenantB/roleC': ['resourceE', 'resourceD'],
-			'*/roleB': ['resourceA', 'resourceB'],
+			['resourceA', 'resourceB', 'resourceE', 'resourceD'],
 		},
 	}
 	"""
@@ -20,15 +17,17 @@ async def get_credentials_authz(credentials_id, tenant_service, role_service):
 	# Add global roles and resources under "*"
 	authz = {}
 	tenant = "*"
-	authz[tenant] = {}
+	authz[tenant] = set()
 	for role in await role_service.get_roles_by_credentials(credentials_id, tenant):
-		authz[tenant][role] = await role_service.get_role_resources(role)
+		authz[tenant].update(await role_service.get_role_resources(role))
+	authz[tenant] = list(authz[tenant])
 
 	# Add tenant-specific roles and resources if tenant service is enabled
 	if tenant_service.is_enabled():
 		for tenant in await tenant_service.get_tenants(credentials_id):
-			authz[tenant] = {}
+			authz[tenant] = set()
 			for role in await role_service.get_roles_by_credentials(credentials_id, tenant):
-				authz[tenant][role] = await role_service.get_role_resources(role)
+				authz[tenant].update(await role_service.get_role_resources(role))
+			authz[tenant] = list(authz[tenant])
 
 	return authz

--- a/seacatauth/decorators.py
+++ b/seacatauth/decorators.py
@@ -131,8 +131,7 @@ def _authorize_tenant(request):
 	requested_tenant = request.match_info.get("tenant")
 
 	# Gather resources from all global roles
-	global_roles = request.Session.Authorization.Authz.get("*")
-	available_resources = set().union(*global_roles.values())
+	available_resources = set().union(request.Session.Authorization.Authz.get("*"))
 
 	# Check for tenant access
 	if requested_tenant in (None, "*"):
@@ -141,8 +140,7 @@ def _authorize_tenant(request):
 	elif requested_tenant in request.Session.Authorization.Authz:
 		# Tenant accessible
 		# Add resources from all roles under the requested_tenant
-		tenant_authz = request.Session.Authorization.Authz.get(requested_tenant)
-		available_resources = available_resources.union(*tenant_authz.values())
+		available_resources = available_resources.union(request.Session.Authorization.Authz.get(requested_tenant))
 	elif "authz:superuser" in available_resources:
 		# Bypassing tenant-access check as superuser
 		# No resources to add

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -72,14 +72,13 @@ def private_auth_middleware_factory(app):
 			#   for `authorization_resource` or "authz:superuser"
 			resources = set(
 				resource
-				for roles in request.Session.Authorization.Authz.values()
-				for resources in roles.values()
+				for resources in request.Session.Authorization.Authz.values()
 				for resource in resources
 			)
 			# Grant access to superuser
 			if "authz:superuser" in resources:
 				return await handler(request)
-			# Grant access the the bearer of `authorization_resource`
+			# Grant access to the bearer of `authorization_resource`
 			if authorization_resource in resources:
 				return await handler(request)
 

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -315,9 +315,6 @@ class OpenIdConnectService(asab.Service):
 			if len(tenants) > 0:
 				userinfo["tenants"] = tenants
 
-		if session.Authorization.Roles is not None:
-			userinfo["roles"] = session.Authorization.Roles
-
 		if session.Authorization.Resources is not None:
 			userinfo["resources"] = session.Authorization.Resources
 
@@ -346,17 +343,9 @@ class OpenIdConnectService(asab.Service):
 			tenant = "*"
 
 		# Include "roles" and "resources" sections, with items relevant to query_tenant
-		session_roles = session.Authorization.Authz.get(tenant)
-		if session_roles is not None:
-			roles = []
-			resources = set()
-			for session_role, session_resources in session_roles.items():
-				roles.append(session_role)
-				resources.update(session_resources)
-			if len(roles) > 0:
-				userinfo["roles"] = roles
-			if len(resources) > 0:
-				userinfo["resources"] = list(resources)
+		resources = session.Authorization.Authz.get(tenant)
+		if resources is not None:
+			userinfo["resources"] = resources
 		else:
 			L.error(
 				"Tenant '{}' not found in session.Authorization.authz.".format(tenant),

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -46,7 +46,6 @@ class AuthenticationData:
 @dataclasses.dataclass
 class AuthorizationData:
 	Authz: dict
-	Roles: list
 	Resources: list
 	Tenants: list
 
@@ -100,7 +99,6 @@ class SessionAdapter:
 		class Authorization:
 			_prefix = "az"
 			Tenants = "az_t"
-			Roles = "az_rl"
 			Resources = "az_rs"
 			Authz = "az_az"
 
@@ -171,7 +169,6 @@ class SessionAdapter:
 			cls.FN.Credentials.Phone: id_token_dict.get("phone_number"),
 			cls.FN.Authorization.Authz: id_token_dict.get("authz"),
 			cls.FN.Authorization.Tenants: id_token_dict.get("tenants"),
-			cls.FN.Authorization.Roles: id_token_dict.get("roles"),
 			cls.FN.Authorization.Resources: id_token_dict.get("resources"),
 		}
 		return cls(session_svc, session_dict)
@@ -224,7 +221,6 @@ class SessionAdapter:
 			session_dict.update({
 				self.FN.Authorization.Authz: self.Authorization.Authz,
 				self.FN.Authorization.Tenants: self.Authorization.Tenants,
-				self.FN.Authorization.Roles: self.Authorization.Roles,
 				self.FN.Authorization.Resources: self.Authorization.Resources,
 			})
 
@@ -318,7 +314,6 @@ class SessionAdapter:
 			return None
 		return AuthorizationData(
 			Authz=authz,
-			Roles=session_dict.pop(cls.FN.Authorization.Roles, None) or session_dict.pop("Rl", None),
 			Resources=session_dict.pop(cls.FN.Authorization.Resources, None) or session_dict.pop("Rs", None),
 			Tenants=session_dict.pop(cls.FN.Authorization.Tenants, None) or session_dict.pop("Tn", None),
 		)

--- a/test/test_rbac.py
+++ b/test/test_rbac.py
@@ -7,29 +7,16 @@ class RBACTestCase(unittest.TestCase):
 	maxDiff = None
 
 	authz_test_data = {
-		"*": {
-			"*/user": ["post:read"],
-			"*/editor": ["post:write", "post:edit"],
-		},
-		"first-tenant": {
-			"*/user": ["post:read"],
-			"*/editor": ["post:write", "post:edit"],
-			"first-tenant/admin": ["authz:tenant:admin"]
-		}
+		"*": ["post:read", "post:write", "post:edit"],
+		"first-tenant": ["post:read", "post:write", "post:edit", "authz:tenant:admin"],
 	}
 
 	notenant_authz_test_data = {
-		"*": {
-			"*/user": ["post:read"],
-			"*/editor": ["post:write", "post:edit"],
-		}
+		"*": ["post:read", "post:write", "post:edit"],
 	}
 
 	superuser_authz_test_data = {
-		"*": {
-			"*/user": ["post:read"],
-			"*/superuser": ["authz:superuser"],
-		}
+		"*": ["post:read", "authz:superuser"],
 	}
 
 	def test_tenant_access(self):


### PR DESCRIPTION
Authz object no longer contains roles and its structure is simplified to `authz={tenant: [resources]}` (instead of `authz={tenant: {role: [resources]}}`).

Roles are no longer included in the session object, userinfo or ID token