### PR TITLE
Get custom login data from login prologue body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@
 - Allow unsetting some client features (#148, PLUM Sprint 230113)
 - OAuth 2.0 PKCE challenge (RFC7636) (#152, PLUM Sprint 230127)
 - Session tracking ID introduced (#135, PLUM Sprint 230210)
-- Clients can register a custom login_uri and login_key (#151, PLUM Sprint 230210)
+- Clients can register a custom login_uri ~~and login_key~~ (#151, PLUM Sprint 230210)
 - Authorize request adds client_id to login URL query (#151, PLUM Sprint 230210)
 - Upgrade Docker image OS to Alpine 3.17 (#166, PLUM Sprint 230224)
 - Assign roles and tenants to multiple credentials at once (#146, PLUM Sprint 230113)
 - Allow OAuth authorize requests with anonymous sessions (#165, PLUM Sprint 230224)
+- Allow extra login parameters to be supplied in login prologue body (#169, PLUM Sprint 230310)
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -103,6 +103,10 @@ asab.Config.add_defaults({
 		"descriptor_file": "",
 		# "descriptor_file": "/conf/login-descriptors.json",
 
+		# Whitespace-separated list of field names that will be passed to the credential provider
+		# locate() method if supplied in login prologue request body `qs` parameter
+		"custom_login_parameters": "",
+
 		# Login attempts before login session is invalidated
 		"login_attempts": 10,
 

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -59,9 +59,10 @@ class AuthenticationHandler(object):
 		# Get arguments specified in login URL query
 		expiration = None
 		login_preferences = None
-		login_key = None
 		query_string = key.get("qs")
-		if query_string is not None:
+		if query_string is None:
+			query_dict = None
+		else:
 			query_dict = urllib.parse.parse_qs(query_string)
 
 			# Get requested session expiration
@@ -77,13 +78,8 @@ class AuthenticationHandler(object):
 			# TODO: This option should be moved to client config or removed completely
 			login_preferences = query_dict.get("ldid")
 
-			# Get login key by client ID
-			client_id = query_dict.get("client_id")
-			if client_id is not None:
-				login_key = await self._get_client_login_key(client_id[0])
-
 		# Locate credentials
-		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True, key=login_key)
+		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True, login_dict=query_dict)
 		if credentials_id is None or credentials_id == []:
 			L.warning("Cannot locate credentials.", struct_data={"ident": ident})
 			# Empty credentials is used for creating a fake login session

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -61,9 +61,14 @@ class AuthenticationHandler(object):
 		login_preferences = None
 		query_string = key.get("qs")
 		if query_string is None:
-			query_dict = None
+			login_dict = None
 		else:
 			query_dict = urllib.parse.parse_qs(query_string)
+
+			login_dict = {
+				k: v
+				for k, v in query_dict.items()
+				if k in self.AuthenticationService.CustomLoginParameters}
 
 			# Get requested session expiration
 			# TODO: This option should be moved to client config or removed completely
@@ -79,7 +84,7 @@ class AuthenticationHandler(object):
 			login_preferences = query_dict.get("ldid")
 
 		# Locate credentials
-		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True, login_dict=query_dict)
+		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True, login_dict=login_dict)
 		if credentials_id is None or credentials_id == []:
 			L.warning("Cannot locate credentials.", struct_data={"ident": ident})
 			# Empty credentials is used for creating a fake login session

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import re
 
 import asab
 
@@ -69,6 +70,12 @@ class AuthenticationService(asab.Service):
 		self.AuditService = app.get_service("seacatauth.AuditService")
 		self.CommunicationService = app.get_service("seacatauth.CommunicationService")
 		self.MetricsService = app.get_service("asab.MetricsService")
+
+		self.CustomLoginParameters = asab.Config.get("seacatauth:authentication", "custom_login_parameters")
+		if self.CustomLoginParameters != "":
+			self.CustomLoginParameters = frozenset(re.split(r"\s+", self.CustomLoginParameters))
+		else:
+			self.CustomLoginParameters = frozenset()
 
 		self.LoginAttempts = asab.Config.getint("seacatauth:authentication", "login_attempts")
 		self.LoginSessionExpiration = asab.Config.getseconds("seacatauth:authentication", "login_session_expiration")

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -14,6 +14,11 @@ L = logging.getLogger(__name__)
 
 
 class ResourceHandler(object):
+	"""
+	Manage resources
+	---
+	- tags: ["Resource management"]
+	"""
 	def __init__(self, app, rbac_svc):
 		self.RBACService = rbac_svc
 		self.ResourceService = app.get_service("seacatauth.ResourceService")

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -125,15 +125,6 @@ CLIENT_METADATA_SCHEMA = {
 	"login_uri": {  # NON-CANONICAL
 		"type": "string",
 		"description": "URL of preferred login page."},
-	"login_key": {  # NON-CANONICAL
-		"type": "object",
-		"description": "Additional data used for locating the credentials at login.",
-		"patternProperties": {
-			"^[a-zA-Z][a-zA-Z0-9_-]{0,126}[a-zA-Z0-9]$": {"anyOf": [
-				{"type": "string"},
-				{"type": "number"},
-				{"type": "boolean"},
-				{"type": "null"}]}}},
 	"authorize_anonymous_users": {  # NON-CANONICAL
 		"type": "boolean",
 		"description": "Allow authorize requests with anonymous users."},
@@ -351,7 +342,7 @@ class ClientService(asab.Service):
 
 		# Optional client metadata
 		for k in frozenset([
-			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri", "login_key",
+			"client_name", "client_uri", "logout_uri", "cookie_domain", "custom_data", "login_uri",
 			"authorize_anonymous_users", "template"]):
 			v = kwargs.get(k)
 			if v is not None and not (isinstance(v, str) and len(v) > 0):

--- a/seacatauth/credentials/providers/abc.py
+++ b/seacatauth/credentials/providers/abc.py
@@ -41,7 +41,7 @@ class CredentialsProviderABC(asab.ConfigObject, abc.ABC):
 		}
 
 
-	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> str:
 		'''
 		Locate credentials based on the vague 'ident', which could be the username, password, phone number etc.
 		Return credentials_id or return None if not found.

--- a/seacatauth/credentials/providers/dictionary.py
+++ b/seacatauth/credentials/providers/dictionary.py
@@ -108,7 +108,7 @@ class DictCredentialsProvider(EditableCredentialsProviderABC):
 		self.Dictionary.pop(credentials_id[len(prefix):])
 		return "OK"
 
-	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> str:
 		# TODO: Implement ident_fields support
 		# Fast match based on the username
 		credentials_id = hashlib.sha224(ident.encode('utf-8')).hexdigest()

--- a/seacatauth/credentials/providers/elasticsearch.py
+++ b/seacatauth/credentials/providers/elasticsearch.py
@@ -108,7 +108,7 @@ class ElasticSearchCredentialsProvider(CredentialsProviderABC):
 		return obj
 
 
-	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> str:
 		query = {"query": {"bool": {
 			"filter": [
 				{"match_phrase": {"type": "user"}},

--- a/seacatauth/credentials/providers/htpasswd.py
+++ b/seacatauth/credentials/providers/htpasswd.py
@@ -36,7 +36,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 		self.HT = HtpasswdFile(self.Config['path'])
 
 
-	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> str:
 		# TODO: Implement ident_fields support
 		'''
 		Locate search for the exact match of provided ident and the username in the htpasswd file

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -301,7 +301,7 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 		return None
 
 
-	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> str:
+	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> str:
 		# TODO: Implement ident_fields support
 		'''
 		Locate search for the exact match of provided ident and the username in the htpasswd file

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -208,7 +208,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 		return "OK"
 
 
-	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> Optional[str]:
+	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> Optional[str]:
 		"""
 		Locate credentials by matching ident string against configured ident fields.
 		"""

--- a/seacatauth/credentials/providers/mysql.py
+++ b/seacatauth/credentials/providers/mysql.py
@@ -70,10 +70,10 @@ class MySQLCredentialsProvider(CredentialsProviderABC):
 			self.DataFields = None
 
 
-	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> Optional[str]:
+	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> Optional[str]:
 		kwargs = {"ident": ident}
-		if key is not None:
-			kwargs.update(key)
+		if login_dict is not None:
+			kwargs.update(login_dict)
 		async with aiomysql.connect(**self.ConnectionParams) as connection:
 			async with connection.cursor(aiomysql.DictCursor) as cursor:
 				await cursor.execute(self.LocateQuery, kwargs)

--- a/seacatauth/credentials/providers/xmongodb.py
+++ b/seacatauth/credentials/providers/xmongodb.py
@@ -85,10 +85,10 @@ class XMongoDBCredentialsProvider(CredentialsProviderABC):
 		return bson.json_util.loads(bound_query)
 
 
-	async def locate(self, ident: str, ident_fields: dict = None, key: dict = None) -> Optional[str]:
+	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> Optional[str]:
 		kwargs = {"ident": ident}
-		if key is not None:
-			kwargs.update(key)
+		if login_dict is not None:
+			kwargs.update(login_dict)
 		query = self._prepare_query(self.LocateQuery, kwargs)
 		cursor = self.Collection.aggregate(query)
 		result = None

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -133,13 +133,15 @@ class CredentialsService(asab.Service):
 		self.CredentialProviders[credentials_provider.ProviderID] = credentials_provider
 
 
-	async def locate(self, ident: str, stop_at_first: bool = False, key: dict = None):
+	async def locate(self, ident: str, stop_at_first: bool = False, login_dict: dict = None):
 		'''
 		Locate credentials based on the vague 'ident', which could be the username, password, phone number etc.
 		'''
 		ident = ident.strip()
 		credentials_ids = []
-		pending = [provider.locate(ident, self.IdentFields, key) for provider in self.CredentialProviders.values()]
+		pending = [
+			provider.locate(ident, self.IdentFields, login_dict)
+			for provider in self.CredentialProviders.values()]
 		while len(pending) > 0:
 			done, pending = await asyncio.wait(pending)
 			for task in done:


### PR DESCRIPTION
- Client `login_key` attribute is removed.
- Extra login prologue data can be provided in the login-prologue body's `qs` field as query-encoded parameter string, e.g.
```
PUT /public/login.prologue
```
```json
{
 "ident": "sophie",
 "qs": "loginDomain=example.sk&comment=this+is+a+random+comment",
 **JWK_PARAMETERS
}
```
- Specify allowed login data keys as a whitespace-separated list in the `[seacatauth:authentication] custom_login_parameters`. Other parameters will be ignored at login time.
- NOTE: Seacat Auth UI login page transfers its URL query string into the login.prologue request body.