### PR TITLE
Clear expired objects during housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Refactoring
 - ~~Bump Python version to 3.11 and Alpine to 3.18 (#215, PLUM Sprint 230602)~~(d415691)
 - Batman auth flow merged with cookie auth flow (#216, PLUM Sprint 230616)
+- Clear expired objects during housekeeping (#218, PLUM Sprint 230616)
 
 ---
 

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -111,10 +111,10 @@ class AuthenticationService(asab.Service):
 			init_values={"successful": 0, "failed": 0}
 		)
 
-		self.App.PubSub.subscribe("Application.tick/60!", self._on_tick)
+		app.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
 
 
-	async def _on_tick(self, event_name):
+	async def _on_housekeeping(self, event_name):
 		await self.delete_expired_login_sessions()
 
 

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -249,7 +249,7 @@ class WebAuthnService(asab.Service):
 		query_filter = {"exp": {"$lt": datetime.datetime.now(datetime.timezone.utc)}}
 		result = await collection.delete_many(query_filter)
 		if result.deleted_count > 0:
-			L.info("Expired WebAuthn challenges deleted", struct_data={
+			L.log(asab.LOG_NOTICE, "Expired WebAuthn challenges deleted.", struct_data={
 				"count": result.deleted_count
 			})
 

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -49,11 +49,11 @@ class WebAuthnService(asab.Service):
 
 		self.KeyNameRegex = re.compile(r"^[a-z][a-z0-9._-]{0,128}[a-z0-9]$")
 
-		self.App.PubSub.subscribe("Application.tick/10!", self._on_tick)
+		app.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
 
 
-	async def _on_tick(self, event_name):
-		await self.delete_expired_challenges()
+	async def _on_housekeeping(self, event_name):
+		await self._delete_expired_challenges()
 
 
 	async def create_webauthn_credential(
@@ -240,7 +240,7 @@ class WebAuthnService(asab.Service):
 		})
 
 
-	async def delete_expired_challenges(self):
+	async def _delete_expired_challenges(self):
 		"""
 		Delete expired WebAuthn registration challenges
 		"""

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -91,7 +91,10 @@ class ChangePasswordService(asab.Service):
 		L.log(asab.LOG_NOTICE, "Password reset token deleted", struct_data={"pwd_token": pwdreset_id})
 
 	async def get_pwdreset_token(self, pwdreset_id: str):
-		return await self.StorageService.get(self.ChangePasswordCollection, pwdreset_id)
+		token = await self.StorageService.get(self.ChangePasswordCollection, pwdreset_id)
+		if token["exp"] < datetime.datetime.now(datetime.timezone.utc):
+			raise KeyError("Password reset token expired.")
+		return token
 
 	async def init_password_change(self, credentials_id: str, is_new_user: bool = False, expiration: float = None):
 		'''

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -33,19 +33,19 @@ class ChangePasswordService(asab.Service):
 
 		self.ResetPwdPath = "/#/reset-password"
 
-		app.PubSub.subscribe("Application.tick/3600!", self._on_tick)
+		app.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
 
-	async def _on_tick(self, event_name):
-		await self.delete_expired_pwdreset_tokens()
+	async def _on_housekeeping(self, event_name):
+		await self._delete_expired_pwdreset_tokens()
 
-	async def delete_expired_pwdreset_tokens(self):
-		expired = []
-		requests = await self.list_pwdreset_tokens()
-		for r in requests["data"]:
-			if datetime.datetime.now(datetime.timezone.utc) > r["exp"]:
-				expired.append(r["_id"])
-		for pwd_id in expired:
-			await self.delete_pwdreset_token(pwdreset_id=pwd_id)
+	async def _delete_expired_pwdreset_tokens(self):
+		collection = self.StorageService.Database[self.ChangePasswordCollection]
+		query_filter = {"exp": {"$lt": datetime.datetime.now(datetime.timezone.utc)}}
+		result = await collection.delete_many(query_filter)
+		if result.deleted_count > 0:
+			L.log(asab.LOG_NOTICE, "Expired password reset tokens deleted.", struct_data={
+				"count": result.deleted_count
+			})
 
 	async def delete_pwdreset_tokens_by_cid(self, cid):
 		expired = []

--- a/seacatauth/credentials/registration/service.py
+++ b/seacatauth/credentials/registration/service.py
@@ -48,15 +48,15 @@ class RegistrationService(asab.Service):
 		self.Enabled = self.CredentialProvider is not None
 
 		if self.Enabled:
-			self.App.PubSub.subscribe("Application.tick/60!", self._on_tick)
+			self.App.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
 
 
 	async def initialize(self, app):
 		self.RoleService = app.get_service("seacatauth.RoleService")
 
 
-	async def _on_tick(self, event_name):
-		await self.delete_expired_unregistered_credentials()
+	async def _on_housekeeping(self, event_name):
+		await self._delete_expired_unregistered_credentials()
 
 
 	async def draft_credentials(
@@ -167,7 +167,7 @@ class RegistrationService(asab.Service):
 		await self.CredentialProvider.delete(credentials["_id"])
 
 
-	async def delete_expired_unregistered_credentials(self):
+	async def _delete_expired_unregistered_credentials(self):
 		"""
 		Delete all credentials that have expired registration time
 		"""

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -94,3 +94,10 @@ class ClientResponseError(Exception):
 		self.Status = status
 		self.Data = data
 		super().__init__("Client responded with error {}: {}".format(status, data))
+
+
+class SessionNotFoundError(KeyError):
+	def __init__(self, message, session_id=None, query=None, *args):
+		self.SessionId = session_id
+		self.Query = query
+		super().__init__(message, *args)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -81,11 +81,11 @@ class OpenIdConnectService(asab.Service):
 
 		self.JSONDumper = asab.web.rest.json.JSONDumper(pretty=False)
 
-		self.App.PubSub.subscribe("Application.tick/60!", self._on_tick)
+		app.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
 
 
-	async def _on_tick(self, event_name):
-		await self.delete_expired_authorization_codes()
+	async def _on_housekeeping(self, event_name):
+		await self._delete_expired_authorization_codes()
 
 
 	def _load_private_key(self):
@@ -166,7 +166,7 @@ class OpenIdConnectService(asab.Service):
 		return code
 
 
-	async def delete_expired_authorization_codes(self):
+	async def _delete_expired_authorization_codes(self):
 		collection = self.StorageService.Database[self.AuthorizationCodeCollection]
 
 		query_filter = {"exp": {"$lt": datetime.datetime.now(datetime.timezone.utc)}}

--- a/seacatauth/session/handler.py
+++ b/seacatauth/session/handler.py
@@ -57,10 +57,18 @@ class SessionHandler(object):
 			description: Items per page
 			schema:
 				type: integer
+		-	name: include_expired
+			in: query
+			description: Whether to include expired sessions in the results
+			required: false
+			schema:
+				type: boolean
+				default: no
 		"""
 		page = int(request.query.get("p", 1)) - 1
 		limit = int(request.query.get("i", 10))
-		data = await self.SessionService.recursive_list(page, limit)
+		include_expired = asab.config.utils.string_to_boolean(request.query.get("include_expired", "no"))
+		data = await self.SessionService.recursive_list(page, limit, include_expired=include_expired)
 		return asab.web.rest.json_response(request, data)
 
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -16,7 +16,7 @@ import asab.storage
 import pymongo
 
 from .adapter import SessionAdapter, rest_get
-
+from .. import exceptions
 from ..events import EventTypes
 
 #
@@ -30,7 +30,7 @@ class SessionService(asab.Service):
 
 	SessionCollection = "s"
 
-	def __init__(self, app, service_name='seacatauth.SessionService'):
+	def __init__(self, app, service_name="seacatauth.SessionService"):
 		super().__init__(app, service_name)
 		self.StorageService = app.get_service("asab.StorageService")
 
@@ -78,12 +78,12 @@ class SessionService(asab.Service):
 
 		self.MinimalRefreshInterval = datetime.timedelta(seconds=60)
 
-		app.PubSub.subscribe("Application.tick/60!", self._on_tick)
+		app.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
 		app.PubSub.subscribe("Application.run!", self._on_start)
 
 		# Metrics
-		self.MetricsService = app.get_service('asab.MetricsService')
-		self.TaskService = app.get_service('asab.TaskService')
+		self.MetricsService = app.get_service("asab.MetricsService")
+		self.TaskService = app.get_service("asab.TaskService")
 		self.SessionGauge = self.MetricsService.create_gauge(
 			"sessions", tags={"help": "Counts active sessions."}, init_values={"sessions": 0})
 		app.PubSub.subscribe("Application.tick/10!", self._on_tick_metric)
@@ -145,7 +145,7 @@ class SessionService(asab.Service):
 		await self.delete_expired_sessions()
 
 
-	async def _on_tick(self, event_name):
+	async def _on_housekeeping(self, event_name):
 		await self.delete_expired_sessions()
 
 	def _on_tick_metric(self, event_name):
@@ -258,7 +258,11 @@ class SessionService(asab.Service):
 		collection = self.StorageService.Database[self.SessionCollection]
 		session_dict = await collection.find_one(query_filter)
 		if session_dict is None:
-			raise KeyError("Session not found")
+			raise exceptions.SessionNotFoundError("Session not found in database.", query=criteria)
+
+		# Do not return expired sessions
+		if session_dict[SessionAdapter.FN.Session.Expiration] < datetime.datetime.now(datetime.timezone.utc):
+			raise exceptions.SessionNotFoundError("Session expired.", query=criteria)
 
 		try:
 			session = SessionAdapter(self, session_dict)
@@ -266,7 +270,7 @@ class SessionService(asab.Service):
 			L.error("Failed to create SessionAdapter from database object", struct_data={
 				"sid": session_dict.get("_id"),
 			})
-			raise KeyError("Session not found") from e
+			raise exceptions.SessionNotFoundError("Session not found in database.", query=criteria) from e
 
 		return session
 
@@ -275,13 +279,18 @@ class SessionService(asab.Service):
 		if isinstance(session_id, str):
 			session_id = bson.ObjectId(session_id)
 		session_dict = await self.StorageService.get(self.SessionCollection, session_id)
+
+		# Do not return expired sessions
+		if session_dict[SessionAdapter.FN.Session.Expiration] < datetime.datetime.now(datetime.timezone.utc):
+			raise exceptions.SessionNotFoundError("Session expired.", session_id=session_id)
+
 		try:
 			session = SessionAdapter(self, session_dict)
 		except Exception as e:
-			L.error("Failed to create SessionAdapter from database object", struct_data={
+			L.exception("Failed to create SessionAdapter from database object", struct_data={
 				"sid": session_dict.get("_id"),
 			})
-			raise e
+			raise exceptions.SessionNotFoundError("Session not found in database.", session_id=session_id) from e
 		return session
 
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -79,7 +79,6 @@ class SessionService(asab.Service):
 		self.MinimalRefreshInterval = datetime.timedelta(seconds=60)
 
 		app.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
-		app.PubSub.subscribe("Application.run!", self._on_start)
 
 		# Metrics
 		self.MetricsService = app.get_service("asab.MetricsService")
@@ -139,10 +138,6 @@ class SessionService(asab.Service):
 			)
 		except Exception as e:
 			L.error("Failed to create index (parent session ID): {}".format(e))
-
-
-	async def _on_start(self, event_name):
-		await self._delete_expired_sessions()
 
 
 	async def _on_housekeeping(self, event_name):


### PR DESCRIPTION
- Expired database objects are deleted during `Application.housekeeping!` event ([see ASAB docs on housekeeping](https://asab.readthedocs.io/en/latest/asab/pubsub.html#cmdoption-arg-application-housekeeping)) instead of more frequent periodic scans (to minimize the number of database write operations). This includes:
  - Sessions
  - Login sessions
  - OAuth authorization codes
  - Incomplete credential registrations
  - Incomplete TOTP registrations
  - Webauthn challenges
  - Password reset tokens

- Expired sessions are excluded from session list, unless `include_expired=yes` is specified in request query.