### PR TITLE
Common AES key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 - Batman auth flow merged with cookie auth flow (#216, PLUM Sprint 230616)
+- `aes_key` option has been moved to `[asab:storage]` section (#221, PLUM Sprint 230616)
 
 ### Features
 - Configurable anonymous session expiration (#217, PLUM Sprint 230616)
@@ -13,6 +14,7 @@
 - ~~Bump Python version to 3.11 and Alpine to 3.18 (#215, PLUM Sprint 230602)~~(d415691)
 - Batman auth flow merged with cookie auth flow (#216, PLUM Sprint 230616)
 - Clear expired objects during housekeeping (#218, PLUM Sprint 230616)
+- `aes_key` option has been moved to `[asab:storage]` section (#221, PLUM Sprint 230616)
 
 ---
 

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -144,10 +144,6 @@ asab.Config.add_defaults({
 
 		# Maximum session age, beyond which the session cannot be extended
 		"maximum_age": "7 d",
-
-		# Key used for sensitive field encryption
-		# MUST NOT BE EMPTY!
-		"aes_key": ""
 	},
 
 	"seacatauth:password": {

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import secrets
 
 import asab
 import asab.web
@@ -23,6 +24,7 @@ class SeaCatAuthApplication(asab.Application):
 	def __init__(self):
 		super().__init__()
 		self.Provisioning = self._should_activate_provisioning()
+		self._check_encryption_config()
 
 		# Load modules
 		self.add_module(asab.web.Module)
@@ -167,6 +169,19 @@ class SeaCatAuthApplication(asab.Application):
 		if self.Provisioning:
 			from .provisioning import ProvisioningService
 			self.ProvisioningService = ProvisioningService(self)
+
+	def _check_encryption_config(self):
+		if len(asab.Config.get("asab:storage", "aes_key", fallback="")) == 0:
+			raise ValueError(
+				"No encryption 'aes_key' specified in [asab:storage] config section. Please supply an encryption key. "
+				"You may use the following randomly generated example: "
+				"""
+				```
+				[asab:storage]
+				aes_key={}
+				```
+				""".replace("\t", "").format(secrets.token_urlsafe(16))
+			)
 
 	def _should_activate_provisioning(self):
 		# Activate via argparse flag

--- a/seacatauth/otp/service.py
+++ b/seacatauth/otp/service.py
@@ -103,7 +103,7 @@ class OTPService(asab.Service):
 		upsertor = self.StorageService.upsertor(collection=self.TOTPCollection, obj_id=credentials_id)
 		upsertor.set("__totp", secret.encode("ascii"), encrypt=True)
 		await upsertor.execute(event_type=EventTypes.TOTP_REGISTERED)
-		L.log(asab.LOG_NOTICE, "TOTP secret registered", struct_data={"cid": credentials_id})
+		L.log(asab.LOG_NOTICE, "TOTP secret registered.", struct_data={"cid": credentials_id})
 
 		await self._delete_prepared_totp_secret(session.SessionId)
 
@@ -130,7 +130,7 @@ class OTPService(asab.Service):
 		upsertor.set("__s", secret, encrypt=True)
 
 		await upsertor.execute(event_type=EventTypes.TOTP_CREATED)
-		L.log(asab.LOG_NOTICE, "TOTP secret created", struct_data={"sid": session_id})
+		L.log(asab.LOG_NOTICE, "TOTP secret created.", struct_data={"sid": session_id})
 
 		return secret
 
@@ -140,14 +140,12 @@ class OTPService(asab.Service):
 		Get TOTP secret from `PreparedTOTPCollection`. If it has already expired, raise `KeyError`.
 		"""
 		data: dict = await self.StorageService.get(collection=self.PreparedTOTPCollection, obj_id=session_id, decrypt=["__s"])
-		secret: str = data["__s"]
+		secret: bytes = data["__s"]
 		expiration_time: Optional[datetime.datetime] = data["exp"]
 		if expiration_time is None or expiration_time < datetime.datetime.now(datetime.timezone.utc):
 			raise KeyError("TOTP secret timed out")
 
-		secret = secret.decode("ascii")
-
-		return secret
+		return secret.decode("ascii")
 
 	async def _get_totp_secret_by_credentials_id(self, credentials_id: str) -> Optional[str]:
 		"""
@@ -156,7 +154,7 @@ class OTPService(asab.Service):
 		"""
 		try:
 			totp_object: dict = await self.StorageService.get(collection=self.TOTPCollection, obj_id=credentials_id, decrypt=["__totp"])
-			secret: str = totp_object.get("__totp")
+			secret: bytes | None = totp_object.get("__totp")
 		except KeyError:
 			secret = None
 
@@ -173,18 +171,18 @@ class OTPService(asab.Service):
 		Delete TOTP secret from `PreparedTOTPCollection`.
 		"""
 		await self.StorageService.delete(collection=self.PreparedTOTPCollection, obj_id=session_id)
-		L.info("TOTP secret deleted", struct_data={"sid": session_id})
+		L.info("TOTP secret deleted.", struct_data={"sid": session_id})
 
 
 	async def _delete_expired_totp_secrets(self):
 		"""
 		Delete expired TOTP secrets
 		"""
-		collection: dict = self.StorageService.Database[self.PreparedTOTPCollection]
+		collection = self.StorageService.Database[self.PreparedTOTPCollection]
 		query_filter: dict = {"exp": {"$lt": datetime.datetime.now(datetime.timezone.utc)}}
 		result = await collection.delete_many(query_filter)
 		if result.deleted_count > 0:
-			L.info("Expired TOTP secrets deleted", struct_data={
+			L.log(asab.LOG_NOTICE, "Expired TOTP secrets deleted.", struct_data={
 				"count": result.deleted_count
 			})
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import secrets
 import uuid
 
 import bson

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -38,22 +38,11 @@ class SessionService(asab.Service):
 		# It needs to be able to search by encrypted values and thus requires
 		# a different way of handling AES CBC init vectors.
 		aes_key = asab.Config.get("asab:storage", "aes_key")
-		if len(aes_key) == 0:
-			aes_key = asab.Config.get("seacatauth:session", "aes_key", fallback="")
-			if len(aes_key) > 0:
-				raise ValueError(
-					"The 'aes_key' config option has been moved from [seacatauth:session] "
-					"into [asab:storage] section. Please update your configuration accordingly.")
-		if len(aes_key) == 0:
-			raise ValueError("""Storage AES key must not be empty.
-				Please specify it in the [asab:storage] section of your Seacat Auth configuration file.
-				You may use the following randomly generated example:
-				```
-				[asab:storage]
-				aes_key={}
-				```
-			""".replace("\t", "").format(secrets.token_urlsafe(16)))
 		self.AESKey = hashlib.sha256(aes_key.encode("utf-8")).digest()
+		if "aes_key" in asab.Config["seacatauth:session"]:
+			L.warning(
+				"The 'aes_key' config option has been moved into [asab:storage] section. "
+				"The key specified in [seacatauth:session] will be ignored.")
 
 		# Block size is used for determining the size of CBC initialization vector
 		self.AESBlockSize = cryptography.hazmat.primitives.ciphers.algorithms.AES.block_size // 8


### PR DESCRIPTION
SessionService now shares AES key with asab.StorageService, even though it uses its own AES encryption mechanism.

**`BREAKING`** Session AES key is read from `[asab:storage]` config section.

- [x] Application should notify the user if no aes_key configured.