### PR TITLE
External login refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@
 - Every cookie introspection should be paired with a cookie entrypoint (#156, PLUM Sprint 230324)
 - Bouncer module replaced by cookie entrypoint (#156, PLUM Sprint 230324)
 - Dropped support for custom cookie domains in the configuration (#156, PLUM Sprint 230324)
+- External login status messages changed (#185, PLUM Sprint 230324)
 
 ### Fix
 - Improve last login search performance (#173, PLUM Sprint 230324)
 
 ### Features
 - Per-client configurable authorization, login and cookies (#156, PLUM Sprint 230324)
+- External login ident stored (#185, PLUM Sprint 230324)
 
 ### Refactoring
 - OpenAPI docs updated (#181, PLUM Sprint 230324)

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -169,7 +169,7 @@ class ExternalLoginHandler(object):
 				"cid": credentials_id,
 				"type": login_provider_type
 			})
-			response = self._my_account_redirect_response(state=state, error="external_login_already_added")
+			response = self._my_account_redirect_response(state=state, error="external_login_already_activated")
 			return response
 
 		login_provider = self.ExternalLoginService.get_provider(login_provider_type)
@@ -181,6 +181,7 @@ class ExternalLoginHandler(object):
 		sub = user_info.get("sub")
 		if sub is None:
 			L.error("Cannot obtain 'sub' field from external login provider", struct_data={
+				"cid": credentials_id,
 				"type": login_provider_type
 			})
 			return self._my_account_redirect_response(state=state, error="external_login_failed")
@@ -197,10 +198,11 @@ class ExternalLoginHandler(object):
 
 		if already_used:
 			L.error("External login already used by different credentials", struct_data={
+				"request_cid": credentials_id,
 				"type": login_provider_type,
 				"sub": sub,
 			})
-			response = self._my_account_redirect_response(state=state, error="external_login_already_in_use")
+			response = self._my_account_redirect_response(state=state, error="external_login_not_activated")
 			return response
 
 		# Update credentials
@@ -212,7 +214,7 @@ class ExternalLoginHandler(object):
 				"type": login_provider_type,
 				"sub": sub,
 			})
-			response = self._my_account_redirect_response(state=state, error="external_login_failed")
+			response = self._my_account_redirect_response(state=state, error="external_login_not_activated")
 			return response
 
 		L.log(asab.LOG_NOTICE, "External login successfully added", struct_data={
@@ -221,7 +223,7 @@ class ExternalLoginHandler(object):
 		})
 
 		# Redirect to home screen
-		return self._my_account_redirect_response(state=state, result="external_login_added")
+		return self._my_account_redirect_response(state=state, result="external_login_activated")
 
 
 	@access_control()

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -247,18 +247,23 @@ class ExternalLoginHandler(object):
 
 
 	def _login_redirect_response(self, state=None, error=None):
-		query_params = []
+		# TODO: Revise with custom per-client login URIs
 		if state is not None:
-			query_params.append(("state", state))
-		if error is not None:
-			query_params.append(("error", error))
-		if len(query_params) > 0:
-			redirect_uri = "{}?{}".format(
-				self.ExternalLoginService.LoginScreenUrl,
-				urllib.parse.urlencode(query_params)
-			)
+			query = "?state={}".format(state)
 		else:
-			redirect_uri = self.ExternalLoginService.LoginScreenUrl
+			query = ""
+
+		if error is not None:
+			fragment_query = "?error={}".format(error)
+		else:
+			fragment_query = ""
+
+		redirect_uri = "{}{}#{}{}".format(
+			self.ExternalLoginService.AuthUiBaseUrl,
+			query,
+			self.ExternalLoginService.LoginUiFragmentPath,
+			fragment_query,
+		)
 
 		response = aiohttp.web.HTTPFound(
 			redirect_uri,
@@ -273,20 +278,28 @@ class ExternalLoginHandler(object):
 
 
 	def _my_account_redirect_response(self, state=None, error=None, result=None):
-		query_params = []
+		# TODO: Revise with custom per-client login URIs
 		if state is not None:
-			query_params.append(("state", state))
-		if error is not None:
-			query_params.append(("error", error))
-		if result is not None:
-			query_params.append(("result", result))
-		if len(query_params) > 0:
-			redirect_uri = "{}?{}".format(
-				self.ExternalLoginService.HomeScreenUrl,
-				urllib.parse.urlencode(query_params)
-			)
+			query = "?state={}".format(state)
 		else:
-			redirect_uri = self.ExternalLoginService.HomeScreenUrl
+			query = ""
+
+		fragment_query_params = []
+		if error is not None:
+			fragment_query_params.append(("error", error))
+		if result is not None:
+			fragment_query_params.append(("result", result))
+		if len(fragment_query_params) > 0:
+			hash_query = "?{}".format(urllib.parse.urlencode(fragment_query_params))
+		else:
+			hash_query = ""
+
+		redirect_uri = "{}{}#{}{}".format(
+			self.ExternalLoginService.AuthUiBaseUrl,
+			query,
+			self.ExternalLoginService.HomeUiFragmentPath,
+			hash_query,
+		)
 
 		response = aiohttp.web.HTTPFound(
 			redirect_uri,

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -169,7 +169,7 @@ class ExternalLoginHandler(object):
 				"cid": credentials_id,
 				"type": login_provider_type
 			})
-			response = self._my_account_redirect_response(state=state, error="external_login_failed")
+			response = self._my_account_redirect_response(state=state, error="external_login_already_added")
 			return response
 
 		login_provider = self.ExternalLoginService.get_provider(login_provider_type)
@@ -200,7 +200,7 @@ class ExternalLoginHandler(object):
 				"type": login_provider_type,
 				"sub": sub,
 			})
-			response = self._my_account_redirect_response(state=state, error="external_login_failed")
+			response = self._my_account_redirect_response(state=state, error="external_login_already_in_use")
 			return response
 
 		# Update credentials

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -221,7 +221,7 @@ class ExternalLoginHandler(object):
 		})
 
 		# Redirect to home screen
-		return self._my_account_redirect_response(state=state, error="external_login_successful")
+		return self._my_account_redirect_response(state=state, result="external_login_successful")
 
 
 	@access_control()

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -207,7 +207,8 @@ class ExternalLoginHandler(object):
 
 		# Update credentials
 		try:
-			await self.ExternalLoginService.create(credentials_id, login_provider_type, sub)
+			await self.ExternalLoginService.create(
+				credentials_id, login_provider_type, sub, user_info.get("email"), user_info.get("ident"))
 		except Exception as e:
 			L.error("{} when creating external login credentials: {}".format(type(e).__name__, str(e)), struct_data={
 				"cid": credentials_id,

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -221,7 +221,7 @@ class ExternalLoginHandler(object):
 		})
 
 		# Redirect to home screen
-		return self._my_account_redirect_response(state=state, result="external_login_successful")
+		return self._my_account_redirect_response(state=state, result="external_login_added")
 
 
 	@access_control()

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -150,6 +150,7 @@ class GenericOAuth2Login(asab.ConfigObject):
 			user_info["sub"] = data_dict["sub"]
 		if "email" in data_dict.keys():
 			user_info["email"] = data_dict["email"]
+			user_info["ident"] = data_dict["email"]
 		return user_info
 
 	def get_login_authorize_uri(self, state=None):

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -58,6 +58,9 @@ class GenericOAuth2Login(asab.ConfigObject):
 		self.Scope = self.Config.get("scope")
 		assert self.Scope is not None
 
+		self.Ident = self.Config.get("ident", "email")
+		assert self.Ident is not None
+
 		# Label for "Sign up with {ext_login_provider}" button
 		# TODO: Make this i18n-compatible (like login descriptors)
 		# TODO: Separate label for "Add external login" button
@@ -150,7 +153,8 @@ class GenericOAuth2Login(asab.ConfigObject):
 			user_info["sub"] = data_dict["sub"]
 		if "email" in data_dict.keys():
 			user_info["email"] = data_dict["email"]
-			user_info["ident"] = data_dict["email"]
+		if self.Ident in data_dict.keys():
+			user_info["ident"] = data_dict[self.Ident]
 		return user_info
 
 	def get_login_authorize_uri(self, state=None):

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -84,7 +84,8 @@ class GenericOAuth2Login(asab.ConfigObject):
 			("response_type", "code"),
 			("client_id", self.ClientId),
 			("scope", self.Scope),
-			("redirect_uri", redirect_uri)
+			("redirect_uri", redirect_uri),
+			("prompt", "select_account"),
 		]
 		if state is not None:
 			query_params.append(("state", state))

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -68,5 +68,7 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 			user_info["sub"] = data["id"]
 		if "email" in data:
 			user_info["email"] = data["email"]
+		if "login" in data:
+			user_info["ident"] = data["login"]
 
 		return user_info

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -26,6 +26,7 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 		"userinfo_uri": "https://api.github.com/user",
 		"scope": "",  # Scope is not required
 		"label": "Sign in with Github",
+		"ident": "login",
 	}
 
 	def __init__(self, external_login_svc, config_section_name):
@@ -68,7 +69,7 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 			user_info["sub"] = data["id"]
 		if "email" in data:
 			user_info["email"] = data["email"]
-		if "login" in data:
-			user_info["ident"] = data["login"]
+		if self.Ident in data:
+			user_info["ident"] = data[self.Ident]
 
 		return user_info

--- a/seacatauth/external_login/service.py
+++ b/seacatauth/external_login/service.py
@@ -63,7 +63,7 @@ class ExternalLoginService(asab.Service):
 		)
 
 
-	async def create(self, credentials_id: str, provider_type: str, sub: str):
+	async def create(self, credentials_id: str, provider_type: str, sub: str, email: str = None, ident: str = None):
 		upsertor = self.StorageService.upsertor(
 			self.ExternalLoginCollection,
 			obj_id=self._make_id(provider_type, sub)
@@ -71,6 +71,10 @@ class ExternalLoginService(asab.Service):
 		upsertor.set("t", provider_type)
 		upsertor.set("s", sub)
 		upsertor.set("cid", credentials_id)
+		if email is not None:
+			upsertor.set("e", email)
+		if ident is not None:
+			upsertor.set("i", ident)
 
 		elcid = await upsertor.execute(event_type=EventTypes.EXTERNAL_LOGIN_CREATED)
 		L.log(asab.LOG_NOTICE, "External login credential created", struct_data={

--- a/seacatauth/external_login/service.py
+++ b/seacatauth/external_login/service.py
@@ -28,9 +28,9 @@ class ExternalLoginService(asab.Service):
 		self.AuthenticationService = app.get_service("seacatauth.AuthenticationService")
 		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
 
-		auth_webui_base_url = asab.Config.get("general", "auth_webui_base_url")
-		self.HomeScreenUrl = auth_webui_base_url.rstrip("/")
-		self.LoginScreenUrl = "{}/#/login".format(auth_webui_base_url.rstrip("/"))
+		self.AuthUiBaseUrl = asab.Config.get("general", "auth_webui_base_url").rstrip("/")
+		self.HomeUiFragmentPath = "/"
+		self.LoginUiFragmentPath = "/login"
 		self.ExternalLoginPath = "/public/ext-login/{ext_login_provider}"
 		self.AddExternalLoginPath = "/public/ext-login-add/{ext_login_provider}"
 

--- a/seacatauth/feature/handler.py
+++ b/seacatauth/feature/handler.py
@@ -33,8 +33,4 @@ class FeatureHandler(object):
 		Get public login and registration features
 		"""
 		features = await self.FeatureService.get_features()
-		response = {
-			"data": features,
-			"result": "OK",
-		}
-		return asab.web.rest.json_response(request, response)
+		return asab.web.rest.json_response(request, data=features)


### PR DESCRIPTION
depends on https://github.com/TeskaLabs/seacat-auth-webui/pull/26

- **`BREAKING`** refactored external login error messages
- **`BREAKING`** refactored /public/features response
- store email and ident with new external logins