### PR TITLE
Keep superuser role after provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - Roles have an optional "description" field (#103, PLUM Sprint 221021)
 
+### Refactoring
+- Keep superuser role after provisioning (#102, PLUM Sprint 221021)
+
 ---
 
 

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -124,6 +124,7 @@ class ProvisioningService(asab.Service):
 		except KeyError:
 			client = None
 
+		# Configure admin_ui_client as a public web application
 		update = {
 			k: v
 			for k, v in CLIENT_TEMPLATES["Public web application"].items()
@@ -152,5 +153,5 @@ class ProvisioningService(asab.Service):
 
 		if client is None:
 			await client_service.register(_custom_client_id=admin_ui_client_id, **update)
-		else:
+		elif update:
 			await client_service.update(client_id=admin_ui_client_id, **update)

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -28,7 +28,7 @@ Use the following credentials to log in:
 _PROVISIONING_CONFIG_DEFAULTS = {
 	"credentials_name": "provisioning-superuser",
 	"credentials_provider_id": "provisioning",
-	"role_name": "provisioning-superrole",
+	"role_name": "superuser",
 	"tenant": "provisioning-tenant",
 	"admin_ui_url": "",
 	"admin_ui_client_id": "seacat-admin-ui",
@@ -104,12 +104,6 @@ class ProvisioningService(asab.Service):
 		# Delete the superuser
 		# This also all its sessions and tenant+role assignments
 		await self.CredentialsService.delete_credentials(self.SuperuserID)
-
-		# Delete superuser role
-		try:
-			await self.RoleService.delete(role_id=self.SuperroleID)
-		except KeyError:
-			L.error("Failed to delete role", struct_data={"role": self.SuperroleID})
 
 		# Delete provisioning tenant with all its roles and assignments
 		tenant_provider = self.TenantService.get_provider()


### PR DESCRIPTION
Provisioning creates a role called `superuser` (by default) with `authz:superuser` resource. This role is preserved when provisioning is over.