### PR TITLE
OAuth 2.0 PKCE challenge (RFC7636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Features
 - Allow unsetting some client features (#148, PLUM Sprint 230113)
-- OAuth PKCE challenge support (#152, PLUM Sprint 230127)
+- OAuth 2.0 PKCE challenge (RFC7636) (#152, PLUM Sprint 230127)
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Features
 - Allow unsetting some client features (#148, PLUM Sprint 230113)
+- OAuth PKCE challenge support (#152, PLUM Sprint 230127)
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -3,7 +3,6 @@ import re
 
 import asab
 import asab.web.rest
-import asab.exceptions
 
 from seacatauth.decorators import access_control
 

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 import asab.storage.exceptions
-import asab.exceptions
+import asab
 
 #
 

--- a/seacatauth/client/__init__.py
+++ b/seacatauth/client/__init__.py
@@ -1,7 +1,9 @@
 from .handler import ClientHandler
 from .service import ClientService
+from . import exceptions
 
 __all__ = [
 	"ClientHandler",
 	"ClientService",
+	"exceptions"
 ]

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -5,7 +5,7 @@ import secrets
 import urllib.parse
 
 import asab.storage.exceptions
-import asab.exceptions
+import asab
 
 from seacatauth.client import exceptions
 

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -16,8 +16,7 @@ L = logging.getLogger(__name__)
 #
 
 # https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
-# TODO: This is not Client responsibility!
-#  Supported OAuth/OIDC param values (and their defaults) should be managed by the OpenIdConnect module.
+# TODO: Supported OAuth/OIDC param values should be managed by the OpenIdConnect module, not Client.
 GRANT_TYPES = [
 	"authorization_code",
 	# "implicit",

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -450,8 +450,10 @@ class ClientService(asab.Service):
 		if response_type not in client["response_types"]:
 			raise exceptions.ClientError(client_id=client_id, response_type=response_type)
 
-		if code_challenge_method is not None and code_challenge_method not in client["code_challenge_methods"]:
-			raise exceptions.ClientError(client_id=client_id, code_challenge_method=code_challenge_method)
+		if code_challenge_method is not None:
+			# If the client has no code_challenge_methods configured, allow only the more secure "S256" method
+			if code_challenge_method not in client.get("code_challenge_methods", ["S256"]):
+				raise exceptions.ClientError(client_id=client_id, code_challenge_method=code_challenge_method)
 
 		return True
 

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -123,7 +123,10 @@ CLIENT_METADATA_SCHEMA = {
 		"items": {
 			"type": "string",
 			"enum": ["plain", "S256"]}},
-	"template": {
+	"login_uri": {  # NON-CANONICAL
+		"type": "string",
+		"description": "URL of preferred login page."},
+	"template": {  # NON-CANONICAL
 		"type": "string",
 		"description": "Client template.",
 	}
@@ -337,7 +340,7 @@ class ClientService(asab.Service):
 
 		# Optional client metadata
 		for k in frozenset([
-			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "template"]):
+			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri", "template"]):
 			v = kwargs.get(k)
 			if v is not None and len(v) > 0:
 				upsertor.set(k, v)

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -119,10 +119,14 @@ CLIENT_METADATA_SCHEMA = {
 		"description":
 			"JSON array containing a list of the PKCE Code Challenge Methods "
 			"that the Client is declaring that it will restrict itself to using. "
-			"If omitted, the default is that the Client will use only the `S256` method.",
+			"If omitted, the client is not expected to use PKCE.",
 		"items": {
 			"type": "string",
 			"enum": ["plain", "S256"]}},
+	"template": {
+		"type": "string",
+		"description": "Client template.",
+	}
 }
 
 REGISTER_CLIENT_SCHEMA = {
@@ -333,7 +337,7 @@ class ClientService(asab.Service):
 
 		# Optional client metadata
 		for k in frozenset([
-			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data"]):
+			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "template"]):
 			v = kwargs.get(k)
 			if v is not None and len(v) > 0:
 				upsertor.set(k, v)

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -172,7 +172,6 @@ class AuthorizeHandler(object):
 				redirect_uri=redirect_uri,
 				scope=scope,
 				response_type="code",
-				code_challenge=code_challenge,
 				code_challenge_method=code_challenge_method,
 			)
 		except client.exceptions.ClientNotFoundError:

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -308,6 +308,8 @@ class AuthorizeHandler(object):
 				client_id=client_id,
 				redirect_uri=redirect_uri,
 				state=state,
+				code_challenge=code_challenge,
+				code_challenge_method=code_challenge_method,
 				login_parameters=login_parameters)
 
 		# We are authenticated!
@@ -441,6 +443,8 @@ class AuthorizeHandler(object):
 	async def reply_with_redirect_to_login(
 		self, response_type: str, scope: list, client_id: str, redirect_uri: str,
 		state: str = None,
+		code_challenge: str = None,
+		code_challenge_method: str = None,
 		login_parameters: dict = None
 	):
 		"""
@@ -462,6 +466,10 @@ class AuthorizeHandler(object):
 		]
 		if state is not None:
 			authorize_query_params.append(("state", state))
+		if code_challenge is not None:
+			authorize_query_params.append(("code_challenge", code_challenge))
+		if code_challenge_method is not None:
+			authorize_query_params.append(("code_challenge_method", code_challenge_method))
 
 		# Build the redirect URI back to this endpoint and add it to login params
 		authorize_redirect_uri = "{}{}?{}".format(

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -241,7 +241,7 @@ class AuthorizeHandler(object):
 			if root_session.Session.Type != "root":
 				L.warning("Session type must be 'root'", struct_data={"sid": root_session.Id, "type": root_session.Session.Type})
 				root_session = None
-			if root_session.Authentication.IsAnonymous:
+			elif root_session.Authentication.IsAnonymous:
 				L.warning("Cannot authorize with anonymous session", struct_data={"sid": root_session.Id})
 				root_session = None
 

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -142,6 +142,9 @@ class TokenHandler(object):
 
 
 	def _evaluate_pkce_challenge(self, code_challenge_method, code_challenge, code_verifier):
+		"""
+		https://datatracker.ietf.org/doc/html/rfc7636#section-4.6
+		"""
 		if code_verifier is None:
 			L.warning("PKCE challenge failed: code_verifier missing in request.")
 			raise InvalidGrantError()

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -1,5 +1,3 @@
-import base64
-import hashlib
 import logging
 import urllib.parse
 import datetime
@@ -111,7 +109,7 @@ class TokenHandler(object):
 				return asab.web.rest.json_response(
 					request, {"error": TokenRequestErrorResponseCode.InvalidGrant}, status=400)
 			except Exception as e:
-				L.error("Code challenge error.".format(e), exc_info=True)
+				L.error("Code challenge error: {}".format(e), exc_info=True)
 				return asab.web.rest.json_response(
 					request, {"error": TokenRequestErrorResponseCode.InvalidGrant}, status=400)
 

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -1,8 +1,8 @@
-# TODO: Restructure. This is OAuth, but not OpenID Connect!
 import base64
 import hashlib
 import re
 import logging
+import asab.exceptions
 
 #
 
@@ -23,19 +23,41 @@ class InvalidCodeChallengeMethodError(Exception):
 
 
 class PKCE:
-	CODE_VERIFIER_PATTERN = re.compile("^[A-Za-z0-9._~-]{43,128}$")
+	CodeVerifierPattern = re.compile("^[A-Za-z0-9._~-]{43,128}$")
+	SupportedCodeChallengeMethods = frozenset(["plain", "S256"])  # TODO: Configurable
+	DefaultCodeChallengeMethod = "plain"
 
 	@classmethod
-	def verify_code_challenge_method(cls, client: dict, code_challenge_method: str):
+	def validate_code_challenge_methods_registration(cls, code_challenge_methods: list):
+		"""
+		Validate whether (any) client can register the requested methods
+		"""
+		for method in code_challenge_methods:
+			if method not in cls.SupportedCodeChallengeMethods:
+				raise asab.exceptions.ValidationError(
+					"Unsupported Code Challenge Method: {!r}.".format(method))
+		if "plain" in code_challenge_methods and len(code_challenge_methods) > 1:
+			# If the client is capable of using "S256", it MUST use "S256", as
+			# "S256" is Mandatory To Implement (MTI) on the server.  Clients are
+			# permitted to use "plain" only if they cannot support "S256" for some
+			# technical reason and know via out-of-band configuration that the
+			# server supports "plain".
+			raise asab.exceptions.ValidationError(
+				"Cannot register the 'plain' Code Challenge Method together with more secure methods. "
+				"Clients are permitted to use 'plain' only if they cannot support 'S256'."
+			)
+
+	@classmethod
+	def validate_code_challenge_method(cls, client: dict, code_challenge_method: str):
+		"""
+		Validate whether the client can use the requested method in authorization
+		"""
 		if code_challenge_method is None:
 			code_challenge_method = "plain"
 
 		allowed_methods = client.get("code_challenge_methods")
 		if allowed_methods is None or len(allowed_methods) == 0:
 			# TODO: If the client has no code_challenge_methods registered, raise an error
-			# If the client is capable of using "S256", it MUST use "S256", as
-			# "S256" is Mandatory To Implement (MTI) on the server.
-			# https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
 			L.warning("Client has no 'code_challenge_methods' registered.", struct_data={"client_id": client["_id"]})
 		elif code_challenge_method not in allowed_methods:
 			raise InvalidCodeChallengeMethodError(
@@ -47,9 +69,11 @@ class PKCE:
 	@classmethod
 	def evaluate_code_challenge(cls, code_challenge_method, code_challenge, code_verifier):
 		"""
+		Evaluate whether the code challenge was successful
+
 		https://datatracker.ietf.org/doc/html/rfc7636#section-4.6
 		"""
-		if cls.CODE_VERIFIER_PATTERN.match(code_verifier) is None:
+		if cls.CodeVerifierPattern.match(code_verifier) is None:
 			raise CodeChallengeFailedError("Code Verifier does not match the required pattern (RFC7636 section 4.1).")
 	
 		if code_challenge_method == "plain":

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -81,7 +81,6 @@ class PKCE:
 
 		https://datatracker.ietf.org/doc/html/rfc7636#section-4.6
 		"""
-		L.warning(f"\n>>>{code_challenge_method=!r}, {code_challenge=!r}, {code_verifier=!r}")
 		if cls.CodeVerifierPattern.match(code_verifier) is None:
 			raise CodeChallengeFailedError("Code Verifier does not match the required pattern (RFC7636 section 4.1).")
 

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -1,0 +1,66 @@
+# TODO: Restructure. This is OAuth, but not OpenID Connect!
+import base64
+import hashlib
+import re
+import logging
+
+#
+
+L = logging.getLogger(__name__)
+
+#
+
+
+class CodeChallengeFailedError(Exception):
+	pass
+
+
+class InvalidCodeChallengeMethodError(Exception):
+	def __init__(self, client_id, code_challenge_method, *args, **kwargs):
+		self.ClientID = client_id
+		self.CodeChallengeMethod = code_challenge_method
+		super().__init__("Invalid code_challenge_method for client", *args)
+
+
+class PKCE:
+	CODE_VERIFIER_PATTERN = re.compile("^[A-Za-z0-9._~-]{43,128}$")
+
+	@classmethod
+	def verify_code_challenge_method(cls, client: dict, code_challenge_method: str):
+		if code_challenge_method is None:
+			code_challenge_method = "plain"
+
+		allowed_methods = client.get("code_challenge_methods")
+		if allowed_methods is None or len(allowed_methods) == 0:
+			# TODO: If the client has no code_challenge_methods registered, raise an error
+			# If the client is capable of using "S256", it MUST use "S256", as
+			# "S256" is Mandatory To Implement (MTI) on the server.
+			# https://datatracker.ietf.org/doc/html/rfc7636#section-4.2
+			L.warning("Client has no 'code_challenge_methods' registered.", struct_data={"client_id": client["_id"]})
+		elif code_challenge_method not in allowed_methods:
+			raise InvalidCodeChallengeMethodError(
+				client_id=client["_id"], code_challenge_method=code_challenge_method)
+		else:
+			# Method is valid for this client
+			pass
+
+	@classmethod
+	def evaluate_code_challenge(cls, code_challenge_method, code_challenge, code_verifier):
+		"""
+		https://datatracker.ietf.org/doc/html/rfc7636#section-4.6
+		"""
+		if cls.CODE_VERIFIER_PATTERN.match(code_verifier) is None:
+			raise CodeChallengeFailedError("Code Verifier does not match the required pattern (RFC7636 section 4.1).")
+	
+		if code_challenge_method == "plain":
+			request_challenge = code_verifier
+		elif code_challenge_method == "S256":
+			request_challenge = base64.urlsafe_b64encode(
+				hashlib.sha256(code_verifier.encode("ascii")).digest()).decode("ascii")
+		else:
+			raise CodeChallengeFailedError("Unsupported code_challenge_method: {!r}".format(code_challenge_method))
+	
+		if request_challenge != code_challenge:
+			raise CodeChallengeFailedError("Code Challenge does not match.")
+	
+	

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -96,5 +96,4 @@ class PKCE:
 			raise CodeChallengeFailedError("Unsupported code_challenge_method: {!r}".format(code_challenge_method))
 
 		if request_challenge != code_challenge:
-			L.warning(f"\n>>>{code_challenge_method=!r}, {code_challenge=!r}, {request_challenge=!r}")
 			raise CodeChallengeFailedError("Code Challenge does not pair with the Code Verifier.")

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -75,7 +75,7 @@ class PKCE:
 		"""
 		if cls.CodeVerifierPattern.match(code_verifier) is None:
 			raise CodeChallengeFailedError("Code Verifier does not match the required pattern (RFC7636 section 4.1).")
-	
+
 		if code_challenge_method == "plain":
 			request_challenge = code_verifier
 		elif code_challenge_method == "S256":
@@ -83,8 +83,6 @@ class PKCE:
 				hashlib.sha256(code_verifier.encode("ascii")).digest()).decode("ascii")
 		else:
 			raise CodeChallengeFailedError("Unsupported code_challenge_method: {!r}".format(code_challenge_method))
-	
+
 		if request_challenge != code_challenge:
 			raise CodeChallengeFailedError("Code Challenge does not match.")
-	
-	

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -93,4 +93,4 @@ class PKCE:
 			raise CodeChallengeFailedError("Unsupported code_challenge_method: {!r}".format(code_challenge_method))
 
 		if request_challenge != code_challenge:
-			raise CodeChallengeFailedError("Code Challenge does not match.")
+			raise CodeChallengeFailedError("Code Challenge does not pair with the Code Verifier.")

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -23,6 +23,14 @@ class InvalidCodeChallengeMethodError(Exception):
 
 
 class PKCE:
+	"""
+	Proof Key for Code Exchange
+
+	https://datatracker.ietf.org/doc/html/rfc7636
+
+	Introduces a code challenge to the OAuth 2.0 Authorization Code Flow
+	"""
+
 	CodeVerifierPattern = re.compile("^[A-Za-z0-9._~-]{43,128}$")
 	SupportedCodeChallengeMethods = frozenset(["plain", "S256"])  # TODO: Configurable
 	DefaultCodeChallengeMethod = "plain"
@@ -43,8 +51,8 @@ class PKCE:
 			# technical reason and know via out-of-band configuration that the
 			# server supports "plain".
 			raise asab.exceptions.ValidationError(
-				"Cannot register the 'plain' Code Challenge Method together with more secure methods. "
-				"Clients are permitted to use 'plain' only if they cannot support 'S256'."
+				"Cannot register the 'plain' Code Challenge Method alongside other more secure methods. "
+				"Clients are permitted to use 'plain' only if they do not support 'S256'."
 			)
 
 	@classmethod

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -237,7 +237,13 @@ class OpenIdConnectService(asab.Service):
 		raise aiohttp.web.HTTPNotImplemented()
 
 
-	async def create_oidc_session(self, root_session, client_id, scope, tenants=None, requested_expiration=None):
+	async def create_oidc_session(
+		self, root_session, client_id, scope,
+		tenants=None,
+		requested_expiration=None,
+		code_challenge: str = None,
+		code_challenge_method: str = None
+	):
 		# TODO: Choose builders based on scope
 		ext_login_svc = self.App.get_service("seacatauth.ExternalLoginService")
 		session_builders = [
@@ -249,6 +255,12 @@ class OpenIdConnectService(asab.Service):
 				tenants=tenants,
 			)
 		]
+
+		if code_challenge is not None:
+			session_builders.append((
+				(SessionAdapter.FN.OAuth2.CodeChallenge, code_challenge),
+				(SessionAdapter.FN.OAuth2.CodeChallengeMethod, code_challenge_method),
+			))
 
 		if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
 			authn_service = self.App.get_service("seacatauth.AuthenticationService")

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -25,6 +25,7 @@ from ..session import (
 from .session import oauth2_session_builder
 from ..audit import AuditCode
 from .. import exceptions
+from . import pkce
 
 #
 
@@ -52,6 +53,7 @@ class OpenIdConnectService(asab.Service):
 		self.RBACService = app.get_service("seacatauth.RBACService")
 		self.RoleService = app.get_service("seacatauth.RoleService")
 		self.AuditService = app.get_service("seacatauth.AuditService")
+		self.PKCE = pkce.PKCE()
 
 		self.BearerRealm = asab.Config.get("openidconnect", "bearer_realm")
 		self.Issuer = asab.Config.get("openidconnect", "issuer", fallback=None)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -53,7 +53,7 @@ class OpenIdConnectService(asab.Service):
 		self.RBACService = app.get_service("seacatauth.RBACService")
 		self.RoleService = app.get_service("seacatauth.RoleService")
 		self.AuditService = app.get_service("seacatauth.AuditService")
-		self.PKCE = pkce.PKCE()
+		self.PKCE = pkce.PKCE()  # TODO: Restructure. This is OAuth, but not OpenID Connect!
 
 		self.BearerRealm = asab.Config.get("openidconnect", "bearer_realm")
 		self.Issuer = asab.Config.get("openidconnect", "issuer", fallback=None)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -258,8 +258,7 @@ class OpenIdConnectService(asab.Service):
 
 		if code_challenge is not None:
 			session_builders.append((
-				(SessionAdapter.FN.OAuth2.CodeChallenge, code_challenge),
-				(SessionAdapter.FN.OAuth2.CodeChallengeMethod, code_challenge_method),
+				(SessionAdapter.FN.OAuth2.PKCE, {"challenge": code_challenge, "method": code_challenge_method}),
 			))
 
 		if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:

--- a/seacatauth/openidconnect/utils.py
+++ b/seacatauth/openidconnect/utils.py
@@ -20,3 +20,20 @@ class AuthErrorResponseCode:
 	RequestNotSupported = "request_not_supported"
 	RequestUriNotSupported = "request_uri_not_supported"
 	RegistrationNotSupported = "registration_not_supported"
+
+
+class TokenRequestErrorResponseCode:
+	# OAuth2.0 token request error response codes defined in RFC6749
+	# https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+	InvalidRequest = "invalid_request"
+	InvalidClient = "invalid_client"
+	InvalidGrant = "invalid_grant"
+	UnauthorizedClient = "unauthorized_client"
+	UnauthorizedGranttype = "unauthorized_grant_type"
+	InvalidScope = "invalid_scope"
+
+
+class InvalidGrantError(Exception):
+	def __init__(self, *args, client_id=None):
+		self.ClientId = client_id
+		super().__init__("Invalid grant.", *args)

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -58,8 +58,7 @@ class OAuth2Data:
 	IDToken: typing.Optional[str]
 	ClientId: typing.Optional[str]
 	Scope: typing.Optional[str]
-	CodeChallenge: typing.Optional[str]
-	CodeChallengeMethod: typing.Optional[str]
+	PKCE: typing.Optional[dict]
 
 
 @dataclasses.dataclass
@@ -123,8 +122,7 @@ class SessionAdapter:
 			RefreshToken = "oa_rt"
 			Scope = "oa_sc"
 			ClientId = "oa_cl"
-			CodeChallenge = "oa_cc"
-			CodeChallengeMethod = "oa_ccm"
+			PKCE = "oa_pkce"
 
 		class Cookie:
 			_prefix = "ck"
@@ -227,8 +225,7 @@ class SessionAdapter:
 				self.FN.OAuth2.RefreshToken: self.OAuth2.RefreshToken,
 				self.FN.OAuth2.ClientId: self.OAuth2.ClientId,
 				self.FN.OAuth2.Scope: self.OAuth2.Scope,
-				self.FN.OAuth2.CodeChallenge: self.OAuth2.CodeChallenge,
-				self.FN.OAuth2.CodeChallengeMethod: self.OAuth2.CodeChallengeMethod,
+				self.FN.OAuth2.PKCE: self.OAuth2.PKCE,
 			})
 
 		# TODO: encrypt sensitive fields
@@ -330,10 +327,7 @@ class SessionAdapter:
 		if refresh_token is not None:
 			refresh_token = base64.urlsafe_b64encode(refresh_token).decode("ascii")
 
-		code_challenge = session_dict.pop(cls.FN.OAuth2.CodeChallenge, None)
-		code_challenge_method = session_dict.pop(cls.FN.OAuth2.CodeChallengeMethod, None)
-		if code_challenge is not None and code_challenge_method is not None:
-			refresh_token = base64.urlsafe_b64encode(refresh_token).decode("ascii")
+		pkce = session_dict.pop(cls.FN.OAuth2.PKCE, None)
 
 		return OAuth2Data(
 			IDToken=id_token,
@@ -341,8 +335,7 @@ class SessionAdapter:
 			RefreshToken=refresh_token,
 			Scope=session_dict.pop(cls.FN.OAuth2.Scope, None) or oa2_data.pop("S", None),
 			ClientId=session_dict.pop(cls.FN.OAuth2.ClientId, None),
-			CodeChallenge=code_challenge,
-			CodeChallengeMethod=code_challenge_method,
+			PKCE=pkce,
 		)
 
 	@classmethod

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -58,6 +58,8 @@ class OAuth2Data:
 	IDToken: typing.Optional[str]
 	ClientId: typing.Optional[str]
 	Scope: typing.Optional[str]
+	CodeChallenge: typing.Optional[str]
+	CodeChallengeMethod: typing.Optional[str]
 
 
 @dataclasses.dataclass
@@ -121,6 +123,8 @@ class SessionAdapter:
 			RefreshToken = "oa_rt"
 			Scope = "oa_sc"
 			ClientId = "oa_cl"
+			CodeChallenge = "oa_cc"
+			CodeChallengeMethod = "oa_ccm"
 
 		class Cookie:
 			_prefix = "ck"
@@ -223,6 +227,8 @@ class SessionAdapter:
 				self.FN.OAuth2.RefreshToken: self.OAuth2.RefreshToken,
 				self.FN.OAuth2.ClientId: self.OAuth2.ClientId,
 				self.FN.OAuth2.Scope: self.OAuth2.Scope,
+				self.FN.OAuth2.CodeChallenge: self.OAuth2.CodeChallenge,
+				self.FN.OAuth2.CodeChallengeMethod: self.OAuth2.CodeChallengeMethod,
 			})
 
 		# TODO: encrypt sensitive fields
@@ -324,12 +330,19 @@ class SessionAdapter:
 		if refresh_token is not None:
 			refresh_token = base64.urlsafe_b64encode(refresh_token).decode("ascii")
 
+		code_challenge = session_dict.pop(cls.FN.OAuth2.CodeChallenge, None)
+		code_challenge_method = session_dict.pop(cls.FN.OAuth2.CodeChallengeMethod, None)
+		if code_challenge is not None and code_challenge_method is not None:
+			refresh_token = base64.urlsafe_b64encode(refresh_token).decode("ascii")
+
 		return OAuth2Data(
 			IDToken=id_token,
 			AccessToken=access_token,
 			RefreshToken=refresh_token,
 			Scope=session_dict.pop(cls.FN.OAuth2.Scope, None) or oa2_data.pop("S", None),
 			ClientId=session_dict.pop(cls.FN.OAuth2.ClientId, None),
+			CodeChallenge=code_challenge,
+			CodeChallengeMethod=code_challenge_method,
 		)
 
 	@classmethod


### PR DESCRIPTION
closes #139

PKCE is always enabled in Seacat Auth; it is not necessary to configure the app.

Both `plain` and `S256` code challenge methods are supported.

To be able to use PKCE with your client:
- Register your client and set its `code_challenge_methods` attribute to `["S256"]` (or `["plain"]` if SHA256 is not implemented on the client server)
- A client is allowed to register only one method at once, i.e. it is not possible to set `{"code_challenge_methods": ["S256", "plain"]}`

The PKCE code challenge works as described in [RFC7636](https://datatracker.ietf.org/doc/html/rfc7636#section-4)

