### PR TITLE
TOTP moved to dedicated collection

### DIFF
--- a/seacatauth/authn/login_factors/totp.py
+++ b/seacatauth/authn/login_factors/totp.py
@@ -14,8 +14,11 @@ class TOTPFactor(LoginFactorABC):
 	Type = "totp"
 
 	async def is_eligible(self, login_data: dict) -> bool:
-		# Check if OTP is set up in credentials
-		cred_svc = self.AuthenticationService.CredentialsService
+		"""
+		Check if OTP is set up in credentials.
+		"""
+		cred_svc = self.AuthenticationService.App.get_service("seacatauth.OTPService")
+
 		cred_id = login_data["credentials_id"]
 		if cred_id == "":
 			# Not eligible for "fake" login session


### PR DESCRIPTION
- some type hints and documentation added
- created new enum EventType for custom data: 
```python
upsertor.execute(custom_data={"event_type": EventType.TOTP_CREATED})
```
- now there are two collections: the old `TOTPUnregisteredSecretCollection = "tos"` and the new `TOTPCollection = "totp"`
- encryption on lines 149, 158: `upsertor.set("__s", secret, encrypt=True)`