### PR TITLE
Do not assign the tenant "*" in bulk assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fix
 - Fix login redirect at the authorize endpoint (#203, PLUM Sprint 230509)
+- Do not assign the tenant "*" in bulk assignment (#209, PLUM Sprint 230519)
 
 ### Features
 - User impersonation (#188, PLUM Sprint 230509)

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -423,21 +423,22 @@ class TenantHandler(object):
 		error_details = []
 		for tenant, roles in json_data["tenants"].items():
 			for credential_id in json_data["credential_ids"]:
-				success = False
-				try:
-					await self.TenantService.assign_tenant(
-						credential_id, tenant, verify_tenant=False, verify_credentials=False)
-					success = True
-				except asab.exceptions.Conflict:
-					L.info("Skipping: Tenant already assigned.", struct_data={
-						"cid": credential_id, "tenant": tenant})
-					success = True
-				except Exception as e:
-					L.error("Cannot assign tenant: {}".format(e), exc_info=True, struct_data={
-						"cid": credential_id, "tenant": tenant})
-					error_details.append({"cid": credential_id, "tenant": tenant})
-				if not success:
-					continue
+				if tenant != "*":
+					success = False
+					try:
+						await self.TenantService.assign_tenant(
+							credential_id, tenant, verify_tenant=False, verify_credentials=False)
+						success = True
+					except asab.exceptions.Conflict:
+						L.info("Skipping: Tenant already assigned.", struct_data={
+							"cid": credential_id, "tenant": tenant})
+						success = True
+					except Exception as e:
+						L.error("Cannot assign tenant: {}".format(e), exc_info=True, struct_data={
+							"cid": credential_id, "tenant": tenant})
+						error_details.append({"cid": credential_id, "tenant": tenant})
+					if not success:
+						continue
 
 				if len(roles) == 0:
 					continue

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -522,6 +522,8 @@ class TenantHandler(object):
 					# If "UNASSIGN-TENANT" is provided instead of the role array
 					# (e.g. `"my-tenant": "UNASSIGN-TENANT"`), revoke access to the tenant completely.
 					# This also automatically unassigns all the tenant's roles
+					if tenant == "*":
+						raise asab.exceptions.ValidationError("Cannot unassign '*' because it is not a tenant.")
 					try:
 						await self.TenantService.unassign_tenant(credential_id, tenant)
 					except KeyError:

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -190,6 +190,7 @@ class TenantService(asab.Service):
 		Optionally, verify first that the tenant and the credentials exist.
 		"""
 		assert (self.is_enabled())
+		assert tenant != "*"
 
 		if verify_tenant:
 			try:
@@ -224,6 +225,7 @@ class TenantService(asab.Service):
 		Revoke credentials' access to specified tenant and unassign the tenant's roles.
 		"""
 		assert (self.is_enabled())
+		assert tenant != "*"
 
 		# Unassign tenant roles
 		role_svc = self.App.get_service("seacatauth.RoleService")


### PR DESCRIPTION
Issue: Assigning global roles using the bulk call caused the tenant `*` to be assigned.

That is now fixed. Also, assertion statements have been added to tenant_assign and tenant_unassign methods to make sure `*` is never assigned.