### PR TITLE
Consider Swagger docs a part of ASAB API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)
+- Swagger doc page uses the same auth rules as ASAB API (#164, PLUM Sprint 230224)
 
 ---
 

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -87,7 +87,7 @@ def private_auth_middleware_factory(app):
 				return await handler(request)
 
 		# TODO authorization should be demanded on the handler level based on @accesscontrol
-		if request.path.startswith("/asab/v1"):
+		if (request.path.startswith("/asab/v1") or request.path == "/doc") and request.method == "GET":
 			if "asab:api:auth" in asab.Config.sections():
 				if request.headers.get("Authorization") == "Bearer " + asab.Config.get("asab:api:auth", "bearer"):
 					return await handler(request)


### PR DESCRIPTION
Treat `/doc` as a part of ASAB API to make it possible for people to READ the swagger docs page easily without authenticating. All requests sent to Seacat Auth API from Swagger page will be rejected, as the API requires proper authn+authz.

Access the docs via the internal address of seacat admin API container (e.g. `http://localhost:8081/doc`) in your browser.

**NOTE:  These locations are for internal dev purposes and should not be exposed to the internet.**