### PR TITLE
Update modtime of active sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 - Configurable anonymous session expiration (#217, PLUM Sprint 230616)
+- Update modtime of active sessions (#226, PLUM Sprint 230616)
 
 ### Refactoring
 - ~~Bump Python version to 3.11 and Alpine to 3.18 (#215, PLUM Sprint 230602)~~(d415691)

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -142,6 +142,7 @@ asab.Config.add_defaults({
 		#   Every time introspection happens, the expiration is postponed to CURRENT TIME + 20 minutes.
 		"touch_extension": "0.5",
 
+		# Specifies how often session can be touched to indicate their activity
 		"touch_cooldown": "60 s",
 
 		# Maximum session age, beyond which the session cannot be extended

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -142,6 +142,8 @@ asab.Config.add_defaults({
 		#   Every time introspection happens, the expiration is postponed to CURRENT TIME + 20 minutes.
 		"touch_extension": "0.5",
 
+		"touch_cooldown": "60 s",
+
 		# Maximum session age, beyond which the session cannot be extended
 		"maximum_age": "7 d",
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -76,7 +76,8 @@ class SessionService(asab.Service):
 			seconds=asab.Config.getseconds("seacatauth:session", "maximum_age")
 		)
 
-		self.MinimalRefreshInterval = datetime.timedelta(seconds=60)
+		touch_cooldown = asab.Config.getseconds("seacatauth:session", "touch_cooldown")
+		self.TouchCooldown = datetime.timedelta(seconds=touch_cooldown)
 
 		app.PubSub.subscribe("Application.tick/60!", self._on_tick)
 		app.PubSub.subscribe("Application.run!", self._on_start)
@@ -375,7 +376,8 @@ class SessionService(asab.Service):
 
 	async def touch(self, session: SessionAdapter, expiration: int = None):
 		"""
-		Extend the expiration of the session group if it hasn't been updated recently.
+		Update session modification time to record activity.
+		Also extend session expiration if possible.
 
 		Return the updated session object.
 		"""
@@ -383,28 +385,11 @@ class SessionService(asab.Service):
 		if session.Session.ParentSessionId is not None:
 			await self.touch(await self.get(session.Session.ParentSessionId))
 
-		if datetime.datetime.now(datetime.timezone.utc) < session.Session.ModifiedAt + self.MinimalRefreshInterval:
-			# Session has been extended recently
-			return session
-		if session.Session.Expiration >= session.Session.MaxExpiration:
-			# Session expiration is already maxed out
+		if datetime.datetime.now(datetime.timezone.utc) < session.Session.ModifiedAt + self.TouchCooldown:
+			# Session has been touched recently
 			return session
 
-		if expiration is not None:
-			expiration = datetime.timedelta(seconds=expiration)
-		elif session.Session.ExpirationExtension is not None:
-			expiration = datetime.timedelta(seconds=session.Session.ExpirationExtension)
-		else:
-			# May be a legacy "machine credentials session". Do not extend.
-			return session
-		expires = datetime.datetime.now(datetime.timezone.utc) + expiration
-
-		if expires < session.Session.Expiration:
-			# Do not shorten the session!
-			return session
-		if expires > session.Session.MaxExpiration:
-			# Do not cross maximum expiration
-			expires = session.Session.MaxExpiration
+		expires = self._calculate_extended_expiration(session, expiration)
 
 		# Update session
 		version = session.Session.Version
@@ -413,7 +398,8 @@ class SessionService(asab.Service):
 			session.SessionId,
 			version=version
 		)
-		upsertor.set(SessionAdapter.FN.Session.Expiration, expires)
+		if expires is not None:
+			upsertor.set(SessionAdapter.FN.Session.Expiration, expires)
 
 		try:
 			await upsertor.execute(event_type=EventTypes.SESSION_EXTENDED)
@@ -422,6 +408,29 @@ class SessionService(asab.Service):
 			L.warning("Conflict: Session already extended", struct_data={"sid": session.Session.Id})
 
 		return await self.get(session.SessionId)
+
+
+	def _calculate_extended_expiration(self, session: SessionAdapter, expiration: int = None):
+		if session.Session.Expiration >= session.Session.MaxExpiration:
+			return None
+
+		if expiration is not None:
+			expiration = datetime.timedelta(seconds=expiration)
+		elif session.Session.ExpirationExtension is not None:
+			expiration = datetime.timedelta(seconds=session.Session.ExpirationExtension)
+		else:
+			# May be a legacy "machine credentials session". Do not extend.
+			return None
+		expires = datetime.datetime.now(datetime.timezone.utc) + expiration
+
+		if expires < session.Session.Expiration:
+			# Do not shorten the session!
+			return None
+		if expires > session.Session.MaxExpiration:
+			# Do not cross maximum expiration
+			expires = session.Session.MaxExpiration
+
+		return expires
 
 
 	async def delete(self, session_id):

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -400,12 +400,12 @@ class SessionService(asab.Service):
 		)
 		if expires is not None:
 			upsertor.set(SessionAdapter.FN.Session.Expiration, expires)
+			L.info("Extending session expiration.", struct_data={"sid": session.Session.Id, "exp": expires})
 
 		try:
 			await upsertor.execute(event_type=EventTypes.SESSION_EXTENDED)
-			L.log(asab.LOG_NOTICE, "Session expiration extended", struct_data={"sid": session.Session.Id, "exp": expires})
 		except KeyError:
-			L.warning("Conflict: Session already extended", struct_data={"sid": session.Session.Id})
+			L.warning("Conflict: Session already extended.", struct_data={"sid": session.Session.Id})
 
 		return await self.get(session.SessionId)
 


### PR DESCRIPTION
fixes #222 

The `SessionService.touch()` method updates session `_m` time even if the session is not modified in other ways. This is to record session activity. This update can happen at most once every one minute (by default). This period is configurable with the `touch_cooldown` option in the `[seacatauth:session]` section.

Example:
```ini
[seacatauth:session]
touch_cooldown=5m
```