### PR TITLE
Resource rename and delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features
 - Roles have an optional "description" field (#103, PLUM Sprint 221021)
 - User registration (invitation only) (#86, PLUM Sprint 221021)
+- Delete and rename resources (#113, PLUM Sprint 221104)
+- List roles that contain a specific resource (#113, PLUM Sprint 221104)
 
 ### Refactoring
 - Keep superuser role after provisioning (#102, PLUM Sprint 221021)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from json import JSONDecodeError
 
 import asab
 import asab.web.rest

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -4,6 +4,7 @@ from json import JSONDecodeError
 
 import asab
 import asab.web.rest
+import asab.exceptions
 
 from seacatauth.decorators import access_control
 
@@ -22,8 +23,9 @@ class ResourceHandler(object):
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/resource", self.list)
 		web_app.router.add_get("/resource/{resource_id}", self.get)
-		web_app.router.add_post("/resource/{resource_id}", self.create)
+		web_app.router.add_post("/resource/{resource_id}", self.create_or_undelete)
 		web_app.router.add_put("/resource/{resource_id}", self.update)
+		web_app.router.add_delete("/resource/{resource_id}", self.delete)
 
 	async def list(self, request):
 		page = int(request.query.get("p", 1)) - 1
@@ -46,33 +48,13 @@ class ResourceHandler(object):
 	async def get(self, request):
 		resource_id = request.match_info["resource_id"]
 		result = await self.ResourceService.get(resource_id)
+		result["result"] = "OK"
 		return asab.web.rest.json_response(
 			request, result
 		)
 
-	@access_control("authz:superuser")
-	async def create(self, request):
-		resource_id = request.match_info["resource_id"]
-
-		# Get description if present
-		try:
-			json_data = await request.json()
-			description = json_data.get("description")
-		except JSONDecodeError:
-			description = None
-
-		data = await self.ResourceService.create(resource_id, description)
-		status = 200 if data["result"] == "OK" else 400
-		return asab.web.rest.json_response(
-			request,
-			status=status,
-			data=data,
-		)
-
-
 	@asab.web.rest.json_schema_handler({
 		"type": "object",
-		"required": ["description"],
 		"additionalProperties": False,
 		"properties": {
 			"description": {
@@ -81,9 +63,40 @@ class ResourceHandler(object):
 		}
 	})
 	@access_control("authz:superuser")
+	async def create_or_undelete(self, request, *, json_data):
+		"""
+		Create a new resource or undelete a resource that has been soft-deleted
+		"""
+		resource_id = request.match_info["resource_id"]
+
+		try:
+			resource = await self.ResourceService.get(resource_id)
+			# Resource exists: can it be undeleted?
+			if resource.get("deleted") in [None, False]:
+				raise asab.exceptions.Conflict("Resource already exists.", key="_id", value=resource_id)
+			undelete = True
+		except KeyError:
+			undelete = False
+
+		if undelete:
+			await self.ResourceService.undelete(resource_id)
+		else:
+			await self.ResourceService.create(resource_id, json_data.get("description"))
+		return asab.web.rest.json_response(request, {"result": "OK"})
+
+
+	@asab.web.rest.json_schema_handler({
+		"type": "object",
+		"additionalProperties": False,
+		"properties": {
+			"name": {"type": "string"},
+			"description": {"type": "string"},
+		}
+	})
+	@access_control("authz:superuser")
 	async def update(self, request, *, json_data):
 		"""
-		Update resource description
+		Update resource name or description
 		"""
 		resource_id = request.match_info["resource_id"]
 		description = json_data["description"]
@@ -94,3 +107,15 @@ class ResourceHandler(object):
 			status=status,
 			data=data,
 		)
+
+
+	@access_control("authz:superuser")
+	async def delete(self, request):
+		"""
+		Delete a resource. The resource is soft-deleted (suspended) by default,
+		unless "hard_delete=true" is specified in query.
+		"""
+		resource_id = request.match_info["resource_id"]
+		hard_delete = request.query.get("hard_delete") == "true"
+		await self.ResourceService.delete(resource_id, hard_delete=hard_delete)
+		return asab.web.rest.json_response(request, {"result": "OK"})

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -34,13 +34,14 @@ class ResourceHandler(object):
 			limit = int(limit)
 
 		# Filter by ID.startswith()
-		query_filter = request.query.get("f", None)
-		if query_filter is not None:
-			query_filter = {
-				"_id": re.compile("^{}".format(
-					re.escape(query_filter)
-				))
-			}
+		query_filter = {}
+		if "f" in request.query:
+			query_filter["_id"] = re.compile(
+				"^{}".format(re.escape(request.query["f"])))
+
+		# Do not include soft-deleted resources unless requested
+		if request.query.get("include_deleted") != "true":
+			query_filter["deleted"] = {"$in": [None, False]}
 
 		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -96,17 +96,15 @@ class ResourceHandler(object):
 	@access_control("authz:superuser")
 	async def update(self, request, *, json_data):
 		"""
-		Update resource name or description
+		Update resource description or rename resource
 		"""
 		resource_id = request.match_info["resource_id"]
-		description = json_data["description"]
-		data = await self.ResourceService.update_description(resource_id, description)
-		status = 200 if data["result"] == "OK" else 400
-		return asab.web.rest.json_response(
-			request,
-			status=status,
-			data=data,
-		)
+		if "description" in json_data:
+			await self.ResourceService.update(resource_id, json_data["description"])
+		if "name" in json_data:
+			await self.ResourceService.rename(resource_id, json_data["name"])
+
+		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
 	@access_control("authz:superuser")

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -2,6 +2,7 @@ import logging
 import re
 
 import asab.storage.exceptions
+import asab.exceptions
 
 #
 
@@ -94,21 +95,15 @@ class ResourceService(asab.Service):
 
 	async def get(self, resource_id: str):
 		data = await self.StorageService.get(self.ResourceCollection, resource_id)
-		data["result"] = "OK"
 		return data
 
 
 	async def create(self, resource_id: str, description: str = None):
 		if self.ResourceIdRegex.match(resource_id) is None:
-			L.error("Invalid ID format", struct_data={"resource_id": resource_id})
-			return {
-				"result": "INVALID-VALUE",
-				"message":
-					"Resource ID must consist only of characters 'a-z0-9.:_-', "
-					"start with a letter, end with a letter or digit, "
-					"and be between 2 and 128 characters long.",
-			}
-
+			raise asab.exceptions.ValidationError(
+				"Resource ID must consist only of characters 'a-z0-9.:_-', "
+				"start with a letter, end with a letter or digit, "
+				"and be between 2 and 128 characters long.")
 		upsertor = self.StorageService.upsertor(self.ResourceCollection, obj_id=resource_id)
 
 		if description is not None:
@@ -116,22 +111,21 @@ class ResourceService(asab.Service):
 
 		try:
 			await upsertor.execute()
-			L.log(asab.LOG_NOTICE, "Resource created", struct_data={"resource_id": resource_id})
-		except asab.storage.exceptions.DuplicateError:
-			L.warning("Resource already exists", struct_data={"resource_id": resource_id})
-			return {
-				"result": "CONFLICT",
-				"message": "Resource already exists",
-			}
+		except asab.storage.exceptions.DuplicateError as e:
+			if e.KeyValue is not None:
+				key, value = e.KeyValue
+				raise asab.exceptions.Conflict(key=key, value=value)
+			else:
+				raise asab.exceptions.Conflict()
 
-		return {"result": "OK"}
+		L.log(asab.LOG_NOTICE, "Resource created", struct_data={"resource": resource_id})
 
 
 	async def update_description(self, resource_id: str, description: str):
 		try:
 			resource = await self.get(resource_id)
 		except KeyError:
-			L.error("Resource not found", struct_data={"resource_id": resource_id})
+			L.error("Resource not found", struct_data={"resource": resource_id})
 			return {
 				"result": "NOT-FOUND",
 				"message": "Resource '{}' not found".format(resource_id),
@@ -157,10 +151,63 @@ class ResourceService(asab.Service):
 				"description": description,
 			})
 		except KeyError:
-			L.error("Resource not found", struct_data={"resource_id": resource_id})
+			L.error("Resource not found", struct_data={"resource": resource_id})
 			return {
 				"result": "NOT-FOUND",
 				"message": "Resource '{}' not found".format(resource_id),
 			}
 
 		return {"result": "OK"}
+
+
+	async def delete(self, resource_id: str, hard_delete: bool = False):
+		if resource_id in map(lambda x: x["id"], self.BuiltinResources):
+			raise RuntimeError("System resource cannot be deleted")
+
+		resource = await self.get(resource_id)
+
+		# Remove the resource from all roles
+		role_svc = self.App.get_service("seacatauth.RoleService")
+		roles = await role_svc.list(resource=resource_id)
+		if roles["count"] > 0:
+			for role in roles["data"]:
+				await role_svc.update(role["_id"], resources_to_remove=[resource_id])
+			L.log(asab.LOG_NOTICE, "Resource unassigned", struct_data={
+				"resource": resource_id,
+				"n_roles": roles["count"],
+			})
+
+		if hard_delete:
+			await self.StorageService.delete(self.ResourceCollection, resource_id)
+			L.warning("Resource deleted", struct_data={
+				"resource": resource_id,
+			})
+		else:
+			upsertor = self.StorageService.upsertor(
+				self.ResourceCollection,
+				obj_id=resource_id,
+				version=resource["_v"]
+			)
+			upsertor.set("deleted", True)
+			await upsertor.execute()
+			L.log(asab.LOG_NOTICE, "Resource soft-deleted", struct_data={
+				"resource": resource_id,
+			})
+
+
+	async def undelete(self, resource_id: str):
+		resource = await self.get(resource_id)
+		if resource.get("deleted") not in [None, False]:
+			raise asab.exceptions.Conflict("Cannot undelete a resource that has not been soft-deleted.")
+
+		upsertor = self.StorageService.upsertor(
+			self.ResourceCollection,
+			obj_id=resource_id,
+			version=resource["_v"]
+		)
+		upsertor.unset("deleted")
+		await upsertor.execute()
+		L.log(asab.LOG_NOTICE, "Resource undeleted", struct_data={
+			"resource": resource_id,
+		})
+

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -219,4 +219,3 @@ class ResourceService(asab.Service):
 			"new_resource": resource_id,
 			"n_roles": roles["count"],
 		})
-

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -177,7 +177,7 @@ class ResourceService(asab.Service):
 
 	async def undelete(self, resource_id: str):
 		resource = await self.get(resource_id)
-		if resource.get("deleted") not in [None, False]:
+		if resource.get("deleted") is not True:
 			raise asab.exceptions.Conflict("Cannot undelete a resource that has not been soft-deleted.")
 
 		upsertor = self.StorageService.upsertor(

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -29,21 +29,16 @@ class RoleHandler(object):
 		web_app.router.add_delete("/role/{tenant}/{role_name}", self.delete)
 		web_app.router.add_put("/role/{tenant}/{role_name}", self.update)
 
+
 	@access_control("authz:superuser")
 	async def list_all(self, request):
-		page = int(request.query.get('p', 1)) - 1
-		limit = request.query.get('i', None)
-		if limit is not None:
-			limit = int(limit)
-		resource = request.query.get("resource")
-
-		result = await self.RoleService.list(None, page, limit, resource=resource)
-		return asab.web.rest.json_response(
-			request, result
-		)
+		return await self._list(request, tenant=None)
 
 	@access_control()
 	async def list(self, request, *, tenant):
+		return await self._list(request, tenant=tenant)
+
+	async def _list(self, request, *, tenant):
 		page = int(request.query.get("p", 1)) - 1
 		limit = request.query.get("i")
 		if limit is not None:
@@ -52,6 +47,7 @@ class RoleHandler(object):
 
 		result = await self.RoleService.list(tenant, page, limit, resource=resource)
 		return asab.web.rest.json_response(request, result)
+
 
 	@access_control()
 	async def get(self, request, *, tenant):
@@ -69,6 +65,7 @@ class RoleHandler(object):
 			request, result
 		)
 
+
 	@access_control("authz:tenant:admin")
 	async def create(self, request, *, tenant):
 		role_name = request.match_info["role_name"]
@@ -78,6 +75,7 @@ class RoleHandler(object):
 			request, result,
 			status=200 if result == "OK" else 400
 		)
+
 
 	@access_control("authz:tenant:admin")
 	async def delete(self, request, *, tenant):
@@ -95,6 +93,7 @@ class RoleHandler(object):
 		return asab.web.rest.json_response(
 			request, result
 		)
+
 
 	@asab.web.rest.json_schema_handler({
 		"type": "object",

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -35,20 +35,22 @@ class RoleHandler(object):
 		limit = request.query.get('i', None)
 		if limit is not None:
 			limit = int(limit)
+		resource = request.query.get("resource")
 
-		result = await self.RoleService.list(None, page, limit)
+		result = await self.RoleService.list(None, page, limit, resource=resource)
 		return asab.web.rest.json_response(
 			request, result
 		)
 
 	@access_control()
 	async def list(self, request, *, tenant):
-		page = int(request.query.get('p', 1)) - 1
-		limit = request.query.get('i', None)
+		page = int(request.query.get("p", 1)) - 1
+		limit = request.query.get("i")
 		if limit is not None:
 			limit = int(limit)
+		resource = request.query.get("resource")
 
-		result = await self.RoleService.list(tenant, page, limit)
+		result = await self.RoleService.list(tenant, page, limit, resource=resource)
 		return asab.web.rest.json_response(request, result)
 
 	@access_control()

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -38,12 +38,14 @@ class RoleService(asab.Service):
 			role=self.RoleNamePattern
 		))
 
-	async def list(self, tenant: Optional[str] = None, page: int = 0, limit: int = None):
+	async def list(self, tenant: Optional[str] = None, page: int = 0, limit: int = None, *, resource: str = None):
 		collection = self.StorageService.Database[self.RoleCollection]
+		query_filter = {}
 		if tenant is not None:
-			query_filter = {"tenant": {"$in": [tenant, None]}}
-		else:
-			query_filter = {}
+			query_filter["tenant"] = {"$in": [tenant, None]}
+		if resource is not None:
+			query_filter["resources"] = resource
+
 		cursor = collection.find(query_filter)
 
 		cursor.sort("_c", -1)

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -38,13 +38,19 @@ class RoleService(asab.Service):
 			role=self.RoleNamePattern
 		))
 
-	async def list(self, tenant: Optional[str] = None, page: int = 0, limit: int = None, *, resource: str = None):
+	async def list(
+		self, tenant: Optional[str] = None, page: int = 0, limit: int = None, *,
+		resource: str = None,
+		active_only: bool = False,
+	):
 		collection = self.StorageService.Database[self.RoleCollection]
 		query_filter = {}
 		if tenant is not None:
 			query_filter["tenant"] = {"$in": [tenant, None]}
 		if resource is not None:
 			query_filter["resources"] = resource
+		if active_only is True:
+			query_filter["deleted"] = {"$in": [False, None]}
 
 		cursor = collection.find(query_filter)
 
@@ -160,8 +166,10 @@ class RoleService(asab.Service):
 			resources_to_set = set(resources_to_set)
 			for res_id in resources_to_set:
 				try:
-					await self.ResourceService.get(res_id)
+					resource = await self.ResourceService.get(res_id)
 				except KeyError:
+					raise KeyError(res_id)
+				if resource.get("deleted") is True:
 					raise KeyError(res_id)
 
 		if resources_to_add is not None:


### PR DESCRIPTION
Closes #99 
Closes #100 

Introduce endpoints for renaming and deleting resources. 

**Known limitations:** Deleted resources may still be present in existing sessions and ID tokens.

# Soft-delete (suspend) resource

Resource is marked as deleted, but stays in the database. It is also unassigned from all roles.
```
DELETE /resource/<resource_name>
```

# Undelete resource

Same endpoint as creating a new resource.
```
POST /resource/<resource_name>
{}
```

# Hard-delete resource

Resource is actually deleted from the database. It is also unassigned from all roles.
```
DELETE /resource/<resource_name>?hard_delete=true
```


# Rename resource

A shorthand for creating a new resource and deleting the old one.
```
PUT /resource/<old_resource_name>
{
  "name": "<new_resource_name>"
}
```

# List roles with a specific resource

Tenant roles + global roles
```
GET /role/<tenant>?resource=<resource_name>
```

All roles (superuser only)
```
GET /role?resource=<resource_name>
```

# Other changes

- Soft-deleted resources are excluded from the resource list (`GET /resource`) by default. Add query parameter `include_deleted=true` to include them.