### PR TITLE
Client session expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 - User impersonation (#188, PLUM Sprint 230509)
+- Configurable client session expiration (#204, PLUM Sprint 230509)
 
 ---
 


### PR DESCRIPTION
Use the new client attribute `session_expiration` to configure the initial duration of the client's sessions. The value can be either an integer or a float specifying the duration in seconds, or a time-unit string, such as `4 h` or `5 d`.

**`BREAKING`** Session expiration can no longer be specified in the authorize query.