### PR TITLE
Include session ID and parent session ID in userinfo and ID token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 ### Breaking changes
 - Endpoint for updating custom tenant data changed (#98, PLUM Sprint 221104)
 
+### Fix
+- Logout with ID token (#116, PLUM Sprint 221104)
+
 ### Features
 - Roles have an optional "description" field (#103, PLUM Sprint 221021)
 - User registration (invitation only) (#86, PLUM Sprint 221021)
+- Include session ID and parent session ID in ID token (#116, PLUM Sprint 221104)
 
 ### Refactoring
 - Keep superuser role after provisioning (#102, PLUM Sprint 221021)

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -48,7 +48,7 @@ def private_auth_middleware_factory(app):
 		token_value = get_bearer_token_value(request)
 		if token_value is not None:
 			try:
-				request.Session = oidc_service.build_session_from_id_token(token_value)
+				request.Session = await oidc_service.build_session_from_id_token(token_value)
 			except ValueError:
 				# If the token cannot be parsed as ID token, it may be an Access token
 				if _allow_access_token_auth:
@@ -117,7 +117,7 @@ def public_auth_middleware_factory(app):
 		token_value = get_bearer_token_value(request)
 		if token_value is not None:
 			try:
-				request.Session = oidc_service.build_session_from_id_token(token_value)
+				request.Session = await oidc_service.build_session_from_id_token(token_value)
 			except ValueError:
 				# If the token cannot be parsed as ID token, it may be an Access token
 				# OIDC endpoints allow authorization via Access token

--- a/seacatauth/openidconnect/handler/session.py
+++ b/seacatauth/openidconnect/handler/session.py
@@ -35,15 +35,15 @@ class SessionHandler(object):
 			return aiohttp.web.HTTPBadRequest()
 
 		try:
-			session = self.OpenIdConnectService.build_session_from_id_token(token_value)
+			session = await self.OpenIdConnectService.build_session_from_id_token(token_value)
 		except ValueError:
 			session = await self.OpenIdConnectService.get_session_by_access_token(token_value)
 		if session is None:
 			return aiohttp.web.HTTPNotFound()
 
-		if session.Session.ParentId is not None:
+		if session.Session.ParentSessionId is not None:
 			try:
-				parent_session = await self.SessionService.get(session.Session.ParentId)
+				parent_session = await self.SessionService.get(session.Session.ParentSessionId)
 			except KeyError:
 				parent_session = None
 		else:
@@ -56,7 +56,7 @@ class SessionHandler(object):
 			# Back compat: This can occur with old sessions
 			L.warning("OIDC session has no parent session", struct_data={
 				"sid": session.Session.Id,
-				"parent_sid": session.Session.ParentId,
+				"parent_sid": session.Session.ParentSessionId,
 			})
 			await self.SessionService.delete(session.Session.Id)
 

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -192,7 +192,7 @@ class OpenIdConnectService(asab.Service):
 		return session
 
 
-	def build_session_from_id_token(self, token_value):
+	async def build_session_from_id_token(self, token_value):
 		try:
 			token = jwcrypto.jwt.JWT(jwt=token_value, key=self.PrivateKey)
 		except jwcrypto.jwt.JWTExpired:
@@ -204,14 +204,18 @@ class OpenIdConnectService(asab.Service):
 
 		try:
 			data_dict = json.loads(token.claims)
+			session_id = data_dict["sid"]
 		except ValueError:
 			L.warning("Cannot read ID token claims")
 			return None
+		except KeyError:
+			L.warning("ID token claims do not contain 'sid'")
+			return None
 
 		try:
-			session = SessionAdapter.from_id_token(self.SessionService, data_dict)
+			session = await self.SessionService.get(session_id)
 		except ValueError:
-			L.warning("Cannot build session from ID token data")
+			L.warning("Session not found")
 			return None
 
 		return session

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -266,7 +266,11 @@ class OpenIdConnectService(asab.Service):
 			"sub": session.Credentials.Id,  # The sub (subject) Claim MUST always be returned in the UserInfo Response.
 			"exp": session.Session.Expiration,
 			"iat": datetime.datetime.now(datetime.timezone.utc),
+			"sid": session.SessionId,
 		}
+
+		if session.Session.ParentSessionId is not None:
+			userinfo["psid"] = session.Session.ParentSessionId
 
 		if session.OAuth2.ClientId is not None:
 			# aud indicates who is allowed to consume the token

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -158,7 +158,8 @@ class SessionAdapter:
 	@classmethod
 	def from_id_token(cls, session_svc, id_token_dict):
 		session_dict = {
-			cls.FN.SessionId: None,
+			cls.FN.SessionId: id_token_dict.get("sid"),
+			cls.FN.Session.ParentSessionId: id_token_dict.get("psid"),
 			cls.FN.Session.Type: "openidconnect",
 			cls.FN.Version: None,
 			cls.FN.CreatedAt: id_token_dict.get("iat"),  # TODO: strptime

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -155,25 +155,6 @@ class SessionAdapter:
 		else:
 			self.Data = None
 
-	@classmethod
-	def from_id_token(cls, session_svc, id_token_dict):
-		session_dict = {
-			cls.FN.SessionId: id_token_dict.get("sid"),
-			cls.FN.Session.ParentSessionId: id_token_dict.get("psid"),
-			cls.FN.Session.Type: "openidconnect",
-			cls.FN.Version: None,
-			cls.FN.CreatedAt: id_token_dict.get("iat"),  # TODO: strptime
-			cls.FN.ModifiedAt: None,
-			cls.FN.Session.Expiration: id_token_dict.get("exp"),  # TODO: strptime
-			cls.FN.Credentials.Id: id_token_dict.get("sub"),
-			cls.FN.Credentials.Username: id_token_dict.get("preferred_username"),
-			cls.FN.Credentials.Email: id_token_dict.get("email"),
-			cls.FN.Credentials.Phone: id_token_dict.get("phone_number"),
-			cls.FN.Credentials.CustomData: id_token_dict.get("custom"),
-			cls.FN.Authorization.Authz: id_token_dict.get("authz") or id_token_dict.get("resources"),
-			cls.FN.Authorization.Tenants: id_token_dict.get("tenants"),
-		}
-		return cls(session_svc, session_dict)
 
 	def __repr__(self):
 		return ("<{} {} t:{} c:{} m:{} exp:{} cid:{} ({}{})>".format(

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -17,7 +17,7 @@ class SessionData:
 	CreatedAt: datetime.datetime
 	ModifiedAt: datetime.datetime
 	Version: int
-	ParentId: typing.Optional[str]
+	ParentSessionId: typing.Optional[str]
 	Type: typing.Optional[str]
 	Expiration: datetime.datetime
 	MaxExpiration: datetime.datetime
@@ -195,7 +195,7 @@ class SessionAdapter:
 			self.FN.ModifiedAt: self.Session.ModifiedAt,
 			self.FN.Version: self.Session.Version,
 			self.FN.Session.Type: self.Session.Type,
-			self.FN.Session.ParentSessionId: self.Session.ParentId,
+			self.FN.Session.ParentSessionId: self.Session.ParentSessionId,
 			self.FN.Session.Expiration: self.Session.Expiration,
 			self.FN.Session.MaxExpiration: self.Session.MaxExpiration,
 			self.FN.Session.ExpirationExtension: self.Session.ExpirationExtension,
@@ -273,7 +273,7 @@ class SessionAdapter:
 			CreatedAt=session_dict.pop(cls.FN.CreatedAt),
 			ModifiedAt=session_dict.pop(cls.FN.ModifiedAt),
 			Type=session_dict.pop(cls.FN.Session.Type, None),
-			ParentId=session_dict.pop(cls.FN.Session.ParentSessionId, None),
+			ParentSessionId=session_dict.pop(cls.FN.Session.ParentSessionId, None),
 			Expiration=session_dict.pop(cls.FN.Session.Expiration, None),
 			MaxExpiration=session_dict.pop(cls.FN.Session.MaxExpiration, None),
 			ExpirationExtension=session_dict.pop(cls.FN.Session.ExpirationExtension, None),

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -328,8 +328,8 @@ class SessionService(asab.Service):
 		Return the updated session object.
 		"""
 		# Get parent session
-		if session.Session.ParentId is not None:
-			session = await self.get(bson.ObjectId(session.Session.ParentId))
+		if session.Session.ParentSessionId is not None:
+			session = await self.get(bson.ObjectId(session.Session.ParentSessionId))
 
 		if datetime.datetime.now(datetime.timezone.utc) < session.Session.ModifiedAt + self.MinimalRefreshInterval:
 			# Session has been extended recently


### PR DESCRIPTION
Fixes #114

ID token and userinfo now contain two new fields:
- `sid`: ID of the client session
- `psid`: ID of the parent session

Session object can no longer be constructed from ID token data; it must be always fetched from the database.