### PR TITLE
Webhook: Event type descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Clients can register a custom login_uri and login_key (#151, PLUM Sprint 230210)
 - Authorize request adds client_id to login URL query (#151, PLUM Sprint 230210)
 - Upgrade Docker image OS to Alpine 3.17 (#166, PLUM Sprint 230224)
+- Introduce event type descriptors - depends on the latest version of ASAB (#132, PLUM Sprint 230310)
 
 ### Features
 - Assign roles and tenants to multiple credentials at once (#146, PLUM Sprint 230113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@
 - Clients can register a custom login_uri and login_key (#151, PLUM Sprint 230210)
 - Authorize request adds client_id to login URL query (#151, PLUM Sprint 230210)
 - Upgrade Docker image OS to Alpine 3.17 (#166, PLUM Sprint 230224)
-- Introduce event type descriptors - depends on the latest version of ASAB (#132, PLUM Sprint 230310)
-
-### Features
-- Assign roles and tenants to multiple credentials at once (#146, PLUM Sprint 230113)
+- Introduce event type descriptors (#132, PLUM Sprint 230310)
+- Allow OAuth authorize requests with anonymous sessions (#165, PLUM Sprint 230224)
+- Allow extra login parameters to be supplied in login prologue body (#169, PLUM Sprint 230310)
+- Assign roles and tenants to multiple credentials at once (#167, PLUM Sprint 230310)
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 - Introduce event type descriptors (#132, PLUM Sprint 230310)
 - Allow OAuth authorize requests with anonymous sessions (#165, PLUM Sprint 230224)
 - Allow extra login parameters to be supplied in login prologue body (#169, PLUM Sprint 230310)
-- Assign roles and tenants to multiple credentials at once (#167, PLUM Sprint 230310)
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@
 - Clients can register a custom login_uri and login_key (#151, PLUM Sprint 230210)
 - Authorize request adds client_id to login URL query (#151, PLUM Sprint 230210)
 - Upgrade Docker image OS to Alpine 3.17 (#166, PLUM Sprint 230224)
-- Introduce event type descriptors (#132, PLUM Sprint 230310)
+- ~~Assign roles and tenants to multiple credentials at once (#146, PLUM Sprint 230113)~~
 - Allow OAuth authorize requests with anonymous sessions (#165, PLUM Sprint 230224)
 - Allow extra login parameters to be supplied in login prologue body (#169, PLUM Sprint 230310)
+- Assign roles and tenants to multiple credentials at once (#167, PLUM Sprint 230310)
+- Introduce event type descriptors (#132, PLUM Sprint 230310)
 
 ### Refactoring
 - Regex validation of cookie_domain client attribute (#144, PLUM Sprint 230113)

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -151,7 +151,7 @@ class AuthenticationService(asab.Service):
 		for k, v in login_session.serialize().items():
 			upsertor.set(k, v)
 
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.LOGIN_SESSION_CREATED})
+		await upsertor.execute(event_type=EventTypes.LOGIN_SESSION_CREATED)
 
 		return login_session
 
@@ -179,7 +179,7 @@ class AuthenticationService(asab.Service):
 		if remaining_login_attempts is not None:
 			upsertor.set("la", remaining_login_attempts)
 
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.LOGIN_SESSION_UPDATED})
+		await upsertor.execute(event_type=EventTypes.LOGIN_SESSION_UPDATED)
 		L.info("Login session updated", struct_data={
 			"lsid": login_session_id,
 		})

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -18,6 +18,8 @@ from ..session import (
 	external_login_session_builder, SessionAdapter,
 )
 
+from ..events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -149,7 +151,7 @@ class AuthenticationService(asab.Service):
 		for k, v in login_session.serialize().items():
 			upsertor.set(k, v)
 
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.LOGIN_SESSION_CREATED})
 
 		return login_session
 
@@ -177,7 +179,7 @@ class AuthenticationService(asab.Service):
 		if remaining_login_attempts is not None:
 			upsertor.set("la", remaining_login_attempts)
 
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.LOGIN_SESSION_UPDATED})
 		L.info("Login session updated", struct_data={
 			"lsid": login_session_id,
 		})

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -11,6 +11,7 @@ import webauthn
 import webauthn.registration
 import webauthn.helpers.structs
 
+from ...events import EventTypes
 #
 
 L = logging.getLogger(__name__)
@@ -86,7 +87,7 @@ class WebAuthnService(asab.Service):
 		upsertor.set("rpid", self.RelyingPartyId)
 		upsertor.set("name", name)
 
-		wacid = await upsertor.execute()
+		wacid = await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.WEBAUTHN_CREDENTIAL_CREATED})
 		L.log(asab.LOG_NOTICE, "WebAuthn credential created", struct_data={"wacid": wacid})
 
 
@@ -156,7 +157,7 @@ class WebAuthnService(asab.Service):
 		if last_login is not None:
 			upsertor.set("ll", last_login)
 
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.WEBAUTHN_CREDENTIAL_UPDATED})
 		L.log(asab.LOG_NOTICE, "WebAuthn credential updated", struct_data={
 			"wacid": webauthn_credential_id,
 		})
@@ -214,7 +215,7 @@ class WebAuthnService(asab.Service):
 		challenge = secrets.token_bytes(32)
 		upsertor.set("ch", challenge)
 
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.REGISTRATION_CHALLENGE_CREATED})
 		L.log(asab.LOG_NOTICE, "WebAuthn challenge created", struct_data={"sid": session_id})
 
 		return challenge

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -215,7 +215,7 @@ class WebAuthnService(asab.Service):
 		challenge = secrets.token_bytes(32)
 		upsertor.set("ch", challenge)
 
-		await upsertor.execute(event_type=EventTypes.REGISTRATION_CHALLENGE_CREATED)
+		await upsertor.execute(event_type=EventTypes.WEBAUTHN_REG_CHALLENGE_CREATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn challenge created", struct_data={"sid": session_id})
 
 		return challenge

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -87,7 +87,7 @@ class WebAuthnService(asab.Service):
 		upsertor.set("rpid", self.RelyingPartyId)
 		upsertor.set("name", name)
 
-		wacid = await upsertor.execute(event_type=EventTypes.WEBAUTHN_REG_CHALLENGE_CREATED)
+		wacid = await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_CREATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn credential created", struct_data={"wacid": wacid})
 
 
@@ -157,7 +157,7 @@ class WebAuthnService(asab.Service):
 		if last_login is not None:
 			upsertor.set("ll", last_login)
 
-		await upsertor.execute(event_type=EventTypes.WEBAUTHN_REG_CHALLENGE_UPDATED)
+		await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_UPDATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn credential updated", struct_data={
 			"wacid": webauthn_credential_id,
 		})
@@ -215,7 +215,7 @@ class WebAuthnService(asab.Service):
 		challenge = secrets.token_bytes(32)
 		upsertor.set("ch", challenge)
 
-		await upsertor.execute(event_type=EventTypes.WEBAUTHN_REG_CHALLENGE_CREATED)
+		await upsertor.execute(event_type=EventTypes.REGISTRATION_CHALLENGE_CREATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn challenge created", struct_data={"sid": session_id})
 
 		return challenge

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -87,7 +87,7 @@ class WebAuthnService(asab.Service):
 		upsertor.set("rpid", self.RelyingPartyId)
 		upsertor.set("name", name)
 
-		wacid = await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.WEBAUTHN_CREDENTIAL_CREATED})
+		wacid = await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.WEBAUTHN_CREDENTIALS_CREATED})
 		L.log(asab.LOG_NOTICE, "WebAuthn credential created", struct_data={"wacid": wacid})
 
 
@@ -157,7 +157,7 @@ class WebAuthnService(asab.Service):
 		if last_login is not None:
 			upsertor.set("ll", last_login)
 
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.WEBAUTHN_CREDENTIAL_UPDATED})
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.WEBAUTHN_CREDENTIALS_UPDATED})
 		L.log(asab.LOG_NOTICE, "WebAuthn credential updated", struct_data={
 			"wacid": webauthn_credential_id,
 		})

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -87,7 +87,7 @@ class WebAuthnService(asab.Service):
 		upsertor.set("rpid", self.RelyingPartyId)
 		upsertor.set("name", name)
 
-		wacid = await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.WEBAUTHN_CREDENTIALS_CREATED})
+		wacid = await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_CREATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn credential created", struct_data={"wacid": wacid})
 
 
@@ -157,7 +157,7 @@ class WebAuthnService(asab.Service):
 		if last_login is not None:
 			upsertor.set("ll", last_login)
 
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.WEBAUTHN_CREDENTIALS_UPDATED})
+		await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_UPDATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn credential updated", struct_data={
 			"wacid": webauthn_credential_id,
 		})
@@ -215,7 +215,7 @@ class WebAuthnService(asab.Service):
 		challenge = secrets.token_bytes(32)
 		upsertor.set("ch", challenge)
 
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.REGISTRATION_CHALLENGE_CREATED})
+		await upsertor.execute(event_type=EventTypes.REGISTRATION_CHALLENGE_CREATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn challenge created", struct_data={"sid": session_id})
 
 		return challenge

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -87,7 +87,7 @@ class WebAuthnService(asab.Service):
 		upsertor.set("rpid", self.RelyingPartyId)
 		upsertor.set("name", name)
 
-		wacid = await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_CREATED)
+		wacid = await upsertor.execute(event_type=EventTypes.WEBAUTHN_REG_CHALLENGE_CREATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn credential created", struct_data={"wacid": wacid})
 
 
@@ -157,7 +157,7 @@ class WebAuthnService(asab.Service):
 		if last_login is not None:
 			upsertor.set("ll", last_login)
 
-		await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_UPDATED)
+		await upsertor.execute(event_type=EventTypes.WEBAUTHN_REG_CHALLENGE_UPDATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn credential updated", struct_data={
 			"wacid": webauthn_credential_id,
 		})
@@ -215,7 +215,7 @@ class WebAuthnService(asab.Service):
 		challenge = secrets.token_bytes(32)
 		upsertor.set("ch", challenge)
 
-		await upsertor.execute(event_type=EventTypes.REGISTRATION_CHALLENGE_CREATED)
+		await upsertor.execute(event_type=EventTypes.WEBAUTHN_REG_CHALLENGE_CREATED)
 		L.log(asab.LOG_NOTICE, "WebAuthn challenge created", struct_data={"sid": session_id})
 
 		return challenge

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -4,6 +4,8 @@ import re
 import asab.storage.exceptions
 import asab
 
+from ...events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -114,7 +116,7 @@ class ResourceService(asab.Service):
 			upsertor.set("description", description)
 
 		try:
-			await upsertor.execute()
+			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.RESOURCE_CREATED})
 		except asab.storage.exceptions.DuplicateError as e:
 			if e.KeyValue is not None:
 				key, value = e.KeyValue
@@ -140,7 +142,7 @@ class ResourceService(asab.Service):
 		else:
 			upsertor.set("description", description)
 
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.RESOURCE_UPDATED})
 		L.log(asab.LOG_NOTICE, "Resource description updated", struct_data={"resource": resource_id})
 
 
@@ -173,7 +175,7 @@ class ResourceService(asab.Service):
 				version=resource["_v"]
 			)
 			upsertor.set("deleted", True)
-			await upsertor.execute()
+			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.RESOURCE_DELETED})
 			L.log(asab.LOG_NOTICE, "Resource soft-deleted", struct_data={
 				"resource": resource_id,
 			})
@@ -190,7 +192,7 @@ class ResourceService(asab.Service):
 			version=resource["_v"]
 		)
 		upsertor.unset("deleted")
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.RESOURCE_UNDELETED})
 		L.log(asab.LOG_NOTICE, "Resource undeleted", struct_data={
 			"resource": resource_id,
 		})

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -116,7 +116,7 @@ class ResourceService(asab.Service):
 			upsertor.set("description", description)
 
 		try:
-			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.RESOURCE_CREATED})
+			await upsertor.execute(event_type=EventTypes.RESOURCE_CREATED)
 		except asab.storage.exceptions.DuplicateError as e:
 			if e.KeyValue is not None:
 				key, value = e.KeyValue
@@ -142,7 +142,7 @@ class ResourceService(asab.Service):
 		else:
 			upsertor.set("description", description)
 
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.RESOURCE_UPDATED})
+		await upsertor.execute(event_type=EventTypes.RESOURCE_UPDATED)
 		L.log(asab.LOG_NOTICE, "Resource description updated", struct_data={"resource": resource_id})
 
 
@@ -175,7 +175,7 @@ class ResourceService(asab.Service):
 				version=resource["_v"]
 			)
 			upsertor.set("deleted", True)
-			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.RESOURCE_DELETED})
+			await upsertor.execute(event_type=EventTypes.RESOURCE_DELETED)
 			L.log(asab.LOG_NOTICE, "Resource soft-deleted", struct_data={
 				"resource": resource_id,
 			})
@@ -192,7 +192,7 @@ class ResourceService(asab.Service):
 			version=resource["_v"]
 		)
 		upsertor.unset("deleted")
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.RESOURCE_UNDELETED})
+		await upsertor.execute(event_type=EventTypes.RESOURCE_UNDELETED)
 		L.log(asab.LOG_NOTICE, "Resource undeleted", struct_data={
 			"resource": resource_id,
 		})

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -309,16 +309,11 @@ class RoleService(asab.Service):
 
 		# Assign new roles
 		for role in roles_to_assign:
-			crid = "{} {}".format(credentials_id, role)
-			upsertor = self.StorageService.upsertor(self.CredentialsRolesCollection, obj_id=crid)
-			upsertor.set("c", credentials_id)
-			upsertor.set("r", role)
+			await self.assign_role(credentials_id, role, verify_tenant=False, verify_credentials=False)
 
-			# TODO: Optimize; this database lookup is being called twice for each role
-			tenant = await self.get_role_tenant(role)
-			if tenant != "*":
-				upsertor.set("t", tenant)
-			await upsertor.execute(event_type=EventTypes.ROLE_ASSIGNED)  # TODO: Make use of the _do_assign_role method here
+		# Unassign roles
+		for role in roles_to_unassign:
+			await self.unassign_role(credentials_id, role)
 
 		L.log(asab.LOG_NOTICE, "Roles assigned", struct_data={
 			"cid": credentials_id,

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -318,7 +318,7 @@ class RoleService(asab.Service):
 			tenant = await self.get_role_tenant(role)
 			if tenant != "*":
 				upsertor.set("t", tenant)
-			await upsertor.execute(event_type=EventTypes.ROLES_ASSIGNED)
+			await upsertor.execute(event_type=EventTypes.ROLE_ASSIGNED)  # TODO: Make use of the _do_assign_role method here
 
 		L.log(asab.LOG_NOTICE, "Roles assigned", struct_data={
 			"cid": credentials_id,

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -6,6 +6,8 @@ import asab.storage.exceptions
 import asab.exceptions
 from ... import exceptions
 
+from ...events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -109,7 +111,7 @@ class RoleService(asab.Service):
 		if tenant != "*":
 			upsertor.set("tenant", tenant)
 		try:
-			await upsertor.execute()
+			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.ROLE_CREATED})
 			L.log(asab.LOG_NOTICE, "Role created", struct_data={"role_id": role_id})
 		except asab.storage.exceptions.DuplicateError:
 			L.error("Couldn't create role: Already exists", struct_data={"role_id": role_id})
@@ -203,7 +205,7 @@ class RoleService(asab.Service):
 			upsertor.set("description", description)
 			log_data["description"] = description
 
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.ROLE_UPDATED})
 		L.log(asab.LOG_NOTICE, "Role updated", struct_data=log_data)
 		return "OK"
 
@@ -316,7 +318,7 @@ class RoleService(asab.Service):
 			tenant = await self.get_role_tenant(role)
 			if tenant != "*":
 				upsertor.set("t", tenant)
-			await upsertor.execute()
+			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.ROLES_ASSIGNED})
 
 		L.log(asab.LOG_NOTICE, "Roles assigned", struct_data={
 			"cid": credentials_id,
@@ -394,7 +396,7 @@ class RoleService(asab.Service):
 			upsertor.set("t", tenant)
 
 		try:
-			await upsertor.execute()
+			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.ROLE_ASSIGNED})
 		except asab.storage.exceptions.DuplicateError as e:
 			if hasattr(e, "KeyValue") and e.KeyValue is not None:
 				key, value = e.KeyValue.popitem()

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -111,7 +111,7 @@ class RoleService(asab.Service):
 		if tenant != "*":
 			upsertor.set("tenant", tenant)
 		try:
-			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.ROLE_CREATED})
+			await upsertor.execute(event_type=EventTypes.ROLE_CREATED)
 			L.log(asab.LOG_NOTICE, "Role created", struct_data={"role_id": role_id})
 		except asab.storage.exceptions.DuplicateError:
 			L.error("Couldn't create role: Already exists", struct_data={"role_id": role_id})
@@ -205,7 +205,7 @@ class RoleService(asab.Service):
 			upsertor.set("description", description)
 			log_data["description"] = description
 
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.ROLE_UPDATED})
+		await upsertor.execute(event_type=EventTypes.ROLE_UPDATED)
 		L.log(asab.LOG_NOTICE, "Role updated", struct_data=log_data)
 		return "OK"
 
@@ -318,7 +318,7 @@ class RoleService(asab.Service):
 			tenant = await self.get_role_tenant(role)
 			if tenant != "*":
 				upsertor.set("t", tenant)
-			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.ROLES_ASSIGNED})
+			await upsertor.execute(event_type=EventTypes.ROLES_ASSIGNED)
 
 		L.log(asab.LOG_NOTICE, "Roles assigned", struct_data={
 			"cid": credentials_id,
@@ -396,7 +396,7 @@ class RoleService(asab.Service):
 			upsertor.set("t", tenant)
 
 		try:
-			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.ROLE_ASSIGNED})
+			await upsertor.execute(event_type=EventTypes.ROLE_ASSIGNED)
 		except asab.storage.exceptions.DuplicateError as e:
 			if hasattr(e, "KeyValue") and e.KeyValue is not None:
 				key, value = e.KeyValue.popitem()

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -357,7 +357,7 @@ class ClientService(asab.Service):
 				upsertor.set(k, v)
 
 		try:
-			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.CLIENT_REGISTERED})
+			await upsertor.execute(event_type=EventTypes.CLIENT_REGISTERED)
 		except asab.storage.exceptions.DuplicateError:
 			raise asab.exceptions.Conflict(key="client_id", value=client_id)
 
@@ -387,7 +387,7 @@ class ClientService(asab.Service):
 		upsertor.set("__client_secret", client_secret.encode("ascii"), encrypt=True)
 		if client_secret_expires_at is not None:
 			upsertor.set("client_secret_expires_at", client_secret_expires_at)
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.CLIENT_RESET})
+		await upsertor.execute(event_type=EventTypes.CLIENT_RESET)
 		L.log(asab.LOG_NOTICE, "Client secret updated", struct_data={"client_id": client_id})
 
 		response = {"client_secret": client_secret}
@@ -426,7 +426,7 @@ class ClientService(asab.Service):
 			else:
 				upsertor.set(k, v)
 
-		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.CLIENT_UPDATED})
+		await upsertor.execute(event_type=EventTypes.CLIENT_UPDATED)
 		L.log(asab.LOG_NOTICE, "Client updated", struct_data={
 			"client_id": client_id,
 			"fields": " ".join(client_update.keys())})

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -9,6 +9,8 @@ import asab.exceptions
 
 from seacatauth.client import exceptions
 
+from ..events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -355,7 +357,7 @@ class ClientService(asab.Service):
 				upsertor.set(k, v)
 
 		try:
-			await upsertor.execute()
+			await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.CLIENT_REGISTERED})
 		except asab.storage.exceptions.DuplicateError:
 			raise asab.exceptions.Conflict(key="client_id", value=client_id)
 
@@ -385,7 +387,7 @@ class ClientService(asab.Service):
 		upsertor.set("__client_secret", client_secret.encode("ascii"), encrypt=True)
 		if client_secret_expires_at is not None:
 			upsertor.set("client_secret_expires_at", client_secret_expires_at)
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.CLIENT_RESET})
 		L.log(asab.LOG_NOTICE, "Client secret updated", struct_data={"client_id": client_id})
 
 		response = {"client_secret": client_secret}
@@ -424,7 +426,7 @@ class ClientService(asab.Service):
 			else:
 				upsertor.set(k, v)
 
-		await upsertor.execute()
+		await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.CLIENT_UPDATED})
 		L.log(asab.LOG_NOTICE, "Client updated", struct_data={
 			"client_id": client_id,
 			"fields": " ".join(client_update.keys())})

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -387,7 +387,7 @@ class ClientService(asab.Service):
 		upsertor.set("__client_secret", client_secret.encode("ascii"), encrypt=True)
 		if client_secret_expires_at is not None:
 			upsertor.set("client_secret_expires_at", client_secret_expires_at)
-		await upsertor.execute(event_type=EventTypes.CLIENT_RESET)
+		await upsertor.execute(event_type=EventTypes.CLIENT_SECRET_RESET)
 		L.log(asab.LOG_NOTICE, "Client secret updated", struct_data={"client_id": client_id})
 
 		response = {"client_secret": client_secret}

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -7,6 +7,8 @@ import asab
 from ...generic import generate_ergonomic_token
 from ...audit import AuditCode
 
+from ...events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -79,7 +81,7 @@ class ChangePasswordService(asab.Service):
 		for request_builder in request_builders:
 			for key, value in request_builder.items():
 				upsertor.set(key, value)
-		request_id = await upsertor.execute()
+		request_id = await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.PWD_RESET_TOKEN_CREATED})
 		assert pwd_change_id == request_id
 		L.log(asab.LOG_NOTICE, "Password reset token created", struct_data={"pwd_token": request_id})
 		return request_id

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -81,7 +81,7 @@ class ChangePasswordService(asab.Service):
 		for request_builder in request_builders:
 			for key, value in request_builder.items():
 				upsertor.set(key, value)
-		request_id = await upsertor.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.PWD_RESET_TOKEN_CREATED})
+		request_id = await upsertor.execute(event_type=EventTypes.PWD_RESET_TOKEN_CREATED)
 		assert pwd_change_id == request_id
 		L.log(asab.LOG_NOTICE, "Password reset token created", struct_data={"pwd_token": request_id})
 		return request_id

--- a/seacatauth/credentials/providers/m2m_mongodb.py
+++ b/seacatauth/credentials/providers/m2m_mongodb.py
@@ -81,7 +81,7 @@ class M2MMongoDBCredentialsProvider(MongoDBCredentialsProvider):
 		u.set("username", credentials["username"])
 		u.set("__password", bcrypt.hash(credentials["password"].encode("utf-8")))
 
-		credentials_id = await u.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.M2M_MONGO_CREDENTIALS_CREATED})
+		credentials_id = await u.execute(event_type=EventTypes.M2M_MONGO_CREDENTIALS_CREATED)
 
 		L.log(asab.LOG_NOTICE, "Credentials created", struct_data={
 			"provider_id": self.ProviderID,

--- a/seacatauth/credentials/providers/m2m_mongodb.py
+++ b/seacatauth/credentials/providers/m2m_mongodb.py
@@ -8,6 +8,8 @@ import pymongo
 from passlib.hash import bcrypt
 from .mongodb import MongoDBCredentialsProvider
 
+from ...events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -79,7 +81,7 @@ class M2MMongoDBCredentialsProvider(MongoDBCredentialsProvider):
 		u.set("username", credentials["username"])
 		u.set("__password", bcrypt.hash(credentials["password"].encode("utf-8")))
 
-		credentials_id = await u.execute()
+		credentials_id = await u.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.M2M_MONGO_CREDENTIALS_CREATED})
 
 		L.log(asab.LOG_NOTICE, "Credentials created", struct_data={
 			"provider_id": self.ProviderID,

--- a/seacatauth/credentials/providers/m2m_mongodb.py
+++ b/seacatauth/credentials/providers/m2m_mongodb.py
@@ -81,7 +81,7 @@ class M2MMongoDBCredentialsProvider(MongoDBCredentialsProvider):
 		u.set("username", credentials["username"])
 		u.set("__password", bcrypt.hash(credentials["password"].encode("utf-8")))
 
-		credentials_id = await u.execute(event_type=EventTypes.M2M_MONGO_CREDENTIALS_CREATED)
+		credentials_id = await u.execute(event_type=EventTypes.M2M_CREDENTIALS_CREATED)
 
 		L.log(asab.LOG_NOTICE, "Credentials created", struct_data={
 			"provider_id": self.ProviderID,

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -18,6 +18,8 @@ import pymongo.errors
 
 from .abc import EditableCredentialsProviderABC
 
+from ...events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -142,7 +144,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 		for field, value in credentials.items():
 			u.set(field, value)
 
-		credentials_id = await u.execute()
+		credentials_id = await u.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.MONGO_CREDENTIALS_CREATED})
 
 		L.log(asab.LOG_NOTICE, "Credentials created", struct_data={
 			"provider_id": self.ProviderID,
@@ -186,7 +188,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 				u.unset(key)
 
 		try:
-			await u.execute()
+			await u.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.MONGO_CREDENTIALS_UPDATED})
 			L.log(asab.LOG_NOTICE, "Credentials updated", struct_data={
 				"cid": credentials_id,
 				"fields": ", ".join(updated_fields or []),

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -144,7 +144,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 		for field, value in credentials.items():
 			u.set(field, value)
 
-		credentials_id = await u.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.MONGO_CREDENTIALS_CREATED})
+		credentials_id = await u.execute(event_type=EventTypes.MONGO_CREDENTIALS_CREATED)
 
 		L.log(asab.LOG_NOTICE, "Credentials created", struct_data={
 			"provider_id": self.ProviderID,
@@ -188,7 +188,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 				u.unset(key)
 
 		try:
-			await u.execute(custom_data={EventTypes.EVENT_TYPE: EventTypes.MONGO_CREDENTIALS_UPDATED})
+			await u.execute(event_type=EventTypes.MONGO_CREDENTIALS_UPDATED)
 			L.log(asab.LOG_NOTICE, "Credentials updated", struct_data={
 				"cid": credentials_id,
 				"fields": ", ".join(updated_fields or []),

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -144,7 +144,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 		for field, value in credentials.items():
 			u.set(field, value)
 
-		credentials_id = await u.execute(event_type=EventTypes.MONGO_CREDENTIALS_CREATED)
+		credentials_id = await u.execute(event_type=EventTypes.CREDENTIALS_CREATED)
 
 		L.log(asab.LOG_NOTICE, "Credentials created", struct_data={
 			"provider_id": self.ProviderID,
@@ -188,7 +188,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 				u.unset(key)
 
 		try:
-			await u.execute(event_type=EventTypes.MONGO_CREDENTIALS_UPDATED)
+			await u.execute(event_type=EventTypes.CREDENTIALS_UPDATED)
 			L.log(asab.LOG_NOTICE, "Credentials updated", struct_data={
 				"cid": credentials_id,
 				"fields": ", ".join(updated_fields or []),

--- a/seacatauth/events.py
+++ b/seacatauth/events.py
@@ -1,5 +1,4 @@
 class EventTypes:
-	EVENT_TYPE = "event_type"
 	LOGIN_SESSION_CREATED = "login_session_created"
 	LOGIN_SESSION_UPDATED = "login_session_updated"
 

--- a/seacatauth/events.py
+++ b/seacatauth/events.py
@@ -1,0 +1,28 @@
+class EventTypes:
+	EVENT_TYPE = "event_type"
+	LOGIN_SESSION_CREATED = "login_session_created"
+	LOGIN_SESSION_UPDATED = "login_session_updated"
+
+	WEBAUTHN_CREDENTIAL_CREATED = "webauthn_credential_created"
+	WEBAUTHN_CREDENTIAL_UPDATED = "webauthn_credential_updated"
+	REGISTRATION_CHALLENGE_CREATED = "registration_challenge_created"
+
+	RESOURCE_CREATED = "resource_created"
+	RESOURCE_UPDATED = "resource_updated"
+	RESOURCE_DELETED = "resource_deleted"
+	RESOURCE_UNDELETED = "resource_undeleted"
+
+	ROLE_CREATED = "role_created"
+	ROLE_UPDATED = "role_updated"
+	ROLE_ASSIGNED = "role_assigned"
+	ROLES_ASSIGNED = "roles_assigned"
+
+	CLIENT_REGISTERED = "client_registered"
+	CLIENT_UPDATED = "client_updated"
+	CLIENT_RESET = "client_reset"
+
+	PWD_RESET_TOKEN_CREATED = "pwd_reset_token_created"
+
+	M2M_MONGO_CREDENTIALS_CREATED = "m2m_mongo_credentials_created"
+	MONGO_CREDENTIALS_CREATED = "mongo_credentials_created"
+	MONGO_CREDENTIALS_UPDATED = "mongo_credentials_updated"

--- a/seacatauth/events.py
+++ b/seacatauth/events.py
@@ -2,8 +2,8 @@ class EventTypes:
 	LOGIN_SESSION_CREATED = "login_session_created"
 	LOGIN_SESSION_UPDATED = "login_session_updated"
 
-	WEBAUTHN_CREDENTIALS_CREATED = "webauthn_credentials_created"
-	WEBAUTHN_CREDENTIALS_UPDATED = "webauthn_credentials_updated"
+	WEBAUTHN_REG_CHALLENGE_CREATED = "webauthn_registration_challenge_created"
+	WEBAUTHN_REG_CHALLENGE_UPDATED = "webauthn_registration_challenge_updated"
 	REGISTRATION_CHALLENGE_CREATED = "registration_challenge_created"
 
 	RESOURCE_CREATED = "resource_created"
@@ -14,14 +14,25 @@ class EventTypes:
 	ROLE_CREATED = "role_created"
 	ROLE_UPDATED = "role_updated"
 	ROLE_ASSIGNED = "role_assigned"
-	ROLES_ASSIGNED = "roles_assigned"
 
 	CLIENT_REGISTERED = "client_registered"
 	CLIENT_UPDATED = "client_updated"
-	CLIENT_RESET = "client_reset"
+	CLIENT_SECRET_RESET = "client_secret_reset"
 
 	PWD_RESET_TOKEN_CREATED = "pwd_reset_token_created"
 
-	M2M_MONGO_CREDENTIALS_CREATED = "m2m_mongo_credentials_created"
-	MONGO_CREDENTIALS_CREATED = "mongo_credentials_created"
-	MONGO_CREDENTIALS_UPDATED = "mongo_credentials_updated"
+	M2M_CREDENTIALS_CREATED = "m2m_credentials_created"
+	CREDENTIALS_CREATED = "credentials_created"
+	CREDENTIALS_UPDATED = "credentials_updated"
+
+	EXTERNAL_LOGIN_CREATED = "external_login_created"
+
+	OPENID_AUTH_CODE_GENERATED = "openid_auth_code_generated"
+
+	TOTP_SECRET_CREATED = "totp_secret_created"
+
+	SESSION_CREATED = "session_created"
+	SESSION_UPDATED = "session_updated"
+	SESSION_EXTENDED = "session_extended"
+
+	TENANT_ASSIGNED = "tenant_assigned"

--- a/seacatauth/events.py
+++ b/seacatauth/events.py
@@ -3,8 +3,8 @@ class EventTypes:
 	LOGIN_SESSION_CREATED = "login_session_created"
 	LOGIN_SESSION_UPDATED = "login_session_updated"
 
-	WEBAUTHN_CREDENTIAL_CREATED = "webauthn_credential_created"
-	WEBAUTHN_CREDENTIAL_UPDATED = "webauthn_credential_updated"
+	WEBAUTHN_CREDENTIALS_CREATED = "webauthn_credentials_created"
+	WEBAUTHN_CREDENTIALS_UPDATED = "webauthn_credentials_updated"
 	REGISTRATION_CHALLENGE_CREATED = "registration_challenge_created"
 
 	RESOURCE_CREATED = "resource_created"

--- a/seacatauth/events.py
+++ b/seacatauth/events.py
@@ -2,8 +2,8 @@ class EventTypes:
 	LOGIN_SESSION_CREATED = "login_session_created"
 	LOGIN_SESSION_UPDATED = "login_session_updated"
 
-	WEBAUTHN_REG_CHALLENGE_CREATED = "webauthn_registration_challenge_created"
-	WEBAUTHN_REG_CHALLENGE_UPDATED = "webauthn_registration_challenge_updated"
+	WEBAUTHN_CREDENTIALS_CREATED = "webauthn_credentials_created"
+	WEBAUTHN_CREDENTIALS_UPDATED = "webauthn_credentials_updated"
 	REGISTRATION_CHALLENGE_CREATED = "registration_challenge_created"
 
 	RESOURCE_CREATED = "resource_created"

--- a/seacatauth/events.py
+++ b/seacatauth/events.py
@@ -4,7 +4,7 @@ class EventTypes:
 
 	WEBAUTHN_CREDENTIALS_CREATED = "webauthn_credentials_created"
 	WEBAUTHN_CREDENTIALS_UPDATED = "webauthn_credentials_updated"
-	REGISTRATION_CHALLENGE_CREATED = "registration_challenge_created"
+	WEBAUTHN_REG_CHALLENGE_CREATED = "webauthn_registration_challenge_created"
 
 	RESOURCE_CREATED = "resource_created"
 	RESOURCE_UPDATED = "resource_updated"

--- a/seacatauth/external_login/service.py
+++ b/seacatauth/external_login/service.py
@@ -7,6 +7,8 @@ import pymongo
 
 from .providers import create_provider, GenericOAuth2Login
 
+from ..events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -70,7 +72,7 @@ class ExternalLoginService(asab.Service):
 		upsertor.set("s", sub)
 		upsertor.set("cid", credentials_id)
 
-		elcid = await upsertor.execute()
+		elcid = await upsertor.execute(event_type=EventTypes.EXTERNAL_LOGIN_CREATED)
 		L.log(asab.LOG_NOTICE, "External login credential created", struct_data={
 			"id": elcid,
 			"cid": credentials_id,

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -27,6 +27,8 @@ from ..audit import AuditCode
 from .. import exceptions
 from . import pkce
 
+from ..events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -150,7 +152,7 @@ class OpenIdConnectService(asab.Service):
 		upsertor.set("sid", session_id)
 		upsertor.set("exp", datetime.datetime.now(datetime.timezone.utc) + self.AuthorizationCodeTimeout)
 
-		await upsertor.execute()
+		await upsertor.execute(event_type=EventTypes.OPENID_AUTH_CODE_GENERATED)
 
 		return code
 

--- a/seacatauth/otp/service.py
+++ b/seacatauth/otp/service.py
@@ -7,6 +7,8 @@ import urllib.parse
 import asab
 import asab.storage
 
+from ..events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -136,7 +138,7 @@ class OTPService(asab.Service):
 		secret = pyotp.random_base32()
 		upsertor.set("__s", secret)
 
-		await upsertor.execute()
+		await upsertor.execute(event_type=EventTypes.TOTP_SECRET_CREATED)
 		L.log(asab.LOG_NOTICE, "TOTP secret created", struct_data={"sid": session_id})
 
 		return secret

--- a/seacatauth/tenant/providers/mongodb.py
+++ b/seacatauth/tenant/providers/mongodb.py
@@ -7,6 +7,8 @@ import asab.storage.exceptions
 
 from .abc import EditableTenantsProviderABC
 
+from ...events import EventTypes
+
 #
 
 L = logging.getLogger(__name__)
@@ -198,7 +200,7 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 		upsertor = self.MongoDBStorageService.upsertor(self.AssignCollection, obj_id=assignment_id)
 		upsertor.set("c", credentials_id)
 		upsertor.set("t", tenant)
-		await upsertor.execute()
+		await upsertor.execute(event_type=EventTypes.TENANT_ASSIGNED)
 
 
 	async def unassign_tenant(self, credentials_id: str, tenant: str):


### PR DESCRIPTION
# Event type descriptors

fixes (#132)
Depends on https://github.com/TeskaLabs/asab/pull/371

Event types are stored in 'events.py' in `EventTypes` class. The usage is the following:

```python
await upsertor.execute(event_type=EventTypes.RESOURCE_UPDATED)
```

All event types are configurable and can be found in one place.