### PR TITLE
Hotfix authorize response when cookie is in scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Release candidate
+
+# Fix
+- Remove set_cookie from authorize response (#125, PLUM Sprint 221202)
+
+---
+
+
 ## v22.48
 
 ### Breaking changes

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -458,9 +458,6 @@ class AuthorizeHandler(object):
 			text="""<!doctype html>\n<html lang="en">\n<head></head><body>...</body>\n</html>\n"""
 		)
 
-		if 'cookie' in scope:
-			set_cookie(self.App, response, session)
-
 		return response
 
 
@@ -575,9 +572,6 @@ class AuthorizeHandler(object):
 			content_type="text/html",
 			text="""<!doctype html>\n<html lang="en">\n<head></head><body>...</body>\n</html>\n"""
 		)
-
-		if "cookie" in scope:
-			set_cookie(self.App, response, session)
 
 		return response
 

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -7,7 +7,7 @@ import aiohttp.web
 import asab
 
 from ...audit import AuditCode
-from ...cookie.utils import set_cookie, delete_cookie
+from ...cookie.utils import delete_cookie
 from ...client import exceptions
 
 #


### PR DESCRIPTION
# Issue
- `/openidconnect/authorize` with `cookie` in `scope` is requested
- client session is created without SCI
- `reply_with_successful_response` fails because it involves setting a cookie which does not exist in the session

# Hotfix
- remove the set_cookie directive (the cookie has already been set anyway; otherwise the authorize call would have failed right at the start)

# Proper solution
-  (to be implemented in #127)
- SCI is added to client sessions with `cookie` in scope
- cookie introspection locates session by the combination of SCI and client_id which should be unique