### PR TITLE
Fix the handling of default registration expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # Fix
 - Remove set_cookie from authorize response (#125, PLUM Sprint 221202)
 - Attempts to access a nonexistent tenant result in 403 (#133, #138, PLUM Sprint 221216)
+- Fixed default registration expiration (#142, PLUM Sprint 230113)
 
 ### Features
 - Client registration allows custom client ID (#128, PLUM Sprint 221202)

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -78,6 +78,8 @@ class RegistrationHandler(object):
 		expiration = json_data.get("expiration")
 		if isinstance(expiration, str):
 			expiration = asab.utils.convert_to_seconds(expiration)
+		else:
+			expiration = self.RegistrationService.RegistrationExpiration
 
 		credential_data = json_data["credentials"]
 

--- a/seacatauth/credentials/registration/service.py
+++ b/seacatauth/credentials/registration/service.py
@@ -139,6 +139,8 @@ class RegistrationService(asab.Service):
 			if key in ["_id", "email", "phone", "username"]
 		}
 
+		credentials_public["expires_at"] = credentials["__registration"]["exp"]
+
 		tenants = await self.TenantService.get_tenants(credentials["_id"])
 		if tenants is not None:
 			credentials_public["tenants"] = tenants


### PR DESCRIPTION
- Invitations without `expiration` now fall back to default expiration without error.
- Expiration date `expires_at` is now included in the `GET /registration/<code>` response