### PR TITLE
Attempts to access a nonexistent tenant should result in HTTP 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # Fix
 - Remove set_cookie from authorize response (#125, PLUM Sprint 221202)
+- Attempts to access a nonexistent tenant result in 403 (#133, PLUM Sprint 221216)
 
 ### Features
 - Client registration allows custom client ID (#128, PLUM Sprint 221202)

--- a/seacatauth/decorators.py
+++ b/seacatauth/decorators.py
@@ -143,8 +143,9 @@ def _authorize_tenant(request):
 		available_resources = available_resources.union(request.Session.Authorization.Authz.get(requested_tenant))
 	elif "authz:superuser" in available_resources:
 		# Bypassing tenant-access check as superuser
-		# No resources to add
-		pass
+		# Only check if tenant exists
+		# TODO: How to get tenant service here?
+		await tenant_service.get_tenant(requested_tenant)
 	else:
 		# Tenant access denied
 		L.warning("Unauthorized access", struct_data={

--- a/seacatauth/decorators.py
+++ b/seacatauth/decorators.py
@@ -94,7 +94,7 @@ def access_control(resource=None):
 			# Use the session object to extend the request with credentials_id, requested tenant and set of resources.
 			# If no tenant is present in the request, the request is considered global (i.e. `request.Tenant = "*"`)
 			# and tenant access authorization always passes.
-			request = _authorize_tenant(request)
+			request = await _authorize_tenant(request)
 
 			# 3) Authorize resource
 			# (if the decorator specifies a required `resource`)
@@ -123,7 +123,7 @@ def access_control(resource=None):
 	return decorator
 
 
-def _authorize_tenant(request):
+async def _authorize_tenant(request):
 	"""
 	Extract and authorize the requested tenant
 	If there's no tenant in the request or if the tenant is "*", no tenant-authorization happens


### PR DESCRIPTION
The `access_control` decorator raises `HTTP 403 Forbidden` when any user tries to access a nonexistent tenant.