### PR TITLE
Granular resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Dropped support for custom cookie domains in the configuration (#156, PLUM Sprint 230324)
 - External login status messages changed (#185, PLUM Sprint 230324)
 - Bulk-unassign tenants using "UNASSIGN-TENANT" (#189, PLUM Sprint 230324)
+- Resource "authz:tenant:admin" is deprecated and replaced by several resources (#183, PLUM Sprint 230412)
+- Viewing and browsing all tenants requires superuser privileges (#183, PLUM Sprint 230412)
+- Seacat Admin built-in resources are not editable (#183, PLUM Sprint 230412)
 
 ### Fix
 - Improve last login search performance (#173, PLUM Sprint 230324)
@@ -21,6 +24,7 @@
 ### Features
 - Per-client configurable authorization, login and cookies (#156, PLUM Sprint 230324)
 - External login ident stored (#185, PLUM Sprint 230324)
+- Granular access control for Admin API (#183, PLUM Sprint 230412)
 
 ### Refactoring
 - OpenAPI docs updated (#181, PLUM Sprint 230324)

--- a/seacatauth/authz/rbac/service.py
+++ b/seacatauth/authz/rbac/service.py
@@ -18,7 +18,7 @@ class RBACService(asab.Service):
 		super().__init__(app, service_name)
 
 	@staticmethod
-	def is_superuser(authz: dict):
+	def is_superuser(authz: dict) -> bool:
 		global_resources = set(
 			resource
 			for resource in authz["*"]
@@ -26,7 +26,7 @@ class RBACService(asab.Service):
 		return "authz:superuser" in global_resources
 
 	@staticmethod
-	def can_access_all_tenants(authz: dict):
+	def can_access_all_tenants(authz: dict) -> bool:
 		global_resources = set(
 			resource
 			for resource in authz["*"]
@@ -34,7 +34,7 @@ class RBACService(asab.Service):
 		return "authz:superuser" in global_resources or "authz:tenant:access" in global_resources
 
 	@staticmethod
-	def has_resource_access(authz: dict, tenant: typing.Union[str, None], requested_resources: list):
+	def has_resource_access(authz: dict, tenant: typing.Union[str, None], requested_resources: list) -> bool:
 		# Superuser passes without further checks
 		if RBACService.is_superuser(authz):
 			return True

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -34,6 +34,7 @@ class ResourceHandler(object):
 		web_app.router.add_delete("/resource/{resource_id}", self.delete)
 
 
+	@access_control("seacat:resource:access")
 	async def list(self, request):
 		"""
 		List resources
@@ -94,6 +95,7 @@ class ResourceHandler(object):
 		return asab.web.rest.json_response(request, resources)
 
 
+	@access_control("seacat:resource:access")
 	async def get(self, request):
 		"""
 		Get resource detail
@@ -112,7 +114,7 @@ class ResourceHandler(object):
 		"properties": {
 			"description": {"type": "string"}}
 	})
-	@access_control("authz:superuser")
+	@access_control("seacat:resource:edit")
 	async def create_or_undelete(self, request, *, json_data):
 		"""
 		Create a new resource or undelete a resource that has been soft-deleted
@@ -143,7 +145,7 @@ class ResourceHandler(object):
 			"description": {"type": "string"},
 		}
 	})
-	@access_control("authz:superuser")
+	@access_control("seacat:resource:edit")
 	async def update(self, request, *, json_data):
 		"""
 		Update resource description or rename resource
@@ -157,7 +159,7 @@ class ResourceHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:resource:edit")
 	async def delete(self, request):
 		"""
 		Delete resource

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -89,7 +89,7 @@ class ResourceHandler(object):
 		if request.query.get("exclude_global_only") == "true":
 			if "_id" not in query_filter:
 				query_filter["_id"] = {}
-			query_filter["_id"]["$nin"] = list(self.ResourceService._GlobalOnlyResources)
+			query_filter["_id"]["$nin"] = list(self.ResourceService.GlobalOnlyResources)
 
 		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)
@@ -102,7 +102,6 @@ class ResourceHandler(object):
 		"""
 		resource_id = request.match_info["resource_id"]
 		result = await self.ResourceService.get(resource_id)
-		result["result"] = "OK"
 		return asab.web.rest.json_response(
 			request, result
 		)

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -61,9 +61,9 @@ class ResourceService(asab.Service):
 		"seacat:tenant:access": {
 			"description": "List tenants, view tenant detail and see tenant members.",
 		},
-		"seacat:tenant:create": {
-			"description": "Create new tenants.",
-		},
+		# "seacat:tenant:create": {  # Requires superuser for now
+		# 	"description": "Create new tenants.",
+		# },
 		"seacat:tenant:edit": {
 			"description": "Edit tenant data.",
 		},

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -28,6 +28,9 @@ class ResourceService(asab.Service):
 		"authz:superuser": {
 			"description": "Grants superuser access, including the access to all tenants.",
 		},
+		"authz:impersonate": {
+			"description": "Open a session as a different user.",
+		},
 		"authz:tenant:access": {
 			"description": "Grants non-superuser access to all tenants.",
 		},
@@ -83,7 +86,7 @@ class ResourceService(asab.Service):
 		},
 	}
 	GlobalOnlyResources = frozenset({
-		"authz:superuser", "authz:tenant:access", "seacat:credentials:access", "seacat:credentials:edit",
+		"authz:superuser", "authz:impersonate", "authz:tenant:access", "seacat:credentials:access", "seacat:credentials:edit",
 		"seacat:session:access", "seacat:session:terminate", "seacat:resource:access", "seacat:resource:edit",
 		"seacat:client:access", "seacat:client:edit", "seacat:tenant:create"})
 

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -79,7 +79,7 @@ class ResourceService(asab.Service):
 			"description": "Assign and unassign tenant roles.",
 		},
 	}
-	_GlobalOnlyResources = frozenset({
+	GlobalOnlyResources = frozenset({
 		"authz:superuser", "authz:tenant:access", "seacat:credentials:access", "seacat:credentials:edit",
 		"seacat:session:access", "seacat:session:terminate", "seacat:resource:access", "seacat:resource:edit",
 		"seacat:client:access", "seacat:client:edit"})
@@ -101,7 +101,7 @@ class ResourceService(asab.Service):
 
 
 	def is_global_only_resource(self, resource_id):
-		return resource_id in self._GlobalOnlyResources
+		return resource_id in self.GlobalOnlyResources
 
 
 	async def _ensure_builtin_resources(self):
@@ -146,7 +146,6 @@ class ResourceService(asab.Service):
 			resources.append(resource_dict)
 
 		return {
-			"result": "OK",
 			"data": resources,
 			"count": count,
 		}

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -30,10 +30,6 @@ class ResourceService(asab.Service):
 			"description": "Grants superuser access, including the access to all tenants. Global-only.",
 		},
 		{
-			"id": "authz:tenant:admin",
-			"description": "Grants administrative rights for the tenant through which this resource is assigned.",
-		},
-		{
 			"id": "authz:tenant:access",
 			"description": "Grants non-superuser access to all tenants. Global-only.",
 		},

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -121,7 +121,7 @@ class ResourceService(asab.Service):
 
 			# Update resource description
 			if description is not None and db_resource.get("description") != description:
-				await self.update(resource_id, description)
+				await self.update(resource_id, description, _internal=True)
 
 
 	async def list(self, page: int = 0, limit: int = None, query_filter: dict = None):
@@ -184,8 +184,8 @@ class ResourceService(asab.Service):
 		L.log(asab.LOG_NOTICE, "Resource created", struct_data={"resource": resource_id})
 
 
-	async def update(self, resource_id: str, description: str):
-		if self.is_seacat_auth_resource(resource_id):
+	async def update(self, resource_id: str, description: str, *, _internal: bool = False):
+		if self.is_seacat_auth_resource(resource_id) and not _internal:
 			raise asab.exceptions.ValidationError("System resource cannot be modified")
 		resource = await self.get(resource_id)
 		upsertor = self.StorageService.upsertor(

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -58,6 +58,9 @@ class ResourceService(asab.Service):
 		"seacat:tenant:access": {
 			"description": "List tenants, view tenant detail and see tenant members.",
 		},
+		"seacat:tenant:create": {
+			"description": "Create new tenants.",
+		},
 		"seacat:tenant:edit": {
 			"description": "Edit tenant data.",
 		},
@@ -82,7 +85,7 @@ class ResourceService(asab.Service):
 	GlobalOnlyResources = frozenset({
 		"authz:superuser", "authz:tenant:access", "seacat:credentials:access", "seacat:credentials:edit",
 		"seacat:session:access", "seacat:session:terminate", "seacat:resource:access", "seacat:resource:edit",
-		"seacat:client:access", "seacat:client:edit"})
+		"seacat:client:access", "seacat:client:edit", "seacat:tenant:create"})
 
 
 	def __init__(self, app, service_name="seacatauth.ResourceService"):

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -188,11 +188,6 @@ class RoleHandler(object):
 		resources_to_set = json_data.get("set")
 		resources_to_add = json_data.get("add")
 		resources_to_remove = json_data.get("del")
-		resources_to_assign = set().union(
-			resources_to_set or [],
-			resources_to_add or [],
-			resources_to_remove or []
-		)
 
 		# Perform extra validations when the request is not superuser-authorized
 		if not request.is_superuser:
@@ -203,17 +198,6 @@ class RoleHandler(object):
 					"cid": request.CredentialsId
 				})
 				raise aiohttp.web.HTTPForbidden()
-
-			# Cannot un/assign Seacat Auth built-in resources
-			# TODO: This may be too strict, revisit this
-			for resource in resources_to_assign:
-				if self.RoleService.ResourceService.is_builtin_resource(resource):
-					L.warning("Not authorized to assign built-in resources", struct_data={
-						"role_id": role_id,
-						"resource": resource,
-						"cid": request.CredentialsId
-					})
-					raise aiohttp.web.HTTPForbidden()
 
 		try:
 			result = await self.RoleService.update(

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -117,7 +117,7 @@ class RoleHandler(object):
 		)
 
 
-	@access_control("authz:tenant:admin")
+	@access_control()
 	async def create(self, request, *, tenant):
 		"""
 		Create a new role
@@ -131,7 +131,7 @@ class RoleHandler(object):
 		)
 
 
-	@access_control("authz:tenant:admin")
+	@access_control()
 	async def delete(self, request, *, tenant):
 		"""
 		Delete role
@@ -172,7 +172,7 @@ class RoleHandler(object):
 			},
 		}
 	})
-	@access_control("authz:tenant:admin")
+	@access_control()
 	async def update(self, request, *, json_data, tenant):
 		"""
 		Edit role description and resources

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -130,11 +130,8 @@ class RoleHandler(object):
 		"""
 		role_name = request.match_info["role_name"]
 		role_id = "{}/{}".format(tenant, role_name)
-		result = await self.RoleService.create(role_id)
-		return asab.web.rest.json_response(
-			request, result,
-			status=200 if result == "OK" else 400
-		)
+		role_id = await self.RoleService.create(role_id)
+		return asab.web.rest.json_response(request, {"result": "OK", "id": role_id})
 
 
 	@access_control("seacat:role:edit")

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -61,7 +61,7 @@ class RoleHandler(object):
 		"""
 		return await self._list(request, tenant=None)
 
-	@access_control()
+	@access_control("seacat:role:access")
 	async def list(self, request, *, tenant):
 		"""
 		List tenant roles
@@ -97,7 +97,7 @@ class RoleHandler(object):
 		return asab.web.rest.json_response(request, result)
 
 
-	@access_control()
+	@access_control("seacat:role:access")
 	async def get(self, request, *, tenant):
 		"""
 		Get role detail
@@ -117,7 +117,7 @@ class RoleHandler(object):
 		)
 
 
-	@access_control()
+	@access_control("seacat:role:edit")
 	async def create(self, request, *, tenant):
 		"""
 		Create a new role
@@ -131,7 +131,7 @@ class RoleHandler(object):
 		)
 
 
-	@access_control()
+	@access_control("seacat:role:edit")
 	async def delete(self, request, *, tenant):
 		"""
 		Delete role
@@ -172,7 +172,7 @@ class RoleHandler(object):
 			},
 		}
 	})
-	@access_control()
+	@access_control("seacat:role:edit")
 	async def update(self, request, *, json_data, tenant):
 		"""
 		Edit role description and resources

--- a/seacatauth/authz/role/handler/roles.py
+++ b/seacatauth/authz/role/handler/roles.py
@@ -79,7 +79,7 @@ class RolesHandler(object):
 				"type": "array",
 				"items": {"type": "string"}}}
 	})
-	@access_control("authz:tenant:admin")
+	@access_control()
 	async def set_roles(self, request, *, json_data, tenant, resources):
 		"""
 		For given credentials, assign listed roles and unassign existing roles that are not in the list
@@ -112,7 +112,7 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-	@access_control("authz:tenant:admin")
+	@access_control()
 	async def assign_role(self, request, *, tenant):
 		"""
 		Assign role to credentials
@@ -143,7 +143,7 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@access_control("authz:tenant:admin")
+	@access_control()
 	async def unassign_role(self, request, *, tenant):
 		"""
 		Unassign role from credentials

--- a/seacatauth/authz/role/handler/roles.py
+++ b/seacatauth/authz/role/handler/roles.py
@@ -36,10 +36,10 @@ class RolesHandler(object):
 		web_app.router.add_post("/role_assign/{credentials_id}/{tenant}/{role_name}", self.assign_role)
 		web_app.router.add_delete("/role_assign/{credentials_id}/{tenant}/{role_name}", self.unassign_role)
 
-	@access_control()
+	@access_control("seacat:role:access")
 	async def get_roles_by_credentials(self, request, *, tenant):
 		"""
-		Get credential's roles
+		Get credentials' roles
 		"""
 		creds_id = request.match_info["credentials_id"]
 		try:
@@ -60,7 +60,7 @@ class RolesHandler(object):
 		"description": "Credential IDs",
 		"items": {"type": "string"}
 	})
-	@access_control()
+	@access_control("seacat:role:access")
 	async def get_roles_batch(self, request, *, tenant, json_data):
 		"""
 		Get the assigned roles for several credentials
@@ -79,7 +79,7 @@ class RolesHandler(object):
 				"type": "array",
 				"items": {"type": "string"}}}
 	})
-	@access_control()
+	@access_control("seacat:role:assign")
 	async def set_roles(self, request, *, json_data, tenant, resources):
 		"""
 		For given credentials, assign listed roles and unassign existing roles that are not in the list
@@ -112,7 +112,7 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-	@access_control()
+	@access_control("seacat:role:assign")
 	async def assign_role(self, request, *, tenant):
 		"""
 		Assign role to credentials
@@ -143,7 +143,7 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@access_control()
+	@access_control("seacat:role:assign")
 	async def unassign_role(self, request, *, tenant):
 		"""
 		Unassign role from credentials

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -345,7 +345,7 @@ class RoleService(asab.Service):
 			# such as "authz:superuser" or "authz:tenant:access", which is correct.
 			# To get a tenant role assigned, the user needs to have the tenant explicitly assigned.
 			if not await self.TenantService.has_tenant_assigned(credentials_id, tenant):
-				raise exceptions.TenantNotAuthorizedError(credentials_id, tenant)
+				raise exceptions.TenantNotAssignedError(credentials_id, tenant)
 
 		await self._do_assign_role(credentials_id, role_id, tenant)
 

--- a/seacatauth/client/handler.py
+++ b/seacatauth/client/handler.py
@@ -92,7 +92,7 @@ class ClientHandler(object):
 		)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:client:access")
 	async def features(self, request):
 		"""
 		Get schema of supported client metadata

--- a/seacatauth/client/handler.py
+++ b/seacatauth/client/handler.py
@@ -35,7 +35,7 @@ class ClientHandler(object):
 		web_app.router.add_delete("/client/{client_id}", self.delete)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:client:access")
 	async def list(self, request):
 		"""
 		List registered clients
@@ -78,7 +78,7 @@ class ClientHandler(object):
 		})
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:client:access")
 	async def get(self, request):
 		"""
 		Get client by client_id
@@ -109,7 +109,7 @@ class ClientHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(REGISTER_CLIENT_SCHEMA)
-	@access_control("authz:superuser")
+	@access_control("seacat:client:edit")
 	async def register(self, request, *, json_data):
 		"""
 		Register a new client
@@ -125,7 +125,7 @@ class ClientHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(UPDATE_CLIENT_SCHEMA)
-	@access_control("authz:superuser")
+	@access_control("seacat:client:edit")
 	async def update(self, request, *, json_data):
 		"""
 		Edit an existing client
@@ -142,7 +142,7 @@ class ClientHandler(object):
 		)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:client:edit")
 	async def reset_secret(self, request):
 		"""
 		Reset client secret
@@ -155,7 +155,7 @@ class ClientHandler(object):
 		)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:client:edit")
 	async def delete(self, request):
 		"""
 		Delete a client

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -97,7 +97,7 @@ class ChangePasswordHandler(object):
 			"expiration": {"type": "number"},
 		}
 	})
-	@access_control()
+	@access_control("seacat:credentials:edit")
 	async def init_password_change(self, request, *, json_data):
 		"""
 		Send a password reset link to specified user

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -97,7 +97,7 @@ class ChangePasswordHandler(object):
 			"expiration": {"type": "number"},
 		}
 	})
-	@access_control("authz:tenant:admin")
+	@access_control()
 	async def init_password_change(self, request, *, json_data):
 		"""
 		Send a password reset link to specified user

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -32,36 +32,37 @@ class CredentialsHandler(object):
 	def __init__(self, app, credentials_svc):
 		self.CredentialsService = credentials_svc
 
-		self.SessionService = app.get_service('seacatauth.SessionService')
+		self.SessionService = app.get_service("seacatauth.SessionService")
 		self.TenantService = app.get_service("seacatauth.TenantService")
-		self.AuditService = app.get_service('seacatauth.AuditService')
+		self.AuditService = app.get_service("seacatauth.AuditService")
 
 		web_app = app.WebContainer.WebApp
 
-		web_app.router.add_get('/credentials', self.list_credentials)
-		web_app.router.add_put('/idents', self.get_idents_from_ids)
-		web_app.router.add_put('/usernames', self.get_idents_from_ids)  # TODO: Back compat. Remove once UI adapts to the new endpoint.
-		web_app.router.add_get('/locate', self.locate_credentials)
-		web_app.router.add_get('/credentials/{credentials_id}', self.get_credentials)
+		web_app.router.add_get("/credentials", self.list_credentials)
+		web_app.router.add_put("/idents", self.get_idents_from_ids)
+		web_app.router.add_put("/usernames", self.get_idents_from_ids)  # TODO: Back compat. Remove once UI adapts to the new endpoint.
+		web_app.router.add_get("/locate", self.locate_credentials)
+		web_app.router.add_get("/credentials/{credentials_id}", self.get_credentials)
 
-		web_app.router.add_post('/credentials/{provider}', self.create_credentials)
-		web_app.router.add_put('/credentials/{credentials_id}', self.update_credentials)
-		web_app.router.add_delete('/credentials/{credentials_id}', self.delete_credentials)
+		web_app.router.add_post("/credentials/{provider}", self.create_credentials)
+		web_app.router.add_put("/credentials/{credentials_id}", self.update_credentials)
+		web_app.router.add_delete("/credentials/{credentials_id}", self.delete_credentials)
 
-		web_app.router.add_put('/public/credentials', self.update_my_credentials)
+		web_app.router.add_put("/public/credentials", self.update_my_credentials)
 
 		# Providers
-		web_app.router.add_get('/provider/{provider_id}', self.get_provider_info)
-		web_app.router.add_get('/providers', self.list_providers)
-		web_app.router.add_get('/public/provider', self.get_my_provider_info)
-		web_app.router.add_put('/enforce-factors/{credentials_id}', self.enforce_factors)
+		web_app.router.add_get("/provider/{provider_id}", self.get_provider_info)
+		web_app.router.add_get("/providers", self.list_providers)
+		web_app.router.add_get("/public/provider", self.get_my_provider_info)
+		web_app.router.add_put("/enforce-factors/{credentials_id}", self.enforce_factors)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_put('/public/credentials', self.update_my_credentials)
-		web_app_public.router.add_get('/public/provider', self.get_my_provider_info)
+		web_app_public.router.add_put("/public/credentials", self.update_my_credentials)
+		web_app_public.router.add_get("/public/provider", self.get_my_provider_info)
 
 
+	@access_control("seacat:credentials:access")
 	async def list_providers(self, request):
 		"""
 		Get credential providers and their metadata
@@ -72,6 +73,7 @@ class CredentialsHandler(object):
 		return asab.web.rest.json_response(request, providers)
 
 
+	@access_control("seacat:credentials:access")
 	async def get_provider_info(self, request):
 		"""
 		Get the metadata of the requested credential provider.
@@ -99,6 +101,7 @@ class CredentialsHandler(object):
 		return asab.web.rest.json_response(request, response)
 
 
+	@access_control("seacat:credentials:access")
 	async def locate_credentials(self, request):
 		"""
 		Return the IDs of credentials that match the specified ident.
@@ -126,6 +129,7 @@ class CredentialsHandler(object):
 		return asab.web.rest.json_response(request, {"credentials_ids": credentials_ids})
 
 
+	@access_control("seacat:credentials:access")
 	async def list_credentials(self, request):
 		"""
 		List credentials
@@ -297,6 +301,7 @@ class CredentialsHandler(object):
 			"type": "string"
 		}
 	})
+	@access_control("seacat:credentials:access")
 	async def get_idents_from_ids(self, request, *, json_data):
 		"""
 		Get human-intelligible identifiers for a list of credential IDs
@@ -324,10 +329,10 @@ class CredentialsHandler(object):
 			"data": result_data
 		})
 
-
+	@access_control("seacat:credentials:access")
 	async def get_credentials(self, request):
 		"""
-		Get requested credentials' metadata
+		Get requested credentials' detail
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		_, provider_id, _ = credentials_id.split(':', 2)
@@ -341,7 +346,7 @@ class CredentialsHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(CREATE_CREDENTIALS)
-	@access_control()
+	@access_control("seacat:credentials:edit")
 	async def create_credentials(self, request, *, json_data):
 		"""
 		Create new credentials
@@ -373,7 +378,7 @@ class CredentialsHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(UPDATE_CREDENTIALS)
-	@access_control("authz:superuser")
+	@access_control("seacat:credentials:edit")
 	async def update_credentials(self, request, *, json_data):
 		"""
 		Update credentials
@@ -422,6 +427,7 @@ class CredentialsHandler(object):
 			}
 		}
 	})
+	@access_control("seacat:credentials:edit")
 	async def enforce_factors(self, request, *, json_data):
 		"""
 		Specify authentication factors to be enforced from the user
@@ -443,7 +449,7 @@ class CredentialsHandler(object):
 		return asab.web.rest.json_response(request, {"result": result})
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:credentials:edit")
 	async def delete_credentials(self, request, *, credentials_id):
 		"""
 		Delete credentials

--- a/seacatauth/credentials/policy.py
+++ b/seacatauth/credentials/policy.py
@@ -173,8 +173,8 @@ class CredentialsPolicy:
 				return False
 			return self.RBACService.has_resource_access(
 				authz,
-				tenant="*",
-				requested_resources=["authz:superuser"],
+				tenant=None,
+				requested_resources=["seacat:credentials:edit"],
 			)
 
 		policy = self.UpdatePolicy.get(attribute)
@@ -190,9 +190,9 @@ class CredentialsPolicy:
 				return False
 			return self.RBACService.has_resource_access(
 				authz,
-				tenant="*",
-				requested_resources=["authz:superuser"],
-			) == "OK"
+				tenant=None,
+				requested_resources=["seacat:credentials:edit"],
+			)
 
 		# TODO: Check configurable resource-based policy
 		else:

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -69,7 +69,7 @@ class RegistrationHandler(object):
 				"examples": ["6 h", "3d", "1w", 7200]},
 		},
 	})
-	@access_control("authz:tenant:assign")  # TODO: Maybe create a dedicated resource for invitations
+	@access_control("seacat:tenant:assign")  # TODO: Maybe create a dedicated resource for invitations
 	async def create_invitation(self, request, *, tenant, credentials_id, json_data):
 		"""
 		Admin request to register a new user and invite them to the specified tenant.
@@ -116,7 +116,7 @@ class RegistrationHandler(object):
 		return asab.web.rest.json_response(request, payload)
 
 
-	@access_control("authz:tenant:assign")
+	@access_control("seacat:tenant:assign")
 	async def resend_invitation(self, request):
 		"""
 		Resend invitation to an already invited user

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -69,7 +69,7 @@ class RegistrationHandler(object):
 				"examples": ["6 h", "3d", "1w", 7200]},
 		},
 	})
-	@access_control("authz:tenant:admin")  # TODO: Maybe create a dedicated resource for invitations
+	@access_control("authz:tenant:assign")  # TODO: Maybe create a dedicated resource for invitations
 	async def create_invitation(self, request, *, tenant, credentials_id, json_data):
 		"""
 		Admin request to register a new user and invite them to the specified tenant.
@@ -116,7 +116,7 @@ class RegistrationHandler(object):
 		return asab.web.rest.json_response(request, payload)
 
 
-	@access_control("authz:tenant:admin")
+	@access_control("authz:tenant:assign")
 	async def resend_invitation(self, request):
 		"""
 		Resend invitation to an already invited user

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -59,14 +59,25 @@ class CredentialsNotFoundError(KeyError):
 		super().__init__("Credentials not found.", *args)
 
 
-class TenantNotAuthorizedError(AccessDeniedError):
+class UnauthorizedTenantAccessError(AccessDeniedError):
 	"""
-	Credentials do not have access to tenant
+	Session not authorized for the tenant.
+	"""
+	def __init__(self, session_id, tenant, credentials_id=None, *args):
+		self.SessionId = session_id
+		self.CredentialsId = credentials_id
+		self.Tenant = tenant
+		super().__init__("Credentials are not authorized under tenant.", *args)
+
+
+class TenantNotAssignedError(KeyError):
+	"""
+	Credentials do not have the tenant assigned.
 	"""
 	def __init__(self, credentials_id, tenant, *args):
 		self.CredentialsId = credentials_id
 		self.Tenant = tenant
-		super().__init__("Credentials not authorized under tenant.", *args)
+		super().__init__("Credentials do not have the tenant assigned.", *args)
 
 
 class TOTPNotActiveError(Exception):

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -61,6 +61,7 @@ def private_auth_middleware_factory(app):
 
 		request.has_resource_access = has_resource_access
 		request.is_superuser = rbac_svc.is_superuser(request.Session.Authorization.Authz)
+		request.can_access_all_tenants = rbac_svc.can_access_all_tenants(request.Session.Authorization.Authz)
 
 		if require_authentication is False:
 			return await handler(request)

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -59,11 +59,8 @@ def private_auth_middleware_factory(app):
 		def has_resource_access(tenant: str, resource: str) -> bool:
 			return rbac_svc.has_resource_access(request.Session.Authorization.Authz, tenant, [resource])
 
-		def is_superuser() -> bool:
-			return has_resource_access("*", "authz:superuser")
-
 		request.has_resource_access = has_resource_access
-		request.is_superuser = is_superuser
+		request.is_superuser = rbac_svc.is_superuser(request.Session.Authorization.Authz)
 
 		if require_authentication is False:
 			return await handler(request)

--- a/seacatauth/session/handler.py
+++ b/seacatauth/session/handler.py
@@ -40,7 +40,7 @@ class SessionHandler(object):
 		web_app_public.router.add_delete(r"/public/sessions", self.delete_own_sessions)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:session:access")
 	async def session_list(self, request):
 		"""
 		List sessions
@@ -64,7 +64,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, data)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:session:access")
 	async def session_detail(self, request):
 		"""
 		Get session detail
@@ -79,7 +79,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, session)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:session:terminate")
 	async def session_delete(self, request):
 		"""
 		Terminate a session
@@ -104,7 +104,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:session:access")
 	async def search_by_credentials_id(self, request):
 		"""
 		List all active sessions of given credentials
@@ -131,7 +131,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, sessions)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:session:terminate")
 	async def delete_by_credentials_id(self, request, *, credentials_id):
 		"""
 		Terminate all sessions of given credentials

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -428,32 +428,10 @@ class SessionService(asab.Service):
 
 
 	async def delete_all_sessions(self):
-		to_delete = []
-		async for session_dict in self._iterate_raw():
-			to_delete.append(session_dict)
+		await self._delete_sessions_by_filter()
 
-		deleted = 0
-		failed = 0
-		# Delete iteratively so that every session is terminated properly
-		for session_dict in to_delete:
-			try:
-				# TODO: Publish pubsub message for session deletion
-				await self.StorageService.delete(self.SessionCollection, session_dict["_id"])
-				deleted += 1
-			except Exception as e:
-				L.error("Cannot delete session", struct_data={
-					"sid": session_dict["_id"],
-					"error": type(e).__name__
-				})
-				failed += 1
-
-		L.log(asab.LOG_NOTICE, "Sessions deleted", struct_data={
-			"deleted_count": deleted,
-			"failed_count": failed
-		})
-
-	async def delete_sessions_by_credentials_id(self, credentials_id):
-		query_filter = {SessionAdapter.FN.Credentials.Id: credentials_id}
+	async def _delete_sessions_by_filter(self, query_filter=None):
+		query_filter = query_filter or {}
 		to_delete = []
 		async for session_dict in self._iterate_raw(query_filter=query_filter):
 			to_delete.append(session_dict)
@@ -477,6 +455,16 @@ class SessionService(asab.Service):
 			"deleted_count": deleted,
 			"failed_count": failed
 		})
+
+	async def delete_sessions_by_credentials_id(self, credentials_id):
+		await self._delete_sessions_by_filter(
+			query_filter={SessionAdapter.FN.Credentials.Id: credentials_id})
+
+
+	async def delete_sessions_by_tenant_in_scope(self, tenant):
+		await self._delete_sessions_by_filter(
+			query_filter={"{}.{}".format(SessionAdapter.FN.Authorization.Authz, tenant): {"$exists": True}})
+
 
 	def aes_encrypt(self, raw_bytes: bytes):
 		algorithm = cryptography.hazmat.primitives.ciphers.algorithms.AES(self.AESKey)

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -103,7 +103,6 @@ class TenantHandler(object):
 			tenants.append(tenant)
 
 		result = {
-			"result": "OK",
 			"data": tenants,
 			"count": count,
 		}

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -254,7 +254,7 @@ class TenantHandler(object):
 		)
 
 
-	@access_control("authz:tenant:assign")
+	@access_control("seacat:tenant:assign")
 	async def assign_tenant(self, request, *, tenant):
 		"""
 		Grant specified tenant access to requested credentials
@@ -271,7 +271,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@access_control("authz:tenant:assign")
+	@access_control("seacat:tenant:assign")
 	async def unassign_tenant(self, request, *, tenant):
 		"""
 		Revoke specified tenant access to requested credentials

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -176,7 +176,8 @@ class TenantHandler(object):
 			await role_service.create(role)
 			# Assign tenant management resources
 			await role_service.update(role, resources_to_set=[
-				"seacat:tenant:access", "seacat:tenant:edit", "seacat:tenant:assign", "seacat:tenant:delete"])
+				"seacat:tenant:access", "seacat:tenant:edit", "seacat:tenant:assign", "seacat:tenant:delete",
+				"seacat:role:access", "seacat:role:edit", "seacat:role:assign"])
 		except:
 			L.error("Error creating role.", exc_info=True, struct_data={"role": role})
 

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -42,7 +42,7 @@ class TenantHandler(object):
 		web_app.router.add_put("/tenant_assign_many", self.bulk_assign_tenants)
 		web_app.router.add_put("/tenant_unassign_many", self.bulk_unassign_tenants)
 
-		web_app.router.add_get("/tenant_propose", self.propose_tenant)
+		web_app.router.add_get("/tenant_propose", self.propose_tenant_name)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
@@ -62,6 +62,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data=result)
 
 
+	@access_control("seacat:tenant:access")
 	async def search(self, request):
 		"""
 		Search registered tenants
@@ -110,6 +111,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data=result)
 
 
+	@access_control("seacat:tenant:access")
 	async def get(self, request):
 		"""
 		Get tenant detail
@@ -130,7 +132,7 @@ class TenantHandler(object):
 		"example": {
 			"id": "acme-corp"}
 	})
-	@access_control("authz:superuser")
+	@access_control("seacat:tenant:edit")
 	async def create(self, request, *, credentials_id, json_data):
 		"""
 		Create a tenant
@@ -189,7 +191,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data=result)
 
 
-	@access_control("authz:superuser")
+	@access_control("seacat:tenant:delete")
 	async def delete(self, request, *, tenant):
 		"""
 		Delete a tenant. Also delete all its roles and assignments linked to this tenant.
@@ -214,7 +216,7 @@ class TenantHandler(object):
 		"example": {
 			"tenants": ["acme-corp", "my-eshop"]}
 	})
-	@access_control()
+	@access_control("seacat:tenant:assign")
 	async def set_tenants(self, request, *, json_data):
 		"""
 		Specify a set of accessible tenants for requested credentials ID
@@ -274,6 +276,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
+	@access_control("seacat:tenant:access")
 	async def get_tenants_by_credentials(self, request):
 		"""
 		Get list of authorized tenants for requested credentials
@@ -290,6 +293,7 @@ class TenantHandler(object):
 		"items": {"type": "string"},
 		"example": ["mongodb:default:abc123def456", "htpasswd:local:zdenek"],
 	})
+	@access_control("seacat:tenant:access")
 	async def get_tenants_batch(self, request, *, json_data):
 		"""
 		Get list of authorized tenants for each listed credential ID
@@ -301,7 +305,8 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, response)
 
 
-	async def propose_tenant(self, request):
+	@access_control("seacat:tenant:access")
+	async def propose_tenant_name(self, request):
 		"""
 		Propose name for a new tenant.
 		"""
@@ -341,6 +346,7 @@ class TenantHandler(object):
 				"my-eshop": []}},
 	})
 	@access_control("authz:superuser")
+	# TODO: For single tenant bulks, require only "seacat:tenant:assign"
 	async def bulk_assign_tenants(self, request, *, json_data):
 		"""
 		Grant tenant access and/or assign roles to a list of credentials
@@ -417,6 +423,7 @@ class TenantHandler(object):
 			"result": "OK"}
 		return asab.web.rest.json_response(request, data=data)
 
+
 	@asab.web.rest.json_schema_handler({
 		"type": "object",
 		"required": ["credential_ids", "tenants"],
@@ -446,6 +453,7 @@ class TenantHandler(object):
 				"my-eshop": []}},
 	})
 	@access_control("authz:superuser")
+	# TODO: For single tenant bulks, require only "seacat:tenant:assign"
 	async def bulk_unassign_tenants(self, request, *, json_data):
 		"""
 		Revoke tenant access and/or unassign roles from a list of credentials

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -238,8 +238,8 @@ class TenantHandler(object):
 		- oAuth:
 			- authz:superuser
 		"""
-		result = await self.TenantService.delete_tenant(tenant)
-		return asab.web.rest.json_response(request, data=result)
+		await self.TenantService.delete_tenant(tenant)
+		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
 	@asab.web.rest.json_schema_handler({

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -166,8 +166,8 @@ class TenantHandler(object):
 		# Assign tenant
 		try:
 			await self.TenantService.assign_tenant(credentials_id, tenant)
-		except:
-			L.error("Error assigning tenant.", exc_info=True, struct_data={"cid": credentials_id, "tenant": tenant})
+		except Exception as e:
+			L.error("Error assigning tenant: {}".format(e), exc_info=True, struct_data={"cid": credentials_id, "tenant": tenant})
 
 		# Create role
 		role = "{}/admin".format(tenant)
@@ -178,14 +178,14 @@ class TenantHandler(object):
 			await role_service.update(role, resources_to_set=[
 				"seacat:tenant:access", "seacat:tenant:edit", "seacat:tenant:assign", "seacat:tenant:delete",
 				"seacat:role:access", "seacat:role:edit", "seacat:role:assign"])
-		except:
-			L.error("Error creating role.", exc_info=True, struct_data={"role": role})
+		except Exception as e:
+			L.error("Error creating admin role: {}".format(e), exc_info=True, struct_data={"role": role})
 
 		# Assign the admin role to the user
 		try:
 			await role_service.assign_role(credentials_id, role)
-		except:
-			L.error("Error assigning role.", exc_info=True, struct_data={"cid": credentials_id, "role": role})
+		except Exception as e:
+			L.error("Error assigning role: {}".format(e), exc_info=True, struct_data={"cid": credentials_id, "role": role})
 
 		return asab.web.rest.json_response(
 			request, data={"result": "OK", "id": tenant_id})

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -147,7 +147,7 @@ class TenantHandler(object):
 		"example": {
 			"id": "acme-corp"}
 	})
-	@access_control("seacat:tenant:create")
+	@access_control("authz:superuser")  # TODO: "seacat:tenant:create"
 	async def create(self, request, *, credentials_id, json_data):
 		"""
 		Create a tenant
@@ -342,7 +342,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, response)
 
 
-	@access_control("seacat:tenant:access")
+	@access_control()
 	async def propose_tenant_name(self, request):
 		"""
 		Propose name for a new tenant.

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -176,14 +176,14 @@ class TenantHandler(object):
 				"very_corporate": True,
 				"schema": "ECS"}}
 	})
-	@access_control("authz:tenant:admin")
+	@access_control("seacat:tenant:edit")
 	async def update_tenant(self, request, *, json_data, tenant):
 		"""
 		Update tenant description and/or its structured data
 		---
 		security:
 		- oAuth:
-			- authz:tenant:admin
+			- seacat:tenant:edit
 		"""
 		result = await self.TenantService.update_tenant(tenant, **json_data)
 		return asab.web.rest.json_response(request, data=result)
@@ -221,7 +221,7 @@ class TenantHandler(object):
 
 		The credentials entity will be granted access to the listed tenants
 		and revoked access to the tenants that are not listed.
-		The caller needs to have access to `authz:tenant:admin` resource for each tenant whose access
+		The caller needs to have access to `authz:tenant:assign` resource for each tenant whose access
 		is being granted or revoked.
 		"""
 		credentials_id = request.match_info["credentials_id"]
@@ -238,7 +238,7 @@ class TenantHandler(object):
 		)
 
 
-	@access_control("authz:tenant:admin")
+	@access_control("authz:tenant:assign")
 	async def assign_tenant(self, request, *, tenant):
 		"""
 		Grant specified tenant access to requested credentials
@@ -246,7 +246,7 @@ class TenantHandler(object):
 		---
 		security:
 		- oAuth:
-			- authz:tenant:admin
+			- authz:tenant:assign
 		"""
 		await self.TenantService.assign_tenant(
 			request.match_info["credentials_id"],
@@ -255,7 +255,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@access_control("authz:tenant:admin")
+	@access_control("authz:tenant:assign")
 	async def unassign_tenant(self, request, *, tenant):
 		"""
 		Revoke specified tenant access to requested credentials
@@ -265,7 +265,7 @@ class TenantHandler(object):
 		---
 		security:
 		- oAuth:
-			- authz:tenant:admin
+			- authz:tenant:assign
 		"""
 		await self.TenantService.unassign_tenant(
 			request.match_info["credentials_id"],

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -146,7 +146,7 @@ class TenantHandler(object):
 		"example": {
 			"id": "acme-corp"}
 	})
-	@access_control("seacat:tenant:edit")
+	@access_control("seacat:tenant:create")
 	async def create(self, request, *, credentials_id, json_data):
 		"""
 		Create a tenant

--- a/seacatauth/tenant/providers/mongodb.py
+++ b/seacatauth/tenant/providers/mongodb.py
@@ -107,7 +107,7 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 			u.set("data", data)
 		tenant_id = await u.execute()
 
-		L.log(asab.LOG_NOTICE, "Tenant data updated", struct_data={"tenant": tenant_id})
+		L.log(asab.LOG_NOTICE, "Tenant data updated.", struct_data={"tenant": tenant_id})
 		return "OK"
 
 
@@ -115,34 +115,8 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 		"""
 		Delete tenant. Also delete all its roles and assignments.
 		"""
-
-		# Unassign and delete tenant roles
-		role_svc = self.App.get_service("seacatauth.RoleService")
-		tenant_roles = (await role_svc.list(tenant=tenant_id))["data"]
-		for role in tenant_roles:
-			role_id = role["_id"]
-
-			# Skip global roles
-			if role_id.startswith("*/"):
-				continue
-
-			# Delete role
-			try:
-				await role_svc.delete(role_id)
-			except KeyError:
-				# Role has probably been improperly deleted before; continue
-				L.error("Role not found", struct_data={
-					"role_id": role_id
-				})
-				continue
-
-		# Unassign tenant from credentials
-		await self.delete_tenant_assignments(tenant_id)
-
-		# Delete tenant
 		await self.MongoDBStorageService.delete(self.TenantsCollection, tenant_id)
-		L.log(asab.LOG_NOTICE, "Tenant deleted", struct_data={"tenant": tenant_id})
-		return True
+		L.log(asab.LOG_NOTICE, "Tenant deleted.", struct_data={"tenant": tenant_id})
 
 
 	async def get(self, tenant_id) -> Optional[dict]:

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -132,7 +132,7 @@ class TenantService(asab.Service):
 					"message": message,
 				}
 			# Check permission
-			if not rbac_svc.has_resource_access(session.Authorization.Authz, tenant, ["authz:tenant:assign"]):
+			if not rbac_svc.has_resource_access(session.Authorization.Authz, tenant, ["seacat:tenant:assign"]):
 				message = "Not authorized for tenant un/assignment"
 				L.error(message, struct_data={
 					"agent_cid": session.Credentials.Id,

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -90,8 +90,9 @@ class TenantService(asab.Service):
 		try:
 			# Create admin role in tenant
 			await role_service.create(role_id)
-			# Assign "authz:tenant:admin" resource
-			await role_service.update(role_id, resources_to_set=["authz:tenant:admin"])
+			# Assign tenant management resources
+			await role_service.update(role_id, resources_to_set=[
+				"seacat:tenant:access", "seacat:tenant:edit", "seacat:tenant:assign"])
 			role_created = True
 		except Exception as e:
 			role_created = False
@@ -191,7 +192,7 @@ class TenantService(asab.Service):
 					"message": message,
 				}
 			# Check permission
-			if not rbac_svc.has_resource_access(session.Authorization.Authz, tenant, ["authz:tenant:admin"]):
+			if not rbac_svc.has_resource_access(session.Authorization.Authz, tenant, ["authz:tenant:assign"]):
 				message = "Not authorized for tenant un/assignment"
 				L.error(message, struct_data={
 					"agent_cid": session.Credentials.Id,

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import uuid
 
 import asab
 import asab.storage.exceptions

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -64,6 +64,8 @@ class TenantService(asab.Service):
 
 
 	async def delete_tenant(self, tenant_id: str):
+		session_service = self.App.get_service("seacatauth.SessionService")
+
 		# Unassign and delete tenant roles
 		role_svc = self.App.get_service("seacatauth.RoleService")
 		tenant_roles = (await role_svc.list(tenant=tenant_id, exclude_global=True))["data"]
@@ -83,6 +85,9 @@ class TenantService(asab.Service):
 
 		# Delete tenant from provider
 		await self.TenantsProvider.delete(tenant_id)
+
+		# Delete sessions that have the tenant in scope
+		await session_service.delete_sessions_by_tenant_in_scope(tenant_id)
 
 
 	def get_provider(self):

--- a/test/test_rbac.py
+++ b/test/test_rbac.py
@@ -9,7 +9,7 @@ class RBACTestCase(unittest.TestCase):
 
 	authz_test_data = {
 		"*": ["post:read", "post:write", "post:edit"],
-		"first-tenant": ["post:read", "post:write", "post:edit", "authz:tenant:admin"],
+		"first-tenant": ["post:read", "post:write", "post:edit", "seacat:tenant:access"],
 	}
 
 	notenant_authz_test_data = {
@@ -62,7 +62,7 @@ class RBACTestCase(unittest.TestCase):
 		access = RBACService.has_resource_access(
 			self.authz_test_data,
 			"first-tenant",
-			["authz:tenant:admin"]
+			["seacat:tenant:access"]
 		)
 		self.assertTrue(access)
 
@@ -119,7 +119,7 @@ class RBACTestCase(unittest.TestCase):
 		access = RBACService.has_resource_access(
 			self.authz_test_data,
 			"*",
-			["authz:tenant:admin"]
+			["seacat:tenant:access"]
 		)
 		self.assertTrue(access)
 
@@ -143,20 +143,20 @@ class RBACTestCase(unittest.TestCase):
 		access = RBACService.has_resource_access(
 			self.authz_test_data,
 			"*",
-			["authz:tenant:admin", "post:edit"]
+			["seacat:tenant:access", "post:edit"]
 		)
 		self.assertTrue(access)
 
 		access = RBACService.has_resource_access(
 			self.authz_test_data,
 			"*",
-			["authz:tenant:admin", "post:delete"]
+			["seacat:tenant:access", "post:delete"]
 		)
 		self.assertFalse(access)
 
 		# Check superuser
 		access = RBACService.has_resource_access(
-			self.superuser_authz_test_data, "*", ["authz:tenant:admin", "post:edit"]
+			self.superuser_authz_test_data, "*", ["seacat:tenant:access", "post:edit"]
 		)
 		self.assertTrue(access)
 
@@ -176,7 +176,7 @@ class RBACTestCase(unittest.TestCase):
 		access = RBACService.has_resource_access(
 			self.authz_test_data,
 			None,
-			["authz:tenant:admin"]
+			["seacat:tenant:access"]
 		)
 		self.assertFalse(access)
 
@@ -200,12 +200,12 @@ class RBACTestCase(unittest.TestCase):
 		access = RBACService.has_resource_access(
 			self.authz_test_data,
 			None,
-			["post:write", "authz:tenant:admin"]
+			["post:write", "seacat:tenant:access"]
 		)
 		self.assertFalse(access)
 
 		# Check superuser
-		access = RBACService.has_resource_access(self.superuser_authz_test_data, None, ["authz:tenant:admin", "post:edit"])
+		access = RBACService.has_resource_access(self.superuser_authz_test_data, None, ["seacat:tenant:access", "post:edit"])
 		self.assertTrue(access)
 
 


### PR DESCRIPTION
closes #190 

# Breaking changes
- Admin API endpoints are now protected by specific resources.
- Seacat Admin built-in resources are not editable anymore.


# Changes
- Implemented built-in Seacat Admin resources as specified in #190. They are automatically created/update on service startup.

- Resource detail may now include `"editable": false` and/or `"global_only": true`.
**Non-editable** resources are Seacat Admin built-in resources and cannot be modified or deleted (not even by a supersuser).
**Global-only** resources cannot be added to tenant proper roles, only to global roles.

Example:
_Request: `GET /resource/authz:superuser`_
_Response:_
```json
{
	"_id": "authz:superuser",
	"_v": 22,
	"_c": "2021-07-01T07:34:17.899000Z",
	"_m": "2023-04-11T10:29:46.376000Z",
	"description": "Grants superuser access, including the access to all tenants.",
	"editable": false,
	"global_only": true
}
```

- Resource list can now exclude global-only resources from the results by adding `exclude_global_only=true` in the request query, e.g. `GET /resources?exclude_global_only=true`.
- Tenant list  `GET /tenants` now includes only tenants that the request is authorized for with the resource `seacat:tenant:access`. Only `authz:superuser` and `authz:tenant:access` enables the user to search all tenants.
