### PR TITLE
Use OIDC-standard scope values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Login with external OAuth2 (Facebook) (#129, PLUM Sprint 221216)
 - Cookie-based client sessions can now authorize for a specific scope and tenant (#137, PLUM Sprint 230113)
 - Standardized error codes in authorize response (#137, PLUM Sprint 230113)
+- OIDC-standardized scope values (#143, PLUM Sprint 230113)
 
 ### Refactoring
 - Cookie introspection for anonymous access is moved to a separate endpoint (#124, PLUM Sprint 221216)

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -301,7 +301,7 @@ class AuthenticationService(asab.Service):
 
 	async def login(self, login_session, from_info: list = None):
 		# TODO: Move this to LoginService
-		scope = frozenset(["userinfo:*"])
+		scope = frozenset(["profile", "email", "phone"])
 
 		ext_login_svc = self.App.get_service("seacatauth.ExternalLoginService")
 		session_builders = [
@@ -362,7 +362,7 @@ class AuthenticationService(asab.Service):
 		"""
 		# TODO: Get tenant, scope and other necessary OIDC info from credentials
 		tenants = None
-		scope = frozenset(["userinfo:*"])
+		scope = frozenset(["profile", "email", "phone"])
 
 		session_builders = [
 			await credentials_session_builder(self.CredentialsService, credentials_id, scope),

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -146,7 +146,7 @@ class CookieHandler(object):
 
 		# TODO: Where to get the tenants from?
 		tenants = None
-		scope = frozenset(["userinfo:*"])
+		scope = frozenset(["profile", "email", "phone"])
 
 		# TODO: Choose builders based on scope
 		session_builders = [

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -210,7 +210,7 @@ class CookieService(asab.Service):
 			(SessionAdapter.FN.Cookie.Domain, cookie_domain),
 		])
 
-		if "userinfo:authn" in scope or "userinfo:*" in scope:
+		if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
 			session_builders.append([
 				(SessionAdapter.FN.Authentication.LoginDescriptor, root_session.Authentication.LoginDescriptor),
 				(SessionAdapter.FN.Authentication.ExternalLoginOptions, root_session.Authentication.ExternalLoginOptions),

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -250,7 +250,7 @@ class OpenIdConnectService(asab.Service):
 			)
 		]
 
-		if "userinfo:authn" in scope or "userinfo:*" in scope:
+		if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
 			authn_service = self.App.get_service("seacatauth.AuthenticationService")
 			session_builders.append(login_descriptor_session_builder(root_session.Authentication.LoginDescriptor))
 			session_builders.append(await external_login_session_builder(ext_login_svc, root_session.Credentials.Id))

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -19,15 +19,19 @@ async def credentials_session_builder(credentials_service, credentials_id, scope
 		(SessionAdapter.FN.Credentials.CreatedAt, credentials.get("_c")),
 		(SessionAdapter.FN.Credentials.ModifiedAt, credentials.get("_m")),
 	]
-	if "userinfo:username" in scope or "userinfo:*" in scope:
+	# "profile", "email" and "phone" are scope values defined by OIDC
+	# (https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims)
+	# The values prefixed with "userinfo:" are kept for backwards compatibility
+	# TODO: Remove the "userinfo:" scope values
+	if "profile" in scope or "userinfo:username" in scope or "userinfo:*" in scope:
 		data.append((SessionAdapter.FN.Credentials.Username, credentials.get("username")))
-	if "userinfo:email" in scope or "userinfo:*" in scope:
+	if "email" in scope or "userinfo:email" in scope or "userinfo:*" in scope:
 		data.append((SessionAdapter.FN.Credentials.Email, credentials.get("email")))
-	if "userinfo:phone" in scope or "userinfo:*" in scope:
+	if "phone" in scope or "userinfo:phone" in scope or "userinfo:*" in scope:
 		data.append((SessionAdapter.FN.Credentials.Phone, credentials.get("phone")))
-	if "userinfo:data" in scope or "userinfo:*" in scope:
+	if "profile" in scope or "userinfo:data" in scope or "userinfo:*" in scope:
 		data.append((SessionAdapter.FN.Credentials.CustomData, credentials.get("data")))
-	if "userinfo:authn" in scope or "userinfo:*" in scope:
+	if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
 		data.append((SessionAdapter.FN.Authentication.TOTPSet, credentials.get("__totp") not in (None, "")))
 	return data
 


### PR DESCRIPTION
Replace current non-standard scope values with the standard defined in https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
- `email` will replace `userinfo:email`
- `phone` will replace `userinfo:phone`
- `profile` will cover all the other Claims

Instead of `scope=userinfo:*`, please use `scope=email phone profile`.

Scope values prefixed with `userinfo:*` are preserved for backwards compatibility, but will be obsoleted at some point.