### PR TITLE
Bulk-unassign tenants using "UNASSIGN-TENANT"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bouncer module replaced by cookie entrypoint (#156, PLUM Sprint 230324)
 - Dropped support for custom cookie domains in the configuration (#156, PLUM Sprint 230324)
 - External login status messages changed (#185, PLUM Sprint 230324)
+- Bulk-unassign tenants using "UNASSIGN-TENANT" (#189, PLUM Sprint 230324)
 
 ### Fix
 - Improve last login search performance (#173, PLUM Sprint 230324)
@@ -20,6 +21,7 @@
 
 ### Refactoring
 - OpenAPI docs updated (#181, PLUM Sprint 230324)
+- Bulk-unassign tenants using "UNASSIGN-TENANT" (#189, PLUM Sprint 230324)
 
 ---
 

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -81,6 +81,13 @@ class RoleHandler(object):
 			description: Show only roles that contain the specified resource
 			schema:
 				type: string
+		-	name: exclude_global
+			in: query
+			description: Show only proper tenant roles
+			schema:
+				type: string
+				enum:
+				- true
 		"""
 		return await self._list(request, tenant=tenant)
 
@@ -90,8 +97,9 @@ class RoleHandler(object):
 		if limit is not None:
 			limit = int(limit)
 		resource = request.query.get("resource")
+		exclude_global = request.query.get("exclude_global", "false") == "true"
 
-		result = await self.RoleService.list(tenant, page, limit, resource=resource)
+		result = await self.RoleService.list(tenant, page, limit, resource=resource, exclude_global=exclude_global)
 		return asab.web.rest.json_response(request, result)
 
 

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -78,12 +78,12 @@ class RoleHandler(object):
 				type: integer
 		-	name: resource
 			in: query
-			description: Show only roles that contain the specified resource
+			description: Show only roles that contain the specified resource.
 			schema:
 				type: string
 		-	name: exclude_global
 			in: query
-			description: Show only proper tenant roles
+			description: Show only proper tenant roles, without globals.
 			schema:
 				type: string
 				enum:

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -48,11 +48,15 @@ class RoleService(asab.Service):
 		self, tenant: Optional[str] = None, page: int = 0, limit: int = None, *,
 		resource: str = None,
 		active_only: bool = False,
+		exclude_global: bool = False,
 	):
 		collection = self.StorageService.Database[self.RoleCollection]
 		query_filter = {}
 		if tenant is not None:
-			query_filter["tenant"] = {"$in": [tenant, None]}
+			if exclude_global:
+				query_filter["tenant"] = {"$in": [tenant]}
+			else:
+				query_filter["tenant"] = {"$in": [tenant, None]}
 		if resource is not None:
 			query_filter["resources"] = resource
 		if active_only is True:

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -478,6 +478,9 @@ class TenantHandler(object):
 					# This also automatically unassigns all the tenant's roles
 					try:
 						await self.TenantService.unassign_tenant(credential_id, tenant)
+					except KeyError:
+						L.info("Skipping: Tenant not assigned.", struct_data={
+							"cid": credential_id, "tenant": tenant})
 					except Exception as e:
 						L.error("Cannot unassign tenant: {}".format(e), exc_info=True, struct_data={
 							"cid": credential_id, "tenant": tenant})

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -316,7 +316,7 @@ class TenantHandler(object):
 		"properties": {
 			"credential_ids": {
 				"type": "array",
-				"description": "List of the IDs of credentials to manage",
+				"description": "List of the IDs of credentials to manage.",
 				"items": {"type": "string"}},
 			"tenants": {
 				"type": "object",
@@ -423,7 +423,7 @@ class TenantHandler(object):
 		"properties": {
 			"credential_ids": {
 				"type": "array",
-				"description": "List of the IDs of credentials to manage",
+				"description": "List of the IDs of credentials to manage.",
 				"items": {"type": "string"}},
 			"tenants": {
 				"type": "object",
@@ -431,19 +431,22 @@ class TenantHandler(object):
 					"Tenants and roles to be unassigned. \n\n"
 					"The keys are the IDs of tenants to be revoked access to. The values are arrays of the respective "
 					"tenant's roles to be unassigned. \n\n"
-					"To completely revoke credentials' access to the tenant, leave the role array empty. \n\n"
-					"To unassign global roles, list them under the `'*'` key.",
+					"To completely revoke credentials' access to the tenant, provide `\"UNASSIGN-TENANT\"` as the "
+					"tenant value, instead of the array of roles. \n\n"
+					"To unassign global roles, list them under the `\"*\"` key.",
 				"patternProperties": {
 					r"^\*$|^[a-z][a-z0-9._-]{2,31}$": {
-						"type": "array",
-						"items": {"type": "string"}}}}},
+						"anyOf": [
+							{"type": "array", "items": {"type": "string"}},
+							{"type": "string", "enum": ["UNASSIGN-TENANT"]}
+						]}}}},
 		"example": {
 			"credential_ids": [
 				"mongodb:default:abc123def456", "htpasswd:local:zdenek"],
 			"tenants": {
 				"*": ["*/global-editor"],
 				"acme-corp": ["acme-corp/user", "acme-corp/supervisor"],
-				"my-eshop": []}},
+				"my-eshop": "UNASSIGN-TENANT"}},
 	})
 	@access_control("authz:superuser")
 	async def bulk_unassign_tenants(self, request, *, json_data):
@@ -459,6 +462,8 @@ class TenantHandler(object):
 
 		# Verify that roles are listed under their proper tenant
 		for tenant, roles in json_data["tenants"].items():
+			if roles == "UNASSIGN-TENANT":
+				continue
 			for role in roles:
 				t, _ = role.split("/", 1)
 				if t != tenant:
@@ -467,9 +472,9 @@ class TenantHandler(object):
 		error_details = []
 		for tenant, roles in json_data["tenants"].items():
 			for credential_id in json_data["credential_ids"]:
-				if len(roles) == 0:
-					# If no roles are listed under the tenant (e.g. `"my-tenant": []`),
-					# revoke access to the tenant completely.
+				if roles == "UNASSIGN-TENANT":
+					# If "UNASSIGN-TENANT" is provided instead of the role array
+					# (e.g. `"my-tenant": "UNASSIGN-TENANT"`), revoke access to the tenant completely.
 					# This also automatically unassigns all the tenant's roles
 					try:
 						await self.TenantService.unassign_tenant(credential_id, tenant)


### PR DESCRIPTION
closes #179 

- In bulk access revoke call `PUT /tenant_unassign_many`, unassign tenant by specifying `"UNASSIGN-TENANT"` as the tenant value, instead of an empty array. This should be more comprehensive.
- Role list `GET /role/<TENANT>` now has an option to exclude global roles. To use it, add `exclude_global=true` to the query string.