### PR TITLE
Fix pymongo import error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8
-        pip install git+https://github.com/TeskaLabs/asab.git@v22.06-rc7
+        pip install git+https://github.com/TeskaLabs/asab.git
     
     - name: Lint with flake8
       run: |
@@ -57,7 +57,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install bson
         pip install pymongo
-        pip install git+https://github.com/TeskaLabs/asab.git@v22.06-rc7#egg=asab[encryption]
+        pip install git+https://github.com/TeskaLabs/asab.git#egg=asab[encryption]
     
     - name: Test with unittest
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - M2M session now has access to all the M2M credentials' assigned tenants (#186, PLUM Sprint 230324)
 - Fix tenant check in role assignment (#187, PLUM Sprint 230324)
 - Fix credential service lookup (#192, PLUM Sprint 230412)
+- Fix pymongo import error (#193, PLUM Sprint 230412)
 
 ### Features
 - Per-client configurable authorization, login and cookies (#156, PLUM Sprint 230324)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN apk add --no-cache  \
 && pip3 install --no-cache-dir \
     aiohttp \
     aiosmtplib \
-    bson \
     motor \
     cryptography \
     jwcrypto>=0.9.1 \
@@ -44,8 +43,8 @@ RUN apk add --no-cache  \
     pyotp \
     webauthn \
     pyyaml \
-    bson \
-    git+https://github.com/TeskaLabs/asab.git@v22.06-rc7
+    pymongo \
+    git+https://github.com/TeskaLabs/asab.git
 
 RUN mkdir -p /app/seacat-auth
 WORKDIR /app/seacat-auth


### PR DESCRIPTION
- Fix dockerfile packages to resolve the following startup error
```
  File "/app/seacat-auth/seacatauth/session/service.py", line 16, in <module>
    import pymongo
  File "/usr/lib/python3.10/site-packages/pymongo/__init__.py", line 89, in <module>
    from pymongo.collection import ReturnDocument
  File "/usr/lib/python3.10/site-packages/pymongo/collection.py", line 35, in <module>
    from bson.raw_bson import RawBSONDocument
  File "/usr/lib/python3.10/site-packages/bson/raw_bson.py", line 56, in <module>
    from bson import _get_object_size, _raw_to_dict
ImportError: cannot import name '_get_object_size' from 'bson' (/usr/lib/python3.10/site-packages/bson/__init__.py)

```
- Remove ASAB version tags since the PEP440 issue in ASAB has been fixed.