### PR TITLE
Impersonation REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - User impersonation (#188, PLUM Sprint 230509)
 - Configurable client session expiration (#204, PLUM Sprint 230509)
 - Additional TLS options in LDAP provider (#208, PLUM Sprint 230519)
+- Impersonation REST API (#210, PLUM Sprint 230602)
+
+### Refactoring
+- Allow impersonating superuser credentials, but exclude the superuser resource (#210, PLUM Sprint 230602)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@
 
 ### Refactoring
 - Allow impersonating superuser credentials, but exclude the superuser resource (#210, PLUM Sprint 230602)
-
-### Refactoring
 - Session performance improvement (#211)
 
 ---

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -32,29 +32,29 @@ class AuthenticationHandler(object):
 	def __init__(self, app, authn_svc):
 		self.App = app
 		self.AuthenticationService = authn_svc
-		self.CredentialsService = app.get_service('seacatauth.CredentialsService')
-		self.SessionService = app.get_service('seacatauth.SessionService')
-		self.CookieService = app.get_service('seacatauth.CookieService')
-		self.AuditService = app.get_service('seacatauth.AuditService')
+		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
+		self.SessionService = app.get_service("seacatauth.SessionService")
+		self.CookieService = app.get_service("seacatauth.CookieService")
+		self.AuditService = app.get_service("seacatauth.AuditService")
 		self.BatmanService = app.BatmanService
-		self.CommunicationService = app.get_service('seacatauth.CommunicationService')
+		self.CommunicationService = app.get_service("seacatauth.CommunicationService")
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_put(r'/public/login.prologue', self.login_prologue)
-		web_app.router.add_put(r'/public/login/{lsid}', self.login)
-		web_app.router.add_put(r'/public/login/{lsid}/smslogin', self.smslogin)
-		web_app.router.add_put(r'/public/login/{lsid}/webauthn', self.webauthn_login)
-		web_app.router.add_put(r'/public/logout', self.logout)
+		web_app.router.add_put(r"/public/login.prologue", self.login_prologue)
+		web_app.router.add_put(r"/public/login/{lsid}", self.login)
+		web_app.router.add_put(r"/public/login/{lsid}/smslogin", self.smslogin)
+		web_app.router.add_put(r"/public/login/{lsid}/webauthn", self.webauthn_login)
+		web_app.router.add_put(r"/public/logout", self.logout)
 		web_app.router.add_put("/impersonate", self.impersonate)
 		web_app.router.add_post("/impersonate", self.impersonate_and_redirect)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_put(r'/public/login.prologue', self.login_prologue)
-		web_app_public.router.add_put(r'/public/login/{lsid}', self.login)
-		web_app_public.router.add_put(r'/public/login/{lsid}/smslogin', self.smslogin)
-		web_app_public.router.add_put(r'/public/login/{lsid}/webauthn', self.webauthn_login)
-		web_app_public.router.add_put(r'/public/logout', self.logout)
+		web_app_public.router.add_put(r"/public/login.prologue", self.login_prologue)
+		web_app_public.router.add_put(r"/public/login/{lsid}", self.login)
+		web_app_public.router.add_put(r"/public/login/{lsid}/smslogin", self.smslogin)
+		web_app_public.router.add_put(r"/public/login/{lsid}/webauthn", self.webauthn_login)
+		web_app_public.router.add_put(r"/public/logout", self.logout)
 		web_app_public.router.add_post("/impersonate", self.impersonate_and_redirect)
 
 	@asab.web.rest.json_schema_handler({

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -438,10 +438,10 @@ class AuthenticationService(asab.Service):
 		target_authz = await build_credentials_authz(
 			self.TenantService, self.RoleService, target_cid, tenants=None)
 		if self.RBACService.is_superuser(target_authz):
-			L.warning("Cannot impersonate a superuser.", struct_data={
-				"impersonator_cid": impersonator_cid, "target_cid": target_cid})
-			raise exceptions.AccessDeniedError(
-				subject=impersonator_cid, resource="impersonate:{}".format(target_cid))
+			L.warning(
+				"Impersonation target is a superuser. Resource 'authz:superuser' will be excluded "
+				"from the impersonated session.",
+				struct_data={"impersonator_cid": impersonator_cid, "target_cid": target_cid})
 
 		scope = frozenset(["profile", "email", "phone"])
 		session_builders = [
@@ -450,7 +450,8 @@ class AuthenticationService(asab.Service):
 				tenant_service=self.TenantService,
 				role_service=self.RoleService,
 				credentials_id=target_cid,
-				tenants=None  # Root session is tenant-agnostic
+				tenants=None,  # Root session is tenant-agnostic
+				exclude_resources={"authz:superuser", "authz:impersonate"},
 			),
 			cookie_session_builder(),
 			await available_factors_session_builder(self, target_cid),

--- a/seacatauth/authz/utils.py
+++ b/seacatauth/authz/utils.py
@@ -1,6 +1,6 @@
 async def build_credentials_authz(
 	tenant_service, role_service, credentials_id,
-	tenants=None, exclude_resources=frozenset()
+	tenants=None, exclude_resources=None
 ):
 	"""
 	Creates a nested 'authz' dict with tenant:resource structure:
@@ -10,6 +10,8 @@ async def build_credentials_authz(
 		'tenantB': ['resourceA', 'resourceB', 'resourceE', 'resourceD'],
 	}
 	"""
+	exclude_resources = exclude_resources or frozenset()
+
 	# Add global roles and resources under "*"
 	authz = {}
 	tenant = "*"

--- a/seacatauth/authz/utils.py
+++ b/seacatauth/authz/utils.py
@@ -1,4 +1,7 @@
-async def build_credentials_authz(tenant_service, role_service, credentials_id, tenants=None):
+async def build_credentials_authz(
+	tenant_service, role_service, credentials_id,
+	tenants=None, exclude_resources=frozenset()
+):
 	"""
 	Creates a nested 'authz' dict with tenant:resource structure:
 	{
@@ -7,13 +10,16 @@ async def build_credentials_authz(tenant_service, role_service, credentials_id, 
 		'tenantB': ['resourceA', 'resourceB', 'resourceE', 'resourceD'],
 	}
 	"""
-
 	# Add global roles and resources under "*"
 	authz = {}
 	tenant = "*"
 	authz[tenant] = set()
 	for role in await role_service.get_roles_by_credentials(credentials_id, [tenant]):
-		authz[tenant].update(await role_service.get_role_resources(role))
+		authz[tenant].update(
+			res
+			for res in await role_service.get_role_resources(role)
+			if res not in exclude_resources
+		)
 	authz[tenant] = list(authz[tenant])
 
 	# Add tenant-specific roles and resources
@@ -21,7 +27,11 @@ async def build_credentials_authz(tenant_service, role_service, credentials_id, 
 		for tenant in tenants:
 			authz[tenant] = set()
 			for role in await role_service.get_roles_by_credentials(credentials_id, [tenant]):
-				authz[tenant].update(await role_service.get_role_resources(role))
+				authz[tenant].update(
+					res
+					for res in await role_service.get_role_resources(role)
+					if res not in exclude_resources
+				)
 			authz[tenant] = list(authz[tenant])
 
 	return authz

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -159,6 +159,12 @@ class CookieService(asab.Service):
 		except KeyError:
 			raise KeyError("Client '{}' not found".format(client_id))
 
+		# Make sure dangerous resources are removed from impersonated sessions
+		if root_session.Authentication.ImpersonatorSessionId is not None:
+			exclude_resources = {"authz:superuser", "authz:impersonate"}
+		else:
+			exclude_resources = None
+
 		# Build the session
 		session_builders = [
 			await credentials_session_builder(self.CredentialsService, root_session.Credentials.Id, scope),
@@ -167,6 +173,7 @@ class CookieService(asab.Service):
 				role_service=self.RoleService,
 				credentials_id=root_session.Credentials.Id,
 				tenants=tenants,
+				exclude_resources=exclude_resources,
 			),
 			cookie_session_builder(),
 		]

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -258,6 +258,12 @@ class OpenIdConnectService(asab.Service):
 		code_challenge_method: str = None
 	):
 		# TODO: Choose builders based on scope
+		# Make sure dangerous resources are removed from impersonated sessions
+		if root_session.Authentication.ImpersonatorSessionId is not None:
+			exclude_resources = {"authz:superuser", "authz:impersonate"}
+		else:
+			exclude_resources = set()
+
 		session_builders = [
 			await credentials_session_builder(self.CredentialsService, root_session.Credentials.Id, scope),
 			await authz_session_builder(
@@ -265,6 +271,7 @@ class OpenIdConnectService(asab.Service):
 				role_service=self.RoleService,
 				credentials_id=root_session.Credentials.Id,
 				tenants=tenants,
+				exclude_resources=exclude_resources,
 			)
 		]
 

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -45,7 +45,7 @@ async def external_login_session_builder(external_login_service, credentials_id)
 
 async def authz_session_builder(
 	tenant_service, role_service, credentials_id,
-	tenants=None, exclude_resources=frozenset()
+	tenants=None, exclude_resources=None
 ):
 	"""
 	Add 'authz' dict with currently authorized tenants and their resources

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -43,13 +43,16 @@ async def external_login_session_builder(external_login_service, credentials_id)
 	return ((SessionAdapter.FN.Authentication.ExternalLoginOptions, external_logins),)
 
 
-async def authz_session_builder(tenant_service, role_service, credentials_id, tenants=None):
+async def authz_session_builder(
+	tenant_service, role_service, credentials_id,
+	tenants=None, exclude_resources=frozenset()
+):
 	"""
 	Add 'authz' dict with currently authorized tenants and their resources
 	Add 'tenants' list with complete list of credential's tenants
 	"""
 	tenants = tenants or []
-	authz = await build_credentials_authz(tenant_service, role_service, credentials_id, tenants)
+	authz = await build_credentials_authz(tenant_service, role_service, credentials_id, tenants, exclude_resources)
 	user_tenants = list(set(await tenant_service.get_tenants(credentials_id)).union(tenants))
 	return (
 		(SessionAdapter.FN.Authorization.Authz, authz),


### PR DESCRIPTION
# New `PUT /impersonate` endpoint
- Creates impersonated root session and sends back a response with a `Set-Cookie` header. 
- Designed as a REST API endpoint. Unlike the POST endpoint, this one does not do any redirections. The redirection is expected to be done by the caller.

# Impersonating superusers
- Impersonating credentials with `authz:superuser` resource is now enabled, but the resource is excluded from the impersonated session.