### PR TITLE
Configurable anonymous session expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking changes
 - Batman auth flow merged with cookie auth flow (#216, PLUM Sprint 230616)
 
+### Features
+- Configurable anonymous session expiration (#217, PLUM Sprint 230616)
+
 ### Refactoring
 - ~~Bump Python version to 3.11 and Alpine to 3.18 (#215, PLUM Sprint 230602)~~(d415691)
 - Batman auth flow merged with cookie auth flow (#216, PLUM Sprint 230616)

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -123,7 +123,7 @@ asab.Config.add_defaults({
 	},
 
 	"seacatauth:session": {
-		# Root session expiration
+		# Root session expiration, also works as the default value for client sessions
 		"expiration": "4 h",
 
 		# Anonymous session expiration

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -123,8 +123,12 @@ asab.Config.add_defaults({
 	},
 
 	"seacatauth:session": {
-		# Default session expiration in seconds
+		# Root session expiration
 		"expiration": "4 h",
+
+		# Anonymous session expiration
+		# By default it is the same as root session expiration
+		"anonymous_expiration": "",
 
 		# Touch extension specifies the timespan by which sessions are extended when session activity is detected
 		# It can be either

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -270,7 +270,7 @@ class CookieService(asab.Service):
 		session = await self.SessionService.create_session(
 			session_type="cookie",
 			parent_session_id=root_session_id,
-			expiration=requested_expiration,
+			expiration=self.SessionService.AnonymousExpiration,
 			session_builders=session_builders,
 		)
 

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -435,7 +435,7 @@ class AuthorizeHandler(object):
 						root_session_id=root_session.SessionId,
 						code_challenge=code_challenge,
 						code_challenge_method=code_challenge_method,
-						requested_expiration=session_expiration,
+						requested_expiration=self.SessionService.AnonymousExpiration,
 						from_info=from_info)
 				elif authorize_type == "cookie":
 					new_session = await self.CookieService.create_anonymous_cookie_client_session(
@@ -443,7 +443,7 @@ class AuthorizeHandler(object):
 						root_session_id=root_session.SessionId,
 						track_id=root_session.TrackId,
 						tenants=tenants,
-						requested_expiration=session_expiration,
+						requested_expiration=self.SessionService.AnonymousExpiration,
 						from_info=from_info)
 					# Cookie flow implicitly redirects to the cookie entry point and puts the final redirect_uri in the query
 					redirect_uri = await self._build_cookie_entry_redirect_uri(client_dict, redirect_uri)
@@ -486,13 +486,13 @@ class AuthorizeHandler(object):
 						tenants=tenants,
 						code_challenge=code_challenge,
 						code_challenge_method=code_challenge_method,
-						requested_expiration=session_expiration,
+						requested_expiration=self.SessionService.AnonymousExpiration,
 						from_info=from_info)
 				elif authorize_type == "cookie":
 					new_session = await self.CookieService.create_anonymous_cookie_client_session(
 						anonymous_cid, client_id, scope,
 						tenants=tenants,
-						requested_expiration=session_expiration,
+						requested_expiration=self.SessionService.AnonymousExpiration,
 						from_info=from_info)
 					# Cookie flow implicitly redirects to the cookie entry point and puts the final redirect_uri in the query
 					redirect_uri = await self._build_cookie_entry_redirect_uri(client_dict, redirect_uri)

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -54,6 +54,11 @@ class SessionService(asab.Service):
 			seconds=asab.Config.getseconds("seacatauth:session", "expiration")
 		)
 
+		if len(asab.Config.get("seacatauth:session", "anonymous_expiration")) > 0:
+			self.AnonymousExpiration = asab.Config.getseconds("seacatauth:session", "anonymous_expiration")
+		else:
+			self.AnonymousExpiration = asab.Config.getseconds("seacatauth:session", "expiration")
+
 		touch_extension = asab.Config.get("seacatauth:session", "touch_extension")
 		# Touch extension can be either
 		#   specified as a ratio of the original expiration (float between 0 and 1)
@@ -573,7 +578,8 @@ class SessionService(asab.Service):
 					((SessionAdapter.FN.Credentials.Id, dst_session.Credentials.Id),),
 					((SessionAdapter.FN.Authentication.IsAnonymous, True),),
 				])
-				await self.create_session("root", session_builders=root_session_builders)
+				await self.create_session(
+					"root", session_builders=root_session_builders, expiration=self.AnonymousExpiration)
 			sub_session_builders = [
 				((SessionAdapter.FN.Session.ParentSessionId, root_session_id),),
 				((SessionAdapter.FN.Session.TrackId, src_session.Session.TrackId),),


### PR DESCRIPTION
the expiration of anonymous session (both root and client subsessions!) can now be overwritten by the `anonymous_expiration` configuration option:
```ini
[seacatauth:session]
anonymous_expiration=8 h
```