### PR TITLE
Add all assigned tenants to M2M session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Cookie-based client sessions can now authorize for a specific scope and tenant (#137, PLUM Sprint 230113)
 - Standardized error codes in authorize response (#137, PLUM Sprint 230113)
 - OIDC-standardized scope values (#143, PLUM Sprint 230113)
+- M2M sessions are now authorized for all the assigned tenants (#141, PLUM Sprint 230113)
 
 ### Refactoring
 - Cookie introspection for anonymous access is moved to a separate endpoint (#124, PLUM Sprint 221216)

--- a/seacatauth/authz/rbac/service.py
+++ b/seacatauth/authz/rbac/service.py
@@ -26,6 +26,14 @@ class RBACService(asab.Service):
 		return "authz:superuser" in global_resources
 
 	@staticmethod
+	def can_access_all_tenants(authz: dict):
+		global_resources = set(
+			resource
+			for resource in authz["*"]
+		)
+		return "authz:superuser" in global_resources or "authz:tenant:access" in global_resources
+
+	@staticmethod
 	def has_resource_access(authz: dict, tenant: typing.Union[str, None], requested_resources: list):
 		# Superuser passes without further checks
 		if RBACService.is_superuser(authz):


### PR DESCRIPTION
M2M sessions now have `tenant:*` in scope, which authorizes the session for all the assigned tenants.