### PR TITLE
Client features endpoint with templates

### DIFF
--- a/seacatauth/openidconnect/client/handler.py
+++ b/seacatauth/openidconnect/client/handler.py
@@ -21,7 +21,7 @@ class ClientHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/client", self.list)
-		web_app.router.add_get("/client/options", self.options)
+		web_app.router.add_get("/client/features", self.features)
 		web_app.router.add_get("/client/{client_id}", self.get)
 		web_app.router.add_post("/client", self.register)
 		web_app.router.add_post("/client/{client_id}/reset_secret", self.reset_secret)
@@ -66,7 +66,7 @@ class ClientHandler(object):
 
 
 	@access_control("authz:superuser")
-	async def options(self, request):
+	async def features(self, request):
 		result = {
 			"metadata_schema": CLIENT_METADATA_SCHEMA,
 			"templates": CLIENT_TEMPLATES

--- a/seacatauth/openidconnect/client/handler.py
+++ b/seacatauth/openidconnect/client/handler.py
@@ -6,7 +6,7 @@ import asab.web.rest
 import asab.exceptions
 
 from ...decorators import access_control
-from .service import CLIENT_METADATA_SCHEMA
+from .service import CLIENT_METADATA_SCHEMA, CLIENT_TEMPLATES
 
 #
 
@@ -21,6 +21,7 @@ class ClientHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/client", self.list)
+		web_app.router.add_get("/client/options", self.options)
 		web_app.router.add_get("/client/{client_id}", self.get)
 		web_app.router.add_post("/client", self.register)
 		web_app.router.add_post("/client/{client_id}/reset_secret", self.reset_secret)
@@ -59,6 +60,17 @@ class ClientHandler(object):
 		result = self._rest_normalize(
 			await self.ClientService.get(client_id),
 			include_client_secret=True)
+		return asab.web.rest.json_response(
+			request, result
+		)
+
+
+	@access_control("authz:superuser")
+	async def options(self, request):
+		result = {
+			"metadata_schema": CLIENT_METADATA_SCHEMA,
+			"templates": CLIENT_TEMPLATES
+		}
 		return asab.web.rest.json_response(
 			request, result
 		)

--- a/seacatauth/openidconnect/client/handler.py
+++ b/seacatauth/openidconnect/client/handler.py
@@ -6,7 +6,7 @@ import asab.web.rest
 import asab.exceptions
 
 from ...decorators import access_control
-from .service import CLIENT_METADATA_SCHEMA, CLIENT_TEMPLATES
+from .service import CLIENT_METADATA_SCHEMA, CLIENT_TEMPLATES, FORM_ELEMENTS
 
 #
 
@@ -67,9 +67,14 @@ class ClientHandler(object):
 
 	@access_control("authz:superuser")
 	async def features(self, request):
+		form_schema = [
+			{attribute: CLIENT_METADATA_SCHEMA["properties"][attribute]}
+			for attribute in FORM_ELEMENTS
+		]
 		result = {
 			"metadata_schema": CLIENT_METADATA_SCHEMA,
-			"templates": CLIENT_TEMPLATES
+			"templates": CLIENT_TEMPLATES,
+			"form_schema": form_schema,
 		}
 		return asab.web.rest.json_response(
 			request, result

--- a/seacatauth/openidconnect/client/handler.py
+++ b/seacatauth/openidconnect/client/handler.py
@@ -6,7 +6,7 @@ import asab.web.rest
 import asab.exceptions
 
 from ...decorators import access_control
-from .service import CLIENT_METADATA_SCHEMA, CLIENT_TEMPLATES, FORM_ELEMENTS
+from .service import CLIENT_METADATA_SCHEMA, CLIENT_TEMPLATES
 
 #
 
@@ -67,14 +67,9 @@ class ClientHandler(object):
 
 	@access_control("authz:superuser")
 	async def features(self, request):
-		form_schema = [
-			{attribute: CLIENT_METADATA_SCHEMA["properties"][attribute]}
-			for attribute in FORM_ELEMENTS
-		]
 		result = {
 			"metadata_schema": CLIENT_METADATA_SCHEMA,
 			"templates": CLIENT_TEMPLATES,
-			"form_schema": form_schema,
 		}
 		return asab.web.rest.json_response(
 			request, result

--- a/seacatauth/openidconnect/client/service.py
+++ b/seacatauth/openidconnect/client/service.py
@@ -78,8 +78,7 @@ CLIENT_METADATA_SCHEMA = {
 			"type": "string",
 			"description":
 				"Requested Client Authentication method for the Token Endpoint. "
-				"If omitted, the default is `client_secret_basic` -- "
-				"the HTTP Basic Authentication Scheme specified in Section 2.3.1 of OAuth 2.0 [RFC6749].",
+				"If omitted, the default is `client_secret_basic`.",
 			"enum": TOKEN_ENDPOINT_AUTH_METHODS},
 		# "token_endpoint_auth_signing_alg": {},
 		# "default_max_age": {},

--- a/seacatauth/openidconnect/client/service.py
+++ b/seacatauth/openidconnect/client/service.py
@@ -86,6 +86,7 @@ CLIENT_METADATA_SCHEMA = {
 	# }
 }
 
+# TODO: Configurable templates
 CLIENT_TEMPLATES = {
 	"Public web application": {
 		"application_type": "web",

--- a/seacatauth/openidconnect/client/service.py
+++ b/seacatauth/openidconnect/client/service.py
@@ -40,7 +40,7 @@ CLIENT_METADATA_SCHEMA = {
 		"response_types": {
 			"type": "array",
 			"description":
-				"JSON array containing a list of the OAuth 2.0 response_type values " 
+				"JSON array containing a list of the OAuth 2.0 response_type values "
 				"that the Client is declaring that it will restrict itself to using. "
 				"If omitted, the default is that the Client will use only the `code` Response Type.",
 			"items": {

--- a/seacatauth/openidconnect/client/service.py
+++ b/seacatauth/openidconnect/client/service.py
@@ -121,7 +121,9 @@ CLIENT_TEMPLATES = {
 		"response_types": ["code"]},
 	"Public mobile app": {
 		"application_type": "native",
-		"token_endpoint_auth_method": "none"},
+		"token_endpoint_auth_method": "none",
+		"grant_types": ["authorization_code"],
+		"response_types": ["code"]},
 	"Custom...": {},
 }
 

--- a/seacatauth/openidconnect/client/service.py
+++ b/seacatauth/openidconnect/client/service.py
@@ -86,6 +86,17 @@ CLIENT_METADATA_SCHEMA = {
 	# }
 }
 
+CLIENT_TEMPLATES = {
+	"Public web application": {
+		"application_type": "web",
+		"token_endpoint_auth_method": "none",
+		"grant_types": ["authorization_code"],
+		"response_types": ["code"]},
+	"Public mobile app": {
+		"application_type": "native",
+		"token_endpoint_auth_method": "none"},
+}
+
 
 class ClientService(asab.Service):
 	"""

--- a/seacatauth/openidconnect/client/service.py
+++ b/seacatauth/openidconnect/client/service.py
@@ -23,30 +23,42 @@ TOKEN_ENDPOINT_AUTH_METHODS = [
 	"none", "client_secret_basic", "client_secret_post", "client_secret_jwt", "private_key_jwt"]
 CLIENT_METADATA_SCHEMA = {
 	"type": "object",
-	"required": ["redirect_uris"],
+	"required": ["redirect_uris", "client_name"],
 	"additionalProperties": False,
 	"properties": {
 		"redirect_uris": {
-			"type": "array", "description": "Array of Redirection URI values used by the Client."},
+			"type": "array",
+			"description": "Array of Redirection URI values used by the Client."},
 		"client_name": {  # Can have language tags (e.g. "client_name#cs")
-			"type": "string"},
+			"type": "string",
+			"description": "Name of the Client to be presented to the End-User."},
 		#  "contacts": {},
 		"application_type": {
 			"type": "string",
+			"description": "Kind of the application. The default, if omitted, is `web`.",
 			"enum": APPLICATION_TYPES},
 		"response_types": {
 			"type": "array",
+			"description":
+				"JSON array containing a list of the OAuth 2.0 response_type values " 
+				"that the Client is declaring that it will restrict itself to using. "
+				"If omitted, the default is that the Client will use only the `code` Response Type.",
 			"items": {
 				"type": "string",
 				"enum": RESPONSE_TYPES}},
 		"grant_types": {
 			"type": "array",
+			"description":
+				"JSON array containing a list of the OAuth 2.0 Grant Types "
+				"that the Client is declaring that it will restrict itself to using. "
+				"If omitted, the default is that the Client will use only the `authorization_code` Grant Type.",
 			"items": {
 				"type": "string",
 				"enum": GRANT_TYPES}},
 		# "logo_uri": {},  # Can have language tags
 		"client_uri": {  # Can have language tags
-			"type": "string"},
+			"type": "string",
+			"description": "URL of the home page of the Client."},
 		# "policy_uri": {},  # Can have language tags
 		# "tos_uri": {},  # Can have language tags
 		# "jwks_uri": {},
@@ -64,6 +76,10 @@ CLIENT_METADATA_SCHEMA = {
 		# "request_object_encryption_enc": {},
 		"token_endpoint_auth_method": {
 			"type": "string",
+			"description":
+				"Requested Client Authentication method for the Token Endpoint. "
+				"If omitted, the default is `client_secret_basic` -- "
+				"the HTTP Basic Authentication Scheme specified in Section 2.3.1 of OAuth 2.0 [RFC6749].",
 			"enum": TOKEN_ENDPOINT_AUTH_METHODS},
 		# "token_endpoint_auth_signing_alg": {},
 		# "default_max_age": {},
@@ -85,6 +101,17 @@ CLIENT_METADATA_SCHEMA = {
 	# 	"^tos_uri#[-a-zA-Z0-9]+$": {"type": "string"},
 	# }
 }
+
+FORM_ELEMENTS = [
+	"client_name",
+	"client_uri",
+	"redirect_uris",
+	"logout_uri",
+	"application_type",
+	"response_types",
+	"grant_types",
+	"token_endpoint_auth_method",
+]
 
 # TODO: Configurable templates
 CLIENT_TEMPLATES = {

--- a/seacatauth/openidconnect/client/service.py
+++ b/seacatauth/openidconnect/client/service.py
@@ -122,6 +122,7 @@ CLIENT_TEMPLATES = {
 	"Public mobile app": {
 		"application_type": "native",
 		"token_endpoint_auth_method": "none"},
+	"Custom...": {},
 }
 
 

--- a/seacatauth/openidconnect/client/service.py
+++ b/seacatauth/openidconnect/client/service.py
@@ -26,13 +26,21 @@ CLIENT_METADATA_SCHEMA = {
 	"required": ["redirect_uris", "client_name"],
 	"additionalProperties": False,
 	"properties": {
-		"redirect_uris": {
-			"type": "array",
-			"description": "Array of Redirection URI values used by the Client."},
+		# The order of the properties is preserved in the UI form
 		"client_name": {  # Can have language tags (e.g. "client_name#cs")
 			"type": "string",
 			"description": "Name of the Client to be presented to the End-User."},
+		"client_uri": {  # Can have language tags
+			"type": "string",
+			"description": "URL of the home page of the Client."},
+		"redirect_uris": {
+			"type": "array",
+			"description": "Array of Redirection URI values used by the Client."},
 		#  "contacts": {},
+		"custom_data": {  # NON-CANONICAL
+			"type": "object", "description": "Additional client data."},
+		"logout_uri": {  # NON-CANONICAL
+			"type": "string", "description": "URI that will be called on session logout."},
 		"application_type": {
 			"type": "string",
 			"description": "Kind of the application. The default, if omitted, is `web`.",
@@ -56,9 +64,6 @@ CLIENT_METADATA_SCHEMA = {
 				"type": "string",
 				"enum": GRANT_TYPES}},
 		# "logo_uri": {},  # Can have language tags
-		"client_uri": {  # Can have language tags
-			"type": "string",
-			"description": "URL of the home page of the Client."},
 		# "policy_uri": {},  # Can have language tags
 		# "tos_uri": {},  # Can have language tags
 		# "jwks_uri": {},
@@ -86,10 +91,6 @@ CLIENT_METADATA_SCHEMA = {
 		# "default_acr_values": {},
 		# "initiate_login_uri": {},
 		# "request_uris": {},
-		"custom_data": {  # NON-CANONICAL
-			"type": "object", "description": "Additional client data."},
-		"logout_uri": {  # NON-CANONICAL
-			"type": "string", "description": "URI that will be called on session logout."},
 	},
 	# "patternProperties": {
 	#   # Language-specific metadata with RFC 5646 language tags
@@ -100,17 +101,6 @@ CLIENT_METADATA_SCHEMA = {
 	# 	"^tos_uri#[-a-zA-Z0-9]+$": {"type": "string"},
 	# }
 }
-
-FORM_ELEMENTS = [
-	"client_name",
-	"client_uri",
-	"redirect_uris",
-	"logout_uri",
-	"application_type",
-	"response_types",
-	"grant_types",
-	"token_endpoint_auth_method",
-]
 
 # TODO: Configurable templates
 CLIENT_TEMPLATES = {


### PR DESCRIPTION
### `GET /client/features`

returns a JSON object with
  - `metadata_schema` which contains the JSON schema for client registration/update, 
  - `templates` which contains metadata templates for common client types,


for example:
```json
{
	"metadata_schema": {
		"type": "object",
		"required": [
			"redirect_uris"
		],
		"additionalProperties": false,
		"properties": {
			"redirect_uris": {
				"type": "array",
				"description": "Array of Redirection URI values used by the Client."
			},
			...
		}
	},
	"templates": {
		"Public web application": {
			"application_type": "web",
			"token_endpoint_auth_method": "none",
			"grant_types": [
				"authorization_code"
			],
			"response_types": [
				"code"
			]
		},
		"Public mobile app": {
			"application_type": "native",
			"token_endpoint_auth_method": "none"
		}
	}
}
```