### PR TITLE
Add tenants to M2M session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fix
 - Improve last login search performance (#173, PLUM Sprint 230324)
+- M2M session now has access to all the M2M credentials' assigned tenants (#186, PLUM Sprint 230324)
 
 ### Features
 - Per-client configurable authorization, login and cookies (#156, PLUM Sprint 230324)


### PR DESCRIPTION
M2M session now has access to all the M2M credentials' assigned tenants.