### PR TITLE
Resource for access to all tenants

### DIFF
--- a/seacatauth/authz/rbac/service.py
+++ b/seacatauth/authz/rbac/service.py
@@ -62,6 +62,9 @@ class RBACService(asab.Service):
 				if tenant is None:
 					# "tenant:access" must be checked against a specific tenant
 					raise TenantRequired()
+				if "authz:tenant:access" in authz["*"]:
+					# "authz:tenant:access" grants access to all tenants
+					continue
 				if tenant == "*":
 					# Soft-check: Pass if at least one tenant is accessible
 					# (Authz must contain "*" plus at least one more tenant)

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -31,7 +31,7 @@ class ResourceService(asab.Service):
 			"description": "Grants administrative rights for the tenant through which this resource is assigned.",
 		},
 		{
-			"id": "tenant:access",
+			"id": "authz:tenant:access",
 			"description": "Grants access to all tenants.",
 		},
 	]

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -30,6 +30,10 @@ class ResourceService(asab.Service):
 			"id": "authz:tenant:admin",
 			"description": "Grants administrative rights for the tenant through which this resource is assigned.",
 		},
+		{
+			"id": "tenant:access",
+			"description": "Grants access to all tenants.",
+		},
 	]
 
 

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -134,8 +134,8 @@ class RoleService(asab.Service):
 				message = "Resource 'authz:superuser' can only be assigned to global roles."
 				L.warning(message)
 				raise ValueError(message)
-			if "tenant:access" in resources_to_assign:
-				message = "Resource 'tenant:access' can only be assigned to global roles."
+			if "authz:tenant:access" in resources_to_assign:
+				message = "Resource 'authz:tenant:access' can only be assigned to global roles."
 				L.warning(message)
 				raise ValueError(message)
 

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -129,9 +129,13 @@ class RoleService(asab.Service):
 		)
 		if tenant != "*":
 			# TENANT role
-			# Resource "authz:superuser" cannot be assigned to a tenant role
+			# Resources "authz:superuser" and "tenant:access" cannot be assigned to tenant roles
 			if "authz:superuser" in resources_to_assign:
-				message = "Cannot assign resource 'authz:superuser' to a tenant role ({}).".format(role_id)
+				message = "Resource 'authz:superuser' can only be assigned to global roles."
+				L.warning(message)
+				raise ValueError(message)
+			if "tenant:access" in resources_to_assign:
+				message = "Resource 'tenant:access' can only be assigned to global roles."
 				L.warning(message)
 				raise ValueError(message)
 

--- a/seacatauth/authz/utils.py
+++ b/seacatauth/authz/utils.py
@@ -24,6 +24,8 @@ async def get_credentials_authz(credentials_id, tenant_service, role_service):
 
 	# Add tenant-specific roles and resources if tenant service is enabled
 	if tenant_service.is_enabled():
+		# TODO: ?? Add all known tenants if the user has "authz:superuser" or "authz:tenant:access" ??
+		#   Or use OIDC scope and add only tenants in scope?
 		for tenant in await tenant_service.get_tenants(credentials_id):
 			authz[tenant] = set()
 			for role in await role_service.get_roles_by_credentials(credentials_id, tenant):

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -77,6 +77,7 @@ class CredentialsService(asab.Service):
 			providers.append((provider.Order, provider))
 
 			if tenant_service is not None:
+				# TODO: TenantService should have its own config section and create the provider on its own
 				if not provider.Config.getboolean('tenants'):
 					continue
 				tenant_service.create_provider(provider_name, section)

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -250,6 +250,7 @@ class TenantService(asab.Service):
 
 
 	def is_enabled(self):
+		# TODO: Obsolete, TenantService is always enabled. Remove this method.
 		'''
 		Tenants are optional, SeaCat Auth can operate without tenant.
 		'''


### PR DESCRIPTION
Resource `authz:tenant:access` can only be assigned to a global role.

It grants access too all tenants without superuser privileges.

TODO: Consider actually adding ALL existing tenants to user's authz object if they have `authz:tenant:access` or `authz:superuser`. This would propagate it to userinfo and elsewhere. This would be temporary solution until we properly fix this with OIDC scopes.