### PR TITLE
Client features refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix cookie client session flow (#155, PLUM Sprint 230210)
 - Renaming resources without description (#158, PLUM Sprint 230210)
 - Batman does not add nonexistent roles to Kibana users (#159, PLUM Sprint 230210)
+- Fixed empty string check in client registration (#168, PLUM Sprint 230224)
 
 ### Features
 - Allow unsetting some client features (#148, PLUM Sprint 230113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Release candidate
 
+### Breaking changes
+- Renamed the Code Challenge Method client feature (#168, PLUM Sprint 230224)
+- Code Challenge Method is now enforced if set (#168, PLUM Sprint 230224)
+
 ### Fix
 - Removed required fields from client update (#144, PLUM Sprint 230113)
 - Store client cookie domain (#147, PLUM Sprint 230113)
@@ -18,13 +22,13 @@
 - Clients can register a custom login_uri and login_key (#151, PLUM Sprint 230210)
 - Authorize request adds client_id to login URL query (#151, PLUM Sprint 230210)
 - Upgrade Docker image OS to Alpine 3.17 (#166, PLUM Sprint 230224)
-
-### Features
-- Assign roles and tenants to multiple credentials at once (#146, PLUM Sprint 230113)
+- Assign roles and tenants to multiple credentials at once (#146, PLUM Sprint 230224)
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)
 - Swagger doc page uses the same auth rules as ASAB API (#164, PLUM Sprint 230224)
+- Renamed the Code Challenge Method client feature (#168, PLUM Sprint 230224)
+- Code Challenge Method is now enforced if set (#168, PLUM Sprint 230224)
 
 ---
 

--- a/seacatauth/client/handler.py
+++ b/seacatauth/client/handler.py
@@ -15,6 +15,13 @@ L = logging.getLogger(__name__)
 
 
 class ClientHandler(object):
+	"""
+	Client management
+
+	---
+	tags:
+	- Client management
+	"""
 	def __init__(self, app, client_svc):
 		self.ClientService = client_svc
 
@@ -30,6 +37,18 @@ class ClientHandler(object):
 
 	@access_control("authz:superuser")
 	async def list(self, request):
+		"""
+		List registered clients
+
+		---
+		query:
+		- p:
+			description: Page number
+		- i:
+			description: Items per page
+		- f:
+			description: Filter
+		"""
 		page = int(request.query.get("p", 1)) - 1
 		limit = request.query.get("i", None)
 		if limit is not None:
@@ -52,6 +71,9 @@ class ClientHandler(object):
 
 	@access_control("authz:superuser")
 	async def get(self, request):
+		"""
+		Get client by client_id
+		"""
 		client_id = request.match_info["client_id"]
 		result = self._rest_normalize(
 			await self.ClientService.get(client_id),
@@ -63,6 +85,11 @@ class ClientHandler(object):
 
 	@access_control("authz:superuser")
 	async def features(self, request):
+		"""
+		Get schema of supported client metadata
+
+		https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
+		"""
 		result = {
 			"metadata_schema": REGISTER_CLIENT_SCHEMA,
 			"templates": CLIENT_TEMPLATES,
@@ -75,6 +102,11 @@ class ClientHandler(object):
 	@asab.web.rest.json_schema_handler(REGISTER_CLIENT_SCHEMA)
 	@access_control("authz:superuser")
 	async def register(self, request, *, json_data):
+		"""
+		Register a new client
+
+		https://openid.net/specs/openid-connect-registration-1_0.html
+		"""
 		if "preferred_client_id" in json_data:
 			if not self.ClientService._AllowCustomClientID:
 				raise asab.exceptions.ValidationError("Specifying custom client_id is not allowed.")
@@ -86,6 +118,11 @@ class ClientHandler(object):
 	@asab.web.rest.json_schema_handler(UPDATE_CLIENT_SCHEMA)
 	@access_control("authz:superuser")
 	async def update(self, request, *, json_data):
+		"""
+		Edit an existing client
+
+		https://openid.net/specs/openid-connect-registration-1_0.html
+		"""
 		client_id = request.match_info["client_id"]
 		if "preferred_client_id" in json_data:
 			raise asab.exceptions.ValidationError("Cannot update attribute 'preferred_client_id'.")
@@ -98,6 +135,9 @@ class ClientHandler(object):
 
 	@access_control("authz:superuser")
 	async def reset_secret(self, request):
+		"""
+		Reset client secret
+		"""
 		client_id = request.match_info["client_id"]
 		response = await self.ClientService.reset_secret(client_id)
 		return asab.web.rest.json_response(
@@ -108,6 +148,9 @@ class ClientHandler(object):
 
 	@access_control("authz:superuser")
 	async def delete(self, request):
+		"""
+		Delete a client
+		"""
 		client_id = request.match_info["client_id"]
 		await self.ClientService.delete(client_id)
 		return asab.web.rest.json_response(

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -105,7 +105,7 @@ CLIENT_METADATA_SCHEMA = {
 		"type": "string",
 		"description":
 			"Requested Client Authentication method for the Token Endpoint. "
-			"If omitted, the default is `client_secret_basic`.",
+			"If omitted, the default is `none`.",
 		"enum": TOKEN_ENDPOINT_AUTH_METHODS},
 	# "token_endpoint_auth_signing_alg": {},
 	# "default_max_age": {},
@@ -289,6 +289,7 @@ class ClientService(asab.Service):
 		assert application_type in APPLICATION_TYPES
 
 		token_endpoint_auth_method = kwargs.get("token_endpoint_auth_method", "none")
+		# TODO: The default should be "client_secret_basic". Change this once implemented.
 		assert token_endpoint_auth_method in TOKEN_ENDPOINT_AUTH_METHODS
 
 		if _custom_client_id is not None:
@@ -312,6 +313,8 @@ class ClientService(asab.Service):
 			client_secret = None
 			client_secret_expires_at = None
 		elif token_endpoint_auth_method == "client_secret_basic":
+			raise NotImplementedError("Token endpoint auth method 'client_secret_basic' is not supported.")
+			# TODO: Finish implementing authorization with client secret
 			# The client is CONFIDENTIAL
 			# Clients capable of maintaining the confidentiality of their
 			# credentials (e.g., client implemented on a secure server with

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -113,15 +113,12 @@ CLIENT_METADATA_SCHEMA = {
 	# "default_acr_values": {},
 	# "initiate_login_uri": {},
 	# "request_uris": {},
-	"code_challenge_methods": {
-		"type": "array",
+	"code_challenge_method": {
+		"type": "string",
 		"description":
-			"JSON array containing a list of the PKCE Code Challenge Methods "
-			"that the Client is declaring that it will restrict itself to using. "
-			"If omitted, the default is that the Client will use only the `S256` method",
-		"items": {
-			"type": "string",
-			"enum": ["plain", "S256"]}},
+			"Code Challenge Method (PKCE) that the Client will be required to use at the Authorize Endpoint. "
+			"The default, if omitted, is `none`.",
+		"enum": ["none", "plain", "S256"]},
 	"login_uri": {  # NON-CANONICAL
 		"type": "string",
 		"description": "URL of preferred login page."},
@@ -344,9 +341,9 @@ class ClientService(asab.Service):
 		upsertor.set("application_type", application_type)
 
 		# Register allowed PKCE Code Challenge Methods
-		code_challenge_methods = kwargs.get("code_challenge_methods", ["S256"])
-		self.OIDCService.PKCE.validate_code_challenge_methods_registration(code_challenge_methods)
-		upsertor.set("code_challenge_methods", code_challenge_methods)
+		code_challenge_method = kwargs.get("code_challenge_method", "none")
+		self.OIDCService.PKCE.validate_code_challenge_method_registration(code_challenge_method)
+		upsertor.set("code_challenge_method", code_challenge_method)
 
 		# Optional client metadata
 		for k in frozenset([
@@ -417,8 +414,8 @@ class ClientService(asab.Service):
 		upsertor = self.StorageService.upsertor(self.ClientCollection, obj_id=client_id, version=client["_v"])
 
 		# Register allowed PKCE Code Challenge Methods
-		if "code_challenge_methods" in kwargs:
-			self.OIDCService.PKCE.validate_code_challenge_methods_registration(kwargs["code_challenge_methods"])
+		if "code_challenge_method" in kwargs:
+			self.OIDCService.PKCE.validate_code_challenge_method_registration(kwargs["code_challenge_method"])
 
 		for k, v in client_update.items():
 			if v is None or len(v) == 0:

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -344,7 +344,7 @@ class ClientService(asab.Service):
 			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri",
 			"authorize_anonymous_users", "authorize_uri"]):
 			v = kwargs.get(k)
-			if v is not None and not (isinstance(v, str) and len(v) > 0):
+			if v is not None and not (isinstance(v, str) and len(v) == 0):
 				upsertor.set(k, v)
 
 		try:

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -119,6 +119,10 @@ CLIENT_METADATA_SCHEMA = {
 			"Code Challenge Method (PKCE) that the Client will be required to use at the Authorize Endpoint. "
 			"The default, if omitted, is `none`.",
 		"enum": ["none", "plain", "S256"]},
+	"authorize_uri": {  # NON-CANONICAL
+		"type": "string",
+		"description":
+			"URL of OAuth authorize endpoint. Useful when logging in from different than the default domain."},
 	"login_uri": {  # NON-CANONICAL
 		"type": "string",
 		"description": "URL of preferred login page."},
@@ -131,7 +135,7 @@ CLIENT_METADATA_SCHEMA = {
 				{"type": "number"},
 				{"type": "boolean"},
 				{"type": "null"}]}}},
-	"template": {  # NON-CANONICAL
+	"template": {  # TODO: Remove this option
 		"type": "string",
 		"description": "Client template.",
 	}
@@ -348,7 +352,7 @@ class ClientService(asab.Service):
 		# Optional client metadata
 		for k in frozenset([
 			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri", "login_key",
-			"template"]):
+			"authorize_uri", "template"]):
 			v = kwargs.get(k)
 			if v is not None and len(v) > 0:
 				upsertor.set(k, v)

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -129,10 +129,6 @@ CLIENT_METADATA_SCHEMA = {
 	"authorize_anonymous_users": {  # NON-CANONICAL
 		"type": "boolean",
 		"description": "Allow authorize requests with anonymous users."},
-	"template": {  # TODO: Remove this option
-		"type": "string",
-		"description": "Client template.",
-	}
 }
 
 REGISTER_CLIENT_SCHEMA = {
@@ -346,7 +342,7 @@ class ClientService(asab.Service):
 		# Optional client metadata
 		for k in frozenset([
 			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri",
-			"authorize_anonymous_users", "authorize_uri", "template"]):
+			"authorize_anonymous_users", "authorize_uri"]):
 			v = kwargs.get(k)
 			if v is not None and not (isinstance(v, str) and len(v) > 0):
 				upsertor.set(k, v)

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -118,7 +118,7 @@ CLIENT_METADATA_SCHEMA = {
 		"description":
 			"JSON array containing a list of the PKCE Code Challenge Methods "
 			"that the Client is declaring that it will restrict itself to using. "
-			"If omitted, the client is not expected to use PKCE.",
+			"If omitted, the default is that the Client will use only the `S256` method",
 		"items": {
 			"type": "string",
 			"enum": ["plain", "S256"]}},
@@ -344,10 +344,9 @@ class ClientService(asab.Service):
 		upsertor.set("application_type", application_type)
 
 		# Register allowed PKCE Code Challenge Methods
-		code_challenge_methods = kwargs.get("code_challenge_methods")
-		if code_challenge_methods is not None:
-			self.OIDCService.PKCE.validate_code_challenge_methods_registration(code_challenge_methods)
-			upsertor.set("code_challenge_methods", code_challenge_methods)
+		code_challenge_methods = kwargs.get("code_challenge_methods", ["S256"])
+		self.OIDCService.PKCE.validate_code_challenge_methods_registration(code_challenge_methods)
+		upsertor.set("code_challenge_methods", code_challenge_methods)
 
 		# Optional client metadata
 		for k in frozenset([

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -201,38 +201,25 @@ class AuthorizeHandler(object):
 				state=state
 			)
 
-		if code_challenge is not None:
-			try:
-				self.OpenIdConnectService.PKCE.validate_code_challenge_initialization(client_dict, code_challenge_method)
-			except InvalidCodeChallengeMethodError:
-				L.error("Invalid code challenge method.", struct_data={
-					"client_id": client_id, "method": code_challenge_method})
-				await self.audit_authorize_error(
-					client_id, "client_error",
-					redirect_uri=redirect_uri,
-				)
-				return self.reply_with_authentication_error(
-					AuthErrorResponseCode.InvalidRequest,
-					redirect_uri=redirect_uri,
-					error_description="Client error.",
-					state=state
-				)
-			except InvalidCodeChallengeError:
-				L.error("Invalid code challenge request.", struct_data={
-					"client_id": client_id, "method": code_challenge_method, "challenge": code_challenge})
-				await self.audit_authorize_error(
-					client_id, "client_error",
-					redirect_uri=redirect_uri,
-				)
-				return self.reply_with_authentication_error(
-					AuthErrorResponseCode.InvalidRequest,
-					redirect_uri=redirect_uri,
-					error_description="Client error.",
-					state=state
-				)
-		elif code_challenge_method is not None:
-			L.warning("Requesting code_challenge_method without .", struct_data={
+		try:
+			code_challenge_method = self.OpenIdConnectService.PKCE.validate_code_challenge_initialization(
+				client_dict, code_challenge, code_challenge_method)
+		except InvalidCodeChallengeMethodError:
+			L.error("Invalid code challenge method.", struct_data={
 				"client_id": client_id, "method": code_challenge_method})
+			await self.audit_authorize_error(
+				client_id, "client_error",
+				redirect_uri=redirect_uri,
+			)
+			return self.reply_with_authentication_error(
+				AuthErrorResponseCode.InvalidRequest,
+				redirect_uri=redirect_uri,
+				error_description="Client error.",
+				state=state
+			)
+		except InvalidCodeChallengeError:
+			L.error("Invalid code challenge request.", struct_data={
+				"client_id": client_id, "method": code_challenge_method, "challenge": code_challenge})
 			await self.audit_authorize_error(
 				client_id, "client_error",
 				redirect_uri=redirect_uri,

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -50,10 +50,9 @@ class PKCE:
 			# permitted to use "plain" only if they cannot support "S256" for some
 			# technical reason and know via out-of-band configuration that the
 			# server supports "plain".
-			raise asab.exceptions.ValidationError(
-				"Cannot register the 'plain' Code Challenge Method alongside other more secure methods. "
-				"Clients are permitted to use 'plain' only if they do not support 'S256'."
-			)
+			L.warning(
+				"Registering 'plain' Code Challenge Method alongside more secure methods. "
+				"This is not recommended.")
 
 	@classmethod
 	def validate_code_challenge_method(cls, client: dict, code_challenge_method: str):

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -19,7 +19,14 @@ class InvalidCodeChallengeMethodError(Exception):
 	def __init__(self, client_id, code_challenge_method, *args, **kwargs):
 		self.ClientID = client_id
 		self.CodeChallengeMethod = code_challenge_method
-		super().__init__("Invalid code_challenge_method for client", *args)
+		super().__init__("Invalid code_challenge_method for client.", *args)
+
+
+class InvalidCodeChallengeError(Exception):
+	def __init__(self, message=None, *, client_id, **kwargs):
+		self.ClientID = client_id
+		message = message or "Code challenge request is not valid."
+		super().__init__(message)
 
 
 class PKCE:
@@ -32,46 +39,40 @@ class PKCE:
 	"""
 
 	CodeVerifierPattern = re.compile("^[A-Za-z0-9._~-]{43,128}$")
-	SupportedCodeChallengeMethods = frozenset(["plain", "S256"])  # TODO: Configurable
+	SupportedCodeChallengeMethods = frozenset(["none", "plain", "S256"])  # TODO: Configurable
 	DefaultCodeChallengeMethod = "plain"
 
 	@classmethod
-	def validate_code_challenge_methods_registration(cls, code_challenge_methods: list):
+	def validate_code_challenge_method_registration(cls, code_challenge_method: str):
 		"""
 		Validate whether (any) client can register the requested methods
 		"""
-		for method in code_challenge_methods:
-			if method not in cls.SupportedCodeChallengeMethods:
-				raise asab.exceptions.ValidationError(
-					"Unsupported Code Challenge Method: {!r}.".format(method))
-		if "plain" in code_challenge_methods and len(code_challenge_methods) > 1:
-			# If the client is capable of using "S256", it MUST use "S256", as
-			# "S256" is Mandatory To Implement (MTI) on the server.  Clients are
-			# permitted to use "plain" only if they cannot support "S256" for some
-			# technical reason and know via out-of-band configuration that the
-			# server supports "plain".
-			L.warning(
-				"Registering 'plain' Code Challenge Method alongside more secure methods. "
-				"This is not recommended.")
+		if code_challenge_method not in cls.SupportedCodeChallengeMethods:
+			raise asab.exceptions.ValidationError(
+				"Unsupported Code Challenge Method: {!r}.".format(code_challenge_method))
 
 	@classmethod
-	def validate_code_challenge_method(cls, client: dict, code_challenge_method: str):
+	def validate_code_challenge_initialization(
+		cls, client: dict, code_challenge: str = None, requested_code_challenge_method: str = None):
 		"""
 		Validate whether the client can use the requested method in authorization
 		"""
-		if code_challenge_method is None:
-			code_challenge_method = "plain"
+		if requested_code_challenge_method is None:
+			if code_challenge is None:
+				requested_code_challenge_method = "none"
+			else:
+				requested_code_challenge_method = "plain"
 
-		allowed_methods = client.get("code_challenge_methods")
-		if allowed_methods is None or len(allowed_methods) == 0:
-			# TODO: If the client has no code_challenge_methods registered, raise an error
-			L.warning("Client has no 'code_challenge_methods' registered.", struct_data={"client_id": client["_id"]})
-		elif code_challenge_method not in allowed_methods:
+		if requested_code_challenge_method == "none" and code_challenge is not None:
+			raise InvalidCodeChallengeError(
+				"Cannot request code_challenge_method without providing code_challenge.", client_id=client["_id"])
+
+		expected_method = client.get("code_challenge_method", "none")
+		if requested_code_challenge_method != expected_method:
 			raise InvalidCodeChallengeMethodError(
-				client_id=client["_id"], code_challenge_method=code_challenge_method)
-		else:
-			# Method is valid for this client
-			pass
+				client_id=client["_id"], code_challenge_method=requested_code_challenge_method)
+
+		return requested_code_challenge_method
 
 	@classmethod
 	def evaluate_code_challenge(cls, code_challenge_method, code_challenge, code_verifier):


### PR DESCRIPTION
# Changes

- **`BREAKING`** Client feature `code_challenge_methods` is replaced by `code_challenge_method`, whose value is a single string with possible values `none` (default), `plain` and `S256`. The default value `none` implies that the client will not use PKCE.
- **`BREAKING`** Client is now required to always use the Code Challenge Method they registered or to not use PKCE at all if they registered `none` as the Code Challenge Method.
- **`BREAKING`** `template` is no longer a Client feature.
- Introduced `authorize_uri` client feature. It is not used yet.
- The default `token_endpoint_auth_method` value is now `none`. (The specs prescribe `client_secret_basic` as a default but it is not supported yet by Seacat Auth.)