### PR TITLE
Provisioning uses JSON config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fix
 - Handle old assignments of nonexisting credentials (#79, PLUM Sprint 220715)
 
+### Refactoring
+- Provisioning config in a dedicated JSON file (#80, PLUM Sprint 220729)
+
 ---
 
 

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -51,10 +51,7 @@ asab.Config.add_defaults({
 	"seacatauth:provisioning": {
 		# Specifies which environment variable will activate provisioning mode when set to true
 		"env_variable_name": "SEACAT_AUTH_PROVISIONING",
-		"superuser_name": "superuser",
-		"superrole_id": "*/provisioning-superrole",
-		"credentials_provider_id": "provisioning",
-		"tenant": "provisioning-tenant",
+		"provisioning_config_file": "",
 	},
 
 	"seacatauth:credentials": {

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -149,7 +149,7 @@ class SeaCatAuthApplication(asab.Application):
 		self.FeatureHandler = FeatureHandler(self, self.FeatureService)
 
 		# Provisioning service
-		# depends on: RoleService, CredentialService, SessionService
+		# depends on: RoleService, CredentialService
 		if self.Provisioning:
 			from .provisioning import ProvisioningService
 			self.ProvisioningService = ProvisioningService(self)

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -265,9 +265,11 @@ class CredentialsService(asab.Service):
 
 
 	def create_dict_provider(self, provider_id):
-		from .providers.dictionary import DictCredentialsService
-		DictCredentialsService(self.App)
-		service = self.App.get_service("seacatauth.credentials.dict")
+		try:
+			service = self.App.get_service("seacatauth.credentials.dict")
+		except KeyError:
+			from .providers.dictionary import DictCredentialsService
+			service = DictCredentialsService(self.App)
 		provider = service.create_provider(provider_id, None)
 		self.register(provider)
 

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -74,7 +74,7 @@ class ProvisioningService(asab.Service):
 		L.log(asab.LOG_NOTICE, _PROVISIONING_INTRO_MESSAGE.format(username=self.SuperuserName, password=password))
 
 		# Create provisioning tenant
-		result = await self.TenantService.create_tenant(self.TenantID)
+		await self.TenantService.create_tenant(self.TenantID)
 
 		# Assign tenant to provisioning user
 		await self.TenantService.assign_tenant(self.SuperuserID, self.TenantID)

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import passlib.pwd
 
@@ -9,7 +10,7 @@ L = logging.getLogger(__name__)
 
 #
 
-_provisioning_intro_message = """
+_PROVISIONING_INTRO_MESSAGE = """
 
 SeaCat Auth is running in provisioning mode.
 
@@ -20,6 +21,13 @@ Use the following credentials to log in:
 
 """
 
+_PROVISIONING_CONFIG_DEFAULTS = {
+	"credentials_name": "provisioning-superuser",
+	"credentials_provider_id": "provisioning",
+	"role_name": "provisioning-superrole",
+	"tenant": "provisioning-tenant",
+}
+
 
 class ProvisioningService(asab.Service):
 
@@ -28,19 +36,25 @@ class ProvisioningService(asab.Service):
 		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
 		self.RoleService = app.get_service("seacatauth.RoleService")
 		self.TenantService = app.get_service("seacatauth.TenantService")
-		self.SessionService = app.get_service("seacatauth.SessionService")
-		self.SuperuserName = asab.Config.get("seacatauth:provisioning", "superuser_name")
-		self.TenantID = asab.Config.get("seacatauth:provisioning", "tenant")
+		self.ResourceService = app.get_service("seacatauth.ResourceService")
+
+		self.Config = _PROVISIONING_CONFIG_DEFAULTS
+		config_file = asab.Config.get("seacatauth:provisioning", "provisioning_config_file").strip() or None
+		if config_file is not None:
+			with open(config_file) as f:
+				self.Config.update(json.load(f))
+		self.SuperuserName = self.Config["credentials_name"]
+		self.TenantID = self.Config["tenant"]
 		self.SuperuserID = None
-		self.SuperroleID = asab.Config.get("seacatauth:provisioning", "superrole_id")
-		self.CredentialsProviderID = asab.Config.get("seacatauth:provisioning", "credentials_provider_id")
+		self.SuperroleID = "*/{}".format(self.Config["role_name"])
+		self.CredentialsProviderID = self.Config["credentials_provider_id"]
+
 
 	async def initialize(self, app):
 		await super().initialize(app)
 
 		# TODO: ResourceService should be already initialized by the app
-		resource_svc = app.get_service("seacatauth.ResourceService")
-		await resource_svc.initialize(app)
+		await self.ResourceService.initialize(app)
 
 		# Create provisioning credentials provider
 		self.CredentialsService.create_dict_provider(self.CredentialsProviderID)
@@ -57,13 +71,10 @@ class ProvisioningService(asab.Service):
 			"username": self.SuperuserName,
 			"password": password
 		})
-		L.log(asab.LOG_NOTICE, _provisioning_intro_message.format(username=self.SuperuserName, password=password))
+		L.log(asab.LOG_NOTICE, _PROVISIONING_INTRO_MESSAGE.format(username=self.SuperuserName, password=password))
 
 		# Create provisioning tenant
-		try:
-			await self.TenantService.create_tenant(self.TenantID)
-		except KeyError:
-			L.error("Tenant already exists", struct_data={"tenant": self.TenantID})
+		result = await self.TenantService.create_tenant(self.TenantID)
 
 		# Assign tenant to provisioning user
 		await self.TenantService.assign_tenant(self.SuperuserID, self.TenantID)
@@ -76,7 +87,8 @@ class ProvisioningService(asab.Service):
 		) == "OK")
 
 		# Assign superuser role to the provisioning user
-		await self.RoleService.set_roles(self.SuperuserID, {"*"}, [self.SuperroleID])
+		await self.RoleService.assign_role(self.SuperuserID, self.SuperroleID)
+
 
 	async def finalize(self, app):
 		# Delete the superuser


### PR DESCRIPTION
## Issue

Most provisioning config is only relevant during the initial provisioning session.

## Solution

If you need to override provisioning defaults, the provisioning config should be supplied in a dedicated JSON file. Service configuration only contains the path to that file, e.g.:

```ini
[seacatauth:provisioning]
provisioning_config_file=./seacatauth-conf/provisioning.json
```