### PR TITLE
Propagate credentials "data" field to userinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Handle old assignments of nonexisting credentials (#79, PLUM Sprint 220715)
 
 ### Features
-- OpenID Connect client registration (#77, PLUM Sprint 220520)
+- OpenID Connect client registration (#77, PLUM Sprint 220729)
+- Custom credentials data included in userinfo response (#81, PLUM Sprint 220729)
 
 ### Refactoring
 - Provisioning config in a dedicated JSON file (#80, PLUM Sprint 220729)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -283,6 +283,9 @@ class OpenIdConnectService(asab.Service):
 		if session.Credentials.Phone is not None:
 			userinfo["phone_number"] = session.Credentials.Phone
 
+		if session.Credentials.CustomData is not None:
+			userinfo["custom"] = session.Credentials.CustomData
+
 		if session.Credentials.ModifiedAt is not None:
 			userinfo["updated_at"] = session.Credentials.ModifiedAt
 

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -32,6 +32,7 @@ class CredentialsData:
 	Username: typing.Optional[str]
 	Email: typing.Optional[str]
 	Phone: typing.Optional[str]
+	CustomData: typing.Optional[dict]
 
 
 @dataclasses.dataclass
@@ -95,6 +96,7 @@ class SessionAdapter:
 			Phone = "c_p"
 			CreatedAt = "c_c"
 			ModifiedAt = "c_m"
+			CustomData = "c_d"
 
 		class Authorization:
 			_prefix = "az"
@@ -167,6 +169,7 @@ class SessionAdapter:
 			cls.FN.Credentials.Username: id_token_dict.get("preferred_username"),
 			cls.FN.Credentials.Email: id_token_dict.get("email"),
 			cls.FN.Credentials.Phone: id_token_dict.get("phone_number"),
+			cls.FN.Credentials.CustomData: id_token_dict.get("custom"),
 			cls.FN.Authorization.Authz: id_token_dict.get("authz"),
 			cls.FN.Authorization.Tenants: id_token_dict.get("tenants"),
 			cls.FN.Authorization.Resources: id_token_dict.get("resources"),
@@ -205,6 +208,7 @@ class SessionAdapter:
 				self.FN.Credentials.Email: self.Credentials.Email,
 				self.FN.Credentials.Phone: self.Credentials.Phone,
 				self.FN.Credentials.Username: self.Credentials.Username,
+				self.FN.Credentials.CustomData: self.Credentials.CustomData,
 				self.FN.Credentials.CreatedAt: self.Credentials.CreatedAt,
 				self.FN.Credentials.ModifiedAt: self.Credentials.ModifiedAt,
 			})
@@ -289,6 +293,7 @@ class SessionAdapter:
 			Username=session_dict.pop(cls.FN.Credentials.Username, None),
 			Email=session_dict.pop(cls.FN.Credentials.Email, None),
 			Phone=session_dict.pop(cls.FN.Credentials.Phone, None),
+			CustomData=session_dict.pop(cls.FN.Credentials.CustomData, None),
 		)
 
 	# TODO: The following methods contain BACK-COMPAT fallbacks (the or-sections)

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -18,6 +18,7 @@ async def credentials_session_builder(credentials_service, credentials_id):
 		(SessionAdapter.FN.Credentials.Username, credentials.get("username")),
 		(SessionAdapter.FN.Credentials.Email, credentials.get("email")),
 		(SessionAdapter.FN.Credentials.Phone, credentials.get("phone")),
+		(SessionAdapter.FN.Credentials.CustomData, credentials.get("data")),
 		(SessionAdapter.FN.Credentials.CreatedAt, credentials.get("_c")),
 		(SessionAdapter.FN.Credentials.ModifiedAt, credentials.get("_m")),
 		(SessionAdapter.FN.Authentication.TOTPSet, credentials.get("__totp") not in (None, "")),


### PR DESCRIPTION
The `data` field in credentials object is included in userinfo response as `custom`, e.g.:

```json
{
	"sub": "mongodb:ext:60eee70d6b47935cf7bacdda",
	...,
	"custom": {
		"member_of_secret_club": true,
		"secret_token": "r8xd4zv28erszver"
	}
}
```
