### PR TITLE
Unset phone or email by updating it with null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 - Endpoint for updating custom tenant data changed (#98, PLUM Sprint 221104)
+- Unset credential phone/email by setting it to null instead of empty string (#117, PLUM Sprint 221104)
 
 ### Features
 - Roles have an optional "description" field (#103, PLUM Sprint 221021)
@@ -12,6 +13,7 @@
 ### Refactoring
 - Keep superuser role after provisioning (#102, PLUM Sprint 221021)
 - Endpoint for updating custom tenant data changed (#98, PLUM Sprint 221104)
+- Unset credential phone/email by setting it to null instead of empty string (#117, PLUM Sprint 221104)
 
 ---
 

--- a/seacatauth/credentials/schemas.py
+++ b/seacatauth/credentials/schemas.py
@@ -10,19 +10,17 @@ _FIELDS = {
 		"description": "Username",
 	},
 	"email": {
-		"type": "string",
 		"description": "Email address",
 		"anyOf": [
-			{"format": "email"},
-			{"const": ""},
+			{"type": "null"},
+			{"type": "string", "format": "email"},
 		],
 	},
 	"phone": {
-		"type": "string",
 		"description": "Mobile number",
 		"anyOf": [
-			{"pattern": r"^\+?[0-9 ]+$"},
-			{"const": ""},
+			{"type": "null"},
+			{"type": "string", "pattern": r"^\+?[0-9 ]+$"},
 		],
 	},
 	"data": {

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -413,16 +413,16 @@ class CredentialsService(asab.Service):
 			raise asab.exceptions.ValidationError(
 				"Cannot unsuspend credential whose registration has not been completed.")
 
-		if "email" in update_dict and update_dict["email"] == "":
-			email_specified = False
-		elif "email" not in current_dict or current_dict["email"] == "":
+		if "email" in update_dict:
+			email_specified = update_dict["email"] is not None
+		elif "email" not in current_dict or current_dict["email"] is None:
 			email_specified = False
 		else:
 			email_specified = True
 
-		if "phone" in update_dict and update_dict["phone"] == "":
-			phone_specified = False
-		elif "phone" not in current_dict or current_dict["phone"] == "":
+		if "phone" in update_dict:
+			phone_specified = update_dict["phone"] is not None
+		elif "phone" not in current_dict or current_dict["phone"] is None:
 			phone_specified = False
 		else:
 			phone_specified = True


### PR DESCRIPTION
To unset phone or email, send 
```
PUT /credentials/<credential_id>
{<attribute>: null}
```
**`BREAKING`** Empty string is not an accepted value anymore.

## Further changes

Fixed email/phone validation policy.