### PR TITLE
Public API authenticates by cookie only if no Authorization header is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Introspection outputs ID token instead of Access token (#39, PLUM Sprint 220520)
 - Roles are no longer included in userinfo or ID token (#50, PLUM Sprint 220603)
 - Batman no longer checks role names (#54, PLUM Sprint 220603)
+- Public API authenticates by cookie only if no Authorization header is present (#61, PLUM Sprint 220617)
 
 ### Fix
 - Fix TOTP activation error (#43, PLUM Sprint 220520)
@@ -38,6 +39,7 @@
 - Authz object no longer contains roles (#50, PLUM Sprint 220603)
 - Datetime objects are explicitly UTC-aware (#48, PLUM Sprint 220603)
 - RBAC has_resource_access returns boolean (#54, PLUM Sprint 220603)
+- Public API authenticates by cookie only if no Authorization header is present (#61, PLUM Sprint 220617)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Introspection outputs ID token instead of Access token (#39, PLUM Sprint 220520)
 - Roles are no longer included in userinfo or ID token (#50, PLUM Sprint 220603)
 - Batman no longer checks role names (#54, PLUM Sprint 220603)
-- Public API authenticates by cookie only if no Authorization header is present (#61, PLUM Sprint 220617)
+- Public API authenticates by cookie only if no Authorization header is present (#53, PLUM Sprint 220617)
 
 ### Fix
 - Fix TOTP activation error (#43, PLUM Sprint 220520)
@@ -39,7 +39,7 @@
 - Authz object no longer contains roles (#50, PLUM Sprint 220603)
 - Datetime objects are explicitly UTC-aware (#48, PLUM Sprint 220603)
 - RBAC has_resource_access returns boolean (#54, PLUM Sprint 220603)
-- Public API authenticates by cookie only if no Authorization header is present (#61, PLUM Sprint 220617)
+- Public API authenticates by cookie only if no Authorization header is present (#53, PLUM Sprint 220617)
 
 ---
 

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -117,7 +117,7 @@ class CookieService(asab.Service):
 		try:
 			session = await self.SessionService.get_by(SessionAdapter.FN.Cookie.Id, session_cookie_id)
 		except KeyError:
-			L.warning("Session not found", struct_data={"sci": session_cookie_id})
+			L.info("Session not found", struct_data={"sci": session_cookie_id})
 			return None
 
 		return session

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -1,5 +1,3 @@
-import time
-
 import aiohttp.web
 import asab
 import logging

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -4,8 +4,6 @@ import aiohttp.web
 import asab
 import asab.web.rest
 
-from ...generic import get_bearer_token_value
-
 #
 
 L = logging.getLogger(__name__)

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -35,19 +35,7 @@ class UserInfoHandler(object):
 		OpenID Connect Core 1.0, chapter 5.3. UserInfo Endpoint
 		"""
 
-		if request.Session is not None:
-			# Use the session that was authenticated via SCI
-			session = request.Session
-		else:
-			# Authenticate via OAuth2 Bearer token
-			token_value = get_bearer_token_value(request)
-			if token_value is not None:
-				try:
-					session = self.OpenIdConnectService.build_session_from_id_token(token_value)
-				except ValueError:
-					session = await self.OpenIdConnectService.get_session_by_access_token(token_value)
-			else:
-				session = None
+		session = request.Session
 
 		if session is None:
 			L.warning("Request for invalid/expired session")


### PR DESCRIPTION
# Authentication flow

## SeaCat Auth Public API
![SCA public api authn flow-public drawio](https://user-images.githubusercontent.com/11579460/176636519-36ee7a10-9630-4d85-a50d-7c3a20e210fb.png)

## SeaCat Auth OpenID Connect API
![SCA public api authn flow-openidconnect drawio](https://user-images.githubusercontent.com/11579460/176636547-9d3d48bd-2f82-4cf5-8567-5d56af0ff271.png)

