### PR TITLE
Webauthn: Store relaying party ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## Release candidate
+
+### Breaking changes
+- WebAuthn data format changed: Existing WebAuthn credentials are invalidated (#63, PLUM Sprint 220617)
+
+### Refactoring
+- Include relaying party ID in WebAuthn storage (#63, PLUM Sprint 220617)
+
+---
+
+
 ## v22.26
 
 ### Breaking changes

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -83,6 +83,7 @@ class WebAuthnService(asab.Service):
 		upsertor.set("uv", verified_registration.user_verified)
 		upsertor.set("ct", verified_registration.credential_type.value)
 		upsertor.set("ao", verified_registration.attestation_object)
+		upsertor.set("rpid", self.RelyingPartyId)
 		upsertor.set("name", name)
 
 		wacid = await upsertor.execute()
@@ -102,7 +103,10 @@ class WebAuthnService(asab.Service):
 		"""
 		collection = self.StorageService.Database[self.WebAuthnCredentialCollection]
 
-		query_filter = {"cid": credentials_id}
+		query_filter = {
+			"cid": credentials_id,
+			"rpid": self.RelyingPartyId,
+		}
 		cursor = collection.find(query_filter)
 
 		cursor.sort("_c", -1)

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -105,7 +105,7 @@ class WebAuthnService(asab.Service):
 
 		query_filter = {
 			"cid": credentials_id,
-			"rpid": self.RelyingPartyId,
+			"rpid": self.RelyingPartyId,  # For verification, to prevent incompatible (migrated) credentials
 		}
 		cursor = collection.find(query_filter)
 


### PR DESCRIPTION
### Issue
When migrating to a different hostname, saved webauthn credentials (created on old hostname) are not recognized by frontend.

### Solution
Webauthn credentials are saved with the ID of the relaying party that created them. When logging in, only the credentials that match the current relaying party ID are usable.