### PR TITLE
Reduce last login reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 - Batman auth flow merged with cookie auth flow (#216, PLUM Sprint 230616)
+- Last login info is no longer included in userinfo and credentials detail (#219, PLUM Sprint 230616)
 
 ### Features
 - Configurable anonymous session expiration (#217, PLUM Sprint 230616)
@@ -11,6 +12,7 @@
 ### Refactoring
 - ~~Bump Python version to 3.11 and Alpine to 3.18 (#215, PLUM Sprint 230602)~~(d415691)
 - Batman auth flow merged with cookie auth flow (#216, PLUM Sprint 230616)
+- Reduce last login reads (#219, PLUM Sprint 230616)
 
 ---
 

--- a/seacatauth/audit/service.py
+++ b/seacatauth/audit/service.py
@@ -23,17 +23,6 @@ class AuditService(asab.Service):
 		super().__init__(app, service_name)
 		self.StorageService = app.get_service("asab.StorageService")
 
-	async def initialize(self, app):
-		coll = await self.StorageService.collection(self.AuditCollection)
-
-		# Create index to improve the performance of last login searches
-		await coll.create_index(
-			[
-				("cid", pymongo.ASCENDING),
-				("_c", pymongo.DESCENDING),
-				("c", pymongo.ASCENDING)
-			],
-		)
 
 	async def append(self, code: AuditCode, attributes: dict = None):
 		assert (isinstance(code, AuditCode))

--- a/seacatauth/audit/service.py
+++ b/seacatauth/audit/service.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 
 import asab.storage.exceptions
-import pymongo
 
 from .codes import AuditCode
 

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -6,6 +6,7 @@ import aiohttp.web
 import asab
 import asab.web.rest
 import asab.web.webcrypto
+import asab.exceptions
 
 from ..decorators import access_control
 from .schemas import (
@@ -43,14 +44,14 @@ class CredentialsHandler(object):
 		web_app.router.add_put("/usernames", self.get_idents_from_ids)  # TODO: Back compat. Remove once UI adapts to the new endpoint.
 		web_app.router.add_get("/locate", self.locate_credentials)
 		web_app.router.add_get("/credentials/{credentials_id}", self.get_credentials)
-		web_app.router.add_get("/last-login/{credentials_id}", self.get_last_login_data)
+		web_app.router.add_get("/last_login/{credentials_id}", self.get_last_login_data)
 
 		web_app.router.add_post("/credentials/{provider}", self.create_credentials)
 		web_app.router.add_put("/credentials/{credentials_id}", self.update_credentials)
 		web_app.router.add_delete("/credentials/{credentials_id}", self.delete_credentials)
 
 		web_app.router.add_put("/public/credentials", self.update_my_credentials)
-		web_app.router.add_get("/public/last-login", self.get_my_last_login_data)
+		web_app.router.add_get("/public/last_login", self.get_my_last_login_data)
 
 		# Providers
 		web_app.router.add_get("/provider/{provider_id}", self.get_provider_info)
@@ -62,7 +63,7 @@ class CredentialsHandler(object):
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_put("/public/credentials", self.update_my_credentials)
 		web_app_public.router.add_get("/public/provider", self.get_my_provider_info)
-		web_app_public.router.add_get("/public/last-login", self.get_my_last_login_data)
+		web_app_public.router.add_get("/public/last_login", self.get_my_last_login_data)
 
 
 	@access_control("seacat:credentials:access")
@@ -119,6 +120,8 @@ class CredentialsHandler(object):
 		"""
 		Get the current user's last successful/failed login data.
 		"""
+		if request.Session.Authentication.IsAnonymous:
+			raise asab.exceptions.AccessDeniedError()
 		data = await self.AuditService.get_last_logins(credentials_id)
 		return asab.web.rest.json_response(request, data)
 

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -333,6 +333,16 @@ class CredentialsHandler(object):
 	async def get_credentials(self, request):
 		"""
 		Get requested credentials' detail
+
+		---
+		parameters:
+		-	name: last_login
+			in: query
+			description: Whether to include the last successful and failed login data
+			required: false
+			schema:
+				type: boolean
+				default: no
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		_, provider_id, _ = credentials_id.split(':', 2)
@@ -340,7 +350,8 @@ class CredentialsHandler(object):
 
 		credentials = await provider.get(request.match_info["credentials_id"])
 
-		credentials['_ll'] = await self.AuditService.get_last_logins(credentials_id)
+		if asab.config.utils.string_to_boolean(request.query.get("last_login", "no")):
+			credentials["_ll"] = await self.AuditService.get_last_logins(credentials_id)
 
 		return asab.web.rest.json_response(request, credentials)
 

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -43,12 +43,14 @@ class CredentialsHandler(object):
 		web_app.router.add_put("/usernames", self.get_idents_from_ids)  # TODO: Back compat. Remove once UI adapts to the new endpoint.
 		web_app.router.add_get("/locate", self.locate_credentials)
 		web_app.router.add_get("/credentials/{credentials_id}", self.get_credentials)
+		web_app.router.add_get("/last-login/{credentials_id}", self.get_last_login_data)
 
 		web_app.router.add_post("/credentials/{provider}", self.create_credentials)
 		web_app.router.add_put("/credentials/{credentials_id}", self.update_credentials)
 		web_app.router.add_delete("/credentials/{credentials_id}", self.delete_credentials)
 
 		web_app.router.add_put("/public/credentials", self.update_my_credentials)
+		web_app.router.add_get("/public/last-login", self.get_my_last_login_data)
 
 		# Providers
 		web_app.router.add_get("/provider/{provider_id}", self.get_provider_info)
@@ -60,6 +62,7 @@ class CredentialsHandler(object):
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_put("/public/credentials", self.update_my_credentials)
 		web_app_public.router.add_get("/public/provider", self.get_my_provider_info)
+		web_app_public.router.add_get("/public/last-login", self.get_my_last_login_data)
 
 
 	@access_control("seacat:credentials:access")
@@ -99,6 +102,25 @@ class CredentialsHandler(object):
 			"data": data,
 		}
 		return asab.web.rest.json_response(request, response)
+
+
+	@access_control("seacat:credentials:access")
+	async def get_last_login_data(self, request):
+		"""
+		Get the credentials' last successful/failed login data.
+		"""
+		credentials_id = request.match_info["credentials_id"]
+		data = await self.AuditService.get_last_logins(credentials_id)
+		return asab.web.rest.json_response(request, data)
+
+
+	@access_control()
+	async def get_my_last_login_data(self, request, *, credentials_id):
+		"""
+		Get the current user's last successful/failed login data.
+		"""
+		data = await self.AuditService.get_last_logins(credentials_id)
+		return asab.web.rest.json_response(request, data)
 
 
 	@access_control("seacat:credentials:access")

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -480,20 +480,6 @@ class OpenIdConnectService(asab.Service):
 
 		# TODO: Last password change
 
-		# Get last successful and failed login times
-		# TODO: Store last login in session
-		try:
-			last_login = await self.AuditService.get_last_logins(session.Credentials.Id)
-		except Exception as e:
-			last_login = None
-			L.warning("Could not fetch last logins: {}".format(e))
-
-		if last_login is not None:
-			if "fat" in last_login:
-				userinfo["last_failed_login"] = last_login["fat"]
-			if "sat" in last_login:
-				userinfo["last_successful_login"] = last_login["sat"]
-
 		# RFC 7519 states that the exp and iat claim values must be NumericDate values
 		# Convert ALL datetimes to UTC timestamps for consistency
 		for k, v in userinfo.items():


### PR DESCRIPTION
Issue: The audit log is being searched for last login data every time `build_userinfo` is called.

- **`BREAKING`** Last login info is no longer included in userinfo.
- **`BREAKING`** Last login info is no longer included in credentials detail by default. Add `last_login=yes` to request query to include the info in the result.
- PUBLIC API: To get your last login info, use `GET /public/last_login`.
- ADMIN API: To get any user's last login info, use `GET /last_login/{CREDENTIALS_ID}`.
- Audit index for finding last login data is removed to save memory. (Note: It must be removed manually in existing deployments.)


## Required UI changes

Seacat Admin UI
- In credentials detail, to get the last login data, call `GET /credentials/{CREDENTIALS_ID}?last_login=yes`.

Seacat Auth UI
- In account detail, to get the last login data, call `GET /public/last_login`.