### PR TITLE
Custom login URI and custom login key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install bson
         pip install pymongo
-        pip install git+https://github.com/TeskaLabs/asab#egg=asab[storage_encryption]
+        pip install git+https://github.com/TeskaLabs/asab#egg=asab[encryption]
     
     - name: Test with unittest
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Allow unsetting some client features (#148, PLUM Sprint 230113)
 - OAuth 2.0 PKCE challenge (RFC7636) (#152, PLUM Sprint 230127)
 - Session tracking ID introduced (#135, PLUM Sprint 230210)
+- Clients can register a custom login_uri and login_key (#151, PLUM Sprint 230210)
+- Authorize request adds client_id to login URL query (#151, PLUM Sprint 230210)
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -75,7 +75,8 @@ class AuthenticationHandler(object):
 			login_preferences = query_dict.get("ldid")
 
 		# Locate credentials
-		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True)
+		# TODO: Consider getting the `key` from dedicated request header
+		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True, key=key)
 		if credentials_id is None or credentials_id == []:
 			L.warning("Cannot locate credentials.", struct_data={"ident": ident})
 			# Empty credentials is used for creating a fake login session

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -80,7 +80,7 @@ class AuthenticationHandler(object):
 			# Get login key by client ID
 			client_id = query_dict.get("client_id")
 			if client_id is not None:
-				login_key = await self._get_client_login_key(client_id)
+				login_key = await self._get_client_login_key(client_id[0])
 
 		# Locate credentials
 		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True, key=login_key)

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -65,6 +65,7 @@ class AuthenticationHandler(object):
 			query_dict = urllib.parse.parse_qs(query_string)
 
 			# Get requested session expiration
+			# TODO: This option should be moved to client config or removed completely
 			expiration = query_dict.get("expiration")
 			if expiration is not None:
 				try:
@@ -72,21 +73,16 @@ class AuthenticationHandler(object):
 				except Exception as e:
 					L.warning("Error when parsing expiration: {}".format(e))
 
-			# Get requested session expiration
-			client_id = query_dict.get("client_id")
-			if client_id is not None:
-				client_service = self.AuthenticationService.App.get_service("seacatauth.ClientService")
-				try:
-					client = await client_service.get(client_id)
-					login_key = client.get("login_key")
-				except KeyError:
-					login_key = None
-
 			# Get preferred login descriptor IDs
+			# TODO: This option should be moved to client config or removed completely
 			login_preferences = query_dict.get("ldid")
 
+			# Get login key by client ID
+			client_id = query_dict.get("client_id")
+			if client_id is not None:
+				login_key = await self._get_client_login_key(client_id)
+
 		# Locate credentials
-		# TODO: Consider getting the `key` from dedicated request header
 		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True, key=login_key)
 		if credentials_id is None or credentials_id == []:
 			L.warning("Cannot locate credentials.", struct_data={"ident": ident})
@@ -139,7 +135,6 @@ class AuthenticationHandler(object):
 			'key': key.export_public(as_dict=True),
 		}
 		return asab.web.rest.json_response(request, response)
-
 
 	async def login(self, request):
 		lsid = request.match_info["lsid"]
@@ -283,7 +278,6 @@ class AuthenticationHandler(object):
 		body = {"result": "OK" if success is True else "FAILED"}
 		return aiohttp.web.Response(body=login_session.encrypt(body))
 
-
 	async def webauthn_login(self, request):
 		# Decode JSON request
 		lsid = request.match_info["lsid"]
@@ -315,3 +309,13 @@ class AuthenticationHandler(object):
 		await self.AuthenticationService.update_login_session(lsid, data=login_data)
 
 		return aiohttp.web.Response(body=login_session.encrypt(authentication_options))
+
+
+	async def _get_client_login_key(self, client_id):
+		client_service = self.AuthenticationService.App.get_service("seacatauth.ClientService")
+		try:
+			client = await client_service.get(client_id)
+			login_key = client.get("login_key")
+		except KeyError:
+			login_key = None
+		return login_key

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -125,9 +125,9 @@ CLIENT_METADATA_SCHEMA = {
 	"login_uri": {  # NON-CANONICAL
 		"type": "string",
 		"description": "URL of preferred login page."},
-	"login_data": {  # NON-CANONICAL
+	"login_key": {  # NON-CANONICAL
 		"type": "object",
-		"description": "Additional data used for locating the credentials for login."},
+		"description": "Additional data used for locating the credentials at login."},
 	"template": {  # NON-CANONICAL
 		"type": "string",
 		"description": "Client template.",
@@ -342,7 +342,7 @@ class ClientService(asab.Service):
 
 		# Optional client metadata
 		for k in frozenset([
-			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri", "login_data",
+			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri", "login_key",
 			"template"]):
 			v = kwargs.get(k)
 			if v is not None and len(v) > 0:

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -127,7 +127,13 @@ CLIENT_METADATA_SCHEMA = {
 		"description": "URL of preferred login page."},
 	"login_key": {  # NON-CANONICAL
 		"type": "object",
-		"description": "Additional data used for locating the credentials at login."},
+		"description": "Additional data used for locating the credentials at login.",
+		"patternProperties": {
+			"^[a-zA-Z][a-zA-Z0-9_-]{0,126}[a-zA-Z0-9]$": {"anyOf": [
+				{"type": "string"},
+				{"type": "number"},
+				{"type": "boolean"},
+				{"type": "null"}]}}},
 	"template": {  # NON-CANONICAL
 		"type": "string",
 		"description": "Client template.",

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -125,6 +125,9 @@ CLIENT_METADATA_SCHEMA = {
 	"login_uri": {  # NON-CANONICAL
 		"type": "string",
 		"description": "URL of preferred login page."},
+	"login_data": {  # NON-CANONICAL
+		"type": "object",
+		"description": "Additional data used for locating the credentials for login."},
 	"template": {  # NON-CANONICAL
 		"type": "string",
 		"description": "Client template.",
@@ -339,7 +342,8 @@ class ClientService(asab.Service):
 
 		# Optional client metadata
 		for k in frozenset([
-			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri", "template"]):
+			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri", "login_data",
+			"template"]):
 			v = kwargs.get(k)
 			if v is not None and len(v) > 0:
 				upsertor.set(k, v)

--- a/seacatauth/credentials/providers/abc.py
+++ b/seacatauth/credentials/providers/abc.py
@@ -41,7 +41,7 @@ class CredentialsProviderABC(asab.ConfigObject, abc.ABC):
 		}
 
 
-	async def locate(self, ident: str, ident_fields: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
 		'''
 		Locate credentials based on the vague 'ident', which could be the username, password, phone number etc.
 		Return credentials_id or return None if not found.

--- a/seacatauth/credentials/providers/dictionary.py
+++ b/seacatauth/credentials/providers/dictionary.py
@@ -108,7 +108,7 @@ class DictCredentialsProvider(EditableCredentialsProviderABC):
 		self.Dictionary.pop(credentials_id[len(prefix):])
 		return "OK"
 
-	async def locate(self, ident: str, ident_fields: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
 		# TODO: Implement ident_fields support
 		# Fast match based on the username
 		credentials_id = hashlib.sha224(ident.encode('utf-8')).hexdigest()

--- a/seacatauth/credentials/providers/elasticsearch.py
+++ b/seacatauth/credentials/providers/elasticsearch.py
@@ -108,7 +108,7 @@ class ElasticSearchCredentialsProvider(CredentialsProviderABC):
 		return obj
 
 
-	async def locate(self, ident: str, ident_fields: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
 		query = {"query": {"bool": {
 			"filter": [
 				{"match_phrase": {"type": "user"}},

--- a/seacatauth/credentials/providers/htpasswd.py
+++ b/seacatauth/credentials/providers/htpasswd.py
@@ -36,7 +36,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 		self.HT = HtpasswdFile(self.Config['path'])
 
 
-	async def locate(self, ident: str, ident_fields: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
 		# TODO: Implement ident_fields support
 		'''
 		Locate search for the exact match of provided ident and the username in the htpasswd file

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -301,7 +301,7 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 		return None
 
 
-	async def locate(self, ident: str, ident_fields: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
 		# TODO: Implement ident_fields support
 		'''
 		Locate search for the exact match of provided ident and the username in the htpasswd file

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -208,7 +208,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 		return "OK"
 
 
-	async def locate(self, ident: str, ident_fields: dict = None) -> Optional[str]:
+	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> Optional[str]:
 		"""
 		Locate credentials by matching ident string against configured ident fields.
 		"""

--- a/seacatauth/credentials/providers/mysql.py
+++ b/seacatauth/credentials/providers/mysql.py
@@ -70,10 +70,10 @@ class MySQLCredentialsProvider(CredentialsProviderABC):
 			self.DataFields = None
 
 
-	async def locate(self, ident: str, ident_fields: dict = None) -> Optional[str]:
+	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> Optional[str]:
 		async with aiomysql.connect(**self.ConnectionParams) as connection:
 			async with connection.cursor(aiomysql.DictCursor) as cursor:
-				await cursor.execute(self.LocateQuery, {"ident": ident})
+				await cursor.execute(self.LocateQuery, dict(key))
 				result = await cursor.fetchone()
 		if result is None:
 			return None

--- a/seacatauth/credentials/providers/mysql.py
+++ b/seacatauth/credentials/providers/mysql.py
@@ -71,9 +71,12 @@ class MySQLCredentialsProvider(CredentialsProviderABC):
 
 
 	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> Optional[str]:
+		kwargs = {"ident": ident}
+		if key is not None:
+			kwargs.update(key)
 		async with aiomysql.connect(**self.ConnectionParams) as connection:
 			async with connection.cursor(aiomysql.DictCursor) as cursor:
-				await cursor.execute(self.LocateQuery, dict(key))
+				await cursor.execute(self.LocateQuery, kwargs)
 				result = await cursor.fetchone()
 		if result is None:
 			return None

--- a/seacatauth/credentials/providers/xmongodb.py
+++ b/seacatauth/credentials/providers/xmongodb.py
@@ -86,7 +86,10 @@ class XMongoDBCredentialsProvider(CredentialsProviderABC):
 
 
 	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> Optional[str]:
-		query = self._prepare_query(self.LocateQuery, dict(key))
+		kwargs = {"ident": ident}
+		if key is not None:
+			kwargs.update(key)
+		query = self._prepare_query(self.LocateQuery, kwargs)
 		cursor = self.Collection.aggregate(query)
 		result = None
 		async for obj in cursor:

--- a/seacatauth/credentials/providers/xmongodb.py
+++ b/seacatauth/credentials/providers/xmongodb.py
@@ -85,8 +85,8 @@ class XMongoDBCredentialsProvider(CredentialsProviderABC):
 		return bson.json_util.loads(bound_query)
 
 
-	async def locate(self, ident: str, ident_fields: dict = None) -> Optional[str]:
-		query = self._prepare_query(self.LocateQuery, {"ident": ident})
+	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> Optional[str]:
+		query = self._prepare_query(self.LocateQuery, dict(key))
 		cursor = self.Collection.aggregate(query)
 		result = None
 		async for obj in cursor:

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -133,13 +133,13 @@ class CredentialsService(asab.Service):
 		self.CredentialProviders[credentials_provider.ProviderID] = credentials_provider
 
 
-	async def locate(self, ident: str, stop_at_first: bool = False):
+	async def locate(self, ident: str, stop_at_first: bool = False, key: dict = None):
 		'''
 		Locate credentials based on the vague 'ident', which could be the username, password, phone number etc.
 		'''
 		ident = ident.strip()
 		credentials_ids = []
-		pending = [provider.locate(ident, self.IdentFields) for provider in self.CredentialProviders.values()]
+		pending = [provider.locate(ident, self.IdentFields, key) for provider in self.CredentialProviders.values()]
 		while len(pending) > 0:
 			done, pending = await asyncio.wait(pending)
 			for task in done:

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -137,14 +137,16 @@ async def nginx_introspection(
 	return response
 
 
-def parse_url(url: str):
+def urlparse(url: str):
 	"""
-	Parse the URL into a dictionary
+	Parse the URL into a dictionary.
+
+	Convenience wrapper around urllib.parse.urlparse().
 	"""
 	return urllib.parse.urlparse(url)._asdict()
 
 
-def unparse_url(
+def urlunparse(
 	*,
 	scheme: str = "",
 	netloc: str = "",
@@ -154,7 +156,9 @@ def unparse_url(
 	fragment: str = ""
 ):
 	"""
-	Build URL from individual components
+	Build URL from individual components.
+
+	Convenience wrapper around urllib.parse.urlunparse().
 
 	Example usage:
 	```python

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -1,6 +1,6 @@
 import random
 import logging
-
+import urllib.parse
 import aiohttp.web
 import asab
 
@@ -135,6 +135,34 @@ async def nginx_introspection(
 
 	response = aiohttp.web.HTTPOk(headers=headers)
 	return response
+
+
+def parse_url(url: str):
+	"""
+	Parses the URL into a dictionary
+	"""
+	return urllib.parse.urlparse(url)._asdict()
+
+
+def unparse_url(
+	scheme: str = "",
+	netloc: str = "",
+	path: str = "",
+	params: str = "",
+	query: str = "",
+	fragment: str = ""
+):
+	"""
+	Builds URL from individual components
+
+	Example usage:
+	```python
+	parsed = parse_url("http://local.test?option=true")
+	parsed["path"] = "/some/subpath"
+	url = unparse_url(**parsed)
+	```
+	"""
+	return urllib.parse.urlunparse((scheme, netloc, path, params, query, fragment))
 
 
 def generate_ergonomic_token(length: int):

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -145,6 +145,7 @@ def parse_url(url: str):
 
 
 def unparse_url(
+	*,
 	scheme: str = "",
 	netloc: str = "",
 	path: str = "",

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -139,7 +139,7 @@ async def nginx_introspection(
 
 def parse_url(url: str):
 	"""
-	Parses the URL into a dictionary
+	Parse the URL into a dictionary
 	"""
 	return urllib.parse.urlparse(url)._asdict()
 
@@ -153,7 +153,7 @@ def unparse_url(
 	fragment: str = ""
 ):
 	"""
-	Builds URL from individual components
+	Build URL from individual components
 
 	Example usage:
 	```python

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -677,7 +677,7 @@ class AuthorizeHandler(object):
 			# as those used by Seacat Auth, they will be overwritten
 			query.update(login_query_params)
 			parsed["query"] = urllib.parse.urlencode(query)
-			login_url = unparse_url(parsed)
+			login_url = unparse_url(**parsed)
 		else:
 			# Seacat Auth login expects the parameters to be at the end of the URL (in the fragment (hash) part)
 			# TODO: Consider using regular query parameters instead (UI refactoring needed)

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -12,6 +12,7 @@ from ... import client
 from ... import exceptions
 from ..utils import AuthErrorResponseCode
 from ..pkce import InvalidCodeChallengeMethodError
+from ...generic import parse_url, unparse_url
 
 #
 
@@ -480,11 +481,7 @@ class AuthorizeHandler(object):
 
 		login_query_params.append(("redirect_uri", authorize_redirect_uri))
 
-		login_url = "{}{}?{}".format(
-			self.AuthWebuiBaseUrl,
-			self.LoginPath,
-			urllib.parse.urlencode(login_query_params)
-		)
+		login_url = await self._build_login_uri(client_id, login_query_params)
 		response = aiohttp.web.HTTPNotFound(
 			headers={
 				"Location": login_url,
@@ -495,7 +492,6 @@ class AuthorizeHandler(object):
 		)
 		delete_cookie(self.App, response)
 		return response
-
 
 	async def reply_with_factor_setup_redirect(
 		self, session, missing_factors: list,
@@ -559,7 +555,6 @@ class AuthorizeHandler(object):
 		)
 
 		return response
-
 
 	def reply_with_authentication_error(
 		self, error: str, redirect_uri: str,
@@ -663,3 +658,33 @@ class AuthorizeHandler(object):
 			raise exceptions.AccessDeniedError(subject=session.Credentials.Id)
 
 		return tenants
+
+
+	async def _build_login_uri(self, client_id, login_query_params):
+		"""
+		Check if the client has a registered login URI. If not, use the default.
+		Extend the URI with query parameters.
+		"""
+		try:
+			client_dict = await self.OpenIdConnectService.ClientService.get(client_id)
+			client_login_uri = client_dict.get("login_uri")
+		except KeyError:
+			client_login_uri = None
+		if client_login_uri is not None:
+			parsed = parse_url(client_login_uri)
+			query = urllib.parse.parse_qs(parsed["query"])
+			# WARNING: If the client's login URI includes query parameters with the same names
+			# as those used by Seacat Auth, they will be overwritten
+			query.update(login_query_params)
+			parsed["query"] = urllib.parse.urlencode(query)
+			login_url = unparse_url(parsed)
+		else:
+			# Seacat Auth login expects the parameters to be at the end of the URL (in the fragment (hash) part)
+			# TODO: Consider using regular query parameters instead (UI refactoring needed)
+			#   so that Seacat Auth UI does not need a special approach here
+			login_url = "{}{}?{}".format(
+				self.AuthWebuiBaseUrl,
+				self.LoginPath,
+				urllib.parse.urlencode(login_query_params)
+			)
+		return login_url

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -12,7 +12,7 @@ from ... import client
 from ... import exceptions
 from ..utils import AuthErrorResponseCode
 from ..pkce import InvalidCodeChallengeMethodError
-from ...generic import parse_url, unparse_url
+from ...generic import urlparse, urlunparse
 
 #
 
@@ -672,13 +672,13 @@ class AuthorizeHandler(object):
 		except KeyError:
 			client_login_uri = None
 		if client_login_uri is not None:
-			parsed = parse_url(client_login_uri)
+			parsed = urlparse(client_login_uri)
 			query = urllib.parse.parse_qs(parsed["query"])
 			# WARNING: If the client's login URI includes query parameters with the same names
 			# as those used by Seacat Auth, they will be overwritten
 			query.update(login_query_params)
 			parsed["query"] = urllib.parse.urlencode(query)
-			login_url = unparse_url(**parsed)
+			login_url = urlunparse(**parsed)
 		else:
 			# Seacat Auth login expects the parameters to be at the end of the URL (in the fragment (hash) part)
 			# TODO: Consider using regular query parameters instead (UI refactoring needed)

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -480,6 +480,7 @@ class AuthorizeHandler(object):
 		)
 
 		login_query_params.append(("redirect_uri", authorize_redirect_uri))
+		login_query_params.append(("client_id", client_id))
 
 		login_url = await self._build_login_uri(client_id, login_query_params)
 		response = aiohttp.web.HTTPNotFound(


### PR DESCRIPTION
# Changes

- Clients can register a custom `login_uri`
- Clients can register a `login_key` object
- Authorize request adds `client_id` to login URL query
- Module `seacatauth.generic` contains two convenience functions for working with urls.

# Login URI

Clients can now register a custom `login_uri`, which will be used instead of the default if the client's authorize request requires the user to log in.

# Login key

Clients can also register a `login_key`, a dictionary (JSON object) which is used for locating credentials at login. It is passed to the `locate` methods of the Credential providers. The default MongoDB provider does not use a login key, but providers with customizable queries may be configured to use it.

The keys of `login_key` must match `^[a-zA-Z][a-zA-Z0-9_-]{0,126}[a-zA-Z0-9]$` and its values must be one of `string`, `number`, `boolean` or `null` (i.e. `array`s and `object`s are not allowed).
