### PR TITLE
Session performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Configurable client session expiration (#204, PLUM Sprint 230509)
 - Additional TLS options in LDAP provider (#208, PLUM Sprint 230519)
 
+### Refactoring
+- Session performance improvement (#211)
+
 ---
 
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -112,6 +112,16 @@ class SessionService(asab.Service):
 		except Exception as e:
 			L.error("Failed to create compound index (cookie ID, client ID): {}".format(e))
 
+		# Expiration descending
+		try:
+			await collection.create_index(
+				[
+					(SessionAdapter.FN.Session.Expiration, pymongo.DESCENDING)
+				]
+			)
+		except Exception as e:
+			L.error("Failed to create index (expiration desc): {}".format(e))
+
 
 	async def _on_start(self, event_name):
 		await self.delete_expired_sessions()
@@ -346,7 +356,7 @@ class SessionService(asab.Service):
 		collection = self.StorageService.Database[self.SessionCollection]
 
 		if query_filter is None:
-			query_filter = {}
+			return await collection.estimated_document_count()
 
 		return await collection.count_documents(query_filter)
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -113,6 +113,7 @@ class SessionService(asab.Service):
 			L.error("Failed to create compound index (cookie ID, client ID): {}".format(e))
 
 		# Expiration descending
+		# Optimizes deleting expired sessions
 		try:
 			await collection.create_index(
 				[
@@ -120,7 +121,18 @@ class SessionService(asab.Service):
 				]
 			)
 		except Exception as e:
-			L.error("Failed to create index (expiration desc): {}".format(e))
+			L.error("Failed to create index (expiration descending): {}".format(e))
+
+		# Parent session
+		# For searching session groups
+		try:
+			await collection.create_index(
+				[
+					(SessionAdapter.FN.Session.ParentSessionId, pymongo.ASCENDING)
+				]
+			)
+		except Exception as e:
+			L.error("Failed to create index (parent session ID): {}".format(e))
 
 
 	async def _on_start(self, event_name):

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -79,7 +79,8 @@ class SessionService(asab.Service):
 		# Metrics
 		self.MetricsService = app.get_service('asab.MetricsService')
 		self.TaskService = app.get_service('asab.TaskService')
-		self.SessionGauge = self.MetricsService.create_gauge("sessions", tags={"help": "Counts active sessions."}, init_values={"sessions": 0})
+		self.SessionGauge = self.MetricsService.create_gauge(
+			"sessions", tags={"help": "Counts active sessions."}, init_values={"sessions": 0})
 		app.PubSub.subscribe("Application.tick/10!", self._on_tick_metric)
 
 


### PR DESCRIPTION
**Why?**
 - we have found out some performance issues about sessions
 - first one is about iterating for expired sessions 
 - second one si about metric - sum of sessions

**Expired sessions**
 - fixed with simple index

estimated_document_count
 - metric don't use filter, so we can improve it with `estimated_document_count()` method