### PR TITLE
Root session must be as long as its longest subsession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Release candidate
+
+### Fix
+- Root session must be as long as its longest subsession (#228, PLUM Sprint 230630)
+
+---
+
+
 ## v23.27-beta
 
 ### Breaking changes

--- a/docs/integrations/elk.md
+++ b/docs/integrations/elk.md
@@ -20,7 +20,7 @@ Instead of the `PUT /cookie/nginx` endpoint (which exchanges Seacat client cooki
 Batman auth uses `PUT /batman/nginx` (which exchanges Seacat client cookie for Basic auth header).
 
 
-# Configuration example
+## Configuration example
 
 Let's set up Seacat Batman authorization for our Kibana app. We need to have 
 [ElasticSearch](https://www.elastic.co/elasticsearch/) and [Kibana](https://www.elastic.co/kibana/) applications 
@@ -33,7 +33,7 @@ We will need to configure these three components:
   in communication with Seacat Auth.
 - Prepare the necessary **server locations** in Nginx config.
 
-## Seacat Auth configuration
+### Seacat Auth configuration
 
 Create the ELK Batman section and provide ElasticSearch base URL and API credentials, e.g.
 
@@ -44,7 +44,7 @@ username=admin
 password=elasticpassword
 ```
 
-## Client configuration
+### Client configuration
 
 Use Seacat Auth client API (or Seacat Admin UI) to register Kibana as a client. 
 In our case, we can send the following request:
@@ -74,7 +74,7 @@ The server will respond with our client's assigned ID and other attributes:
 
 We will use the `client_id` and `client_cookie` in the next step.
 
-## Nginx configuration
+### Nginx configuration
 
 The minimal configuration requires the following three locations to be defined in nginx:
 
@@ -83,7 +83,7 @@ The minimal configuration requires the following three locations to be defined i
 - **Client cookie entry point:** Public endpoint which dispenses the Seacat client cookie at the end of a successful 
   authorization flow.
 
-### Client site location
+#### Client site location
 
 ```nginx
 location /kibana/ {
@@ -110,7 +110,7 @@ location /kibana/ {
 }
 ```
 
-### Client introspection
+#### Client introspection
 
 ```nginx
 location = /_kibana_introspection {
@@ -136,7 +136,7 @@ location = /_kibana_introspection {
 }
 ```
 
-### Client cookie entry point
+#### Client cookie entry point
 
 Must be located on the same hostname as the protected client location.
 

--- a/docs/reference/session.md
+++ b/docs/reference/session.md
@@ -1,0 +1,47 @@
+---
+title: Session
+---
+
+# Session
+
+- Session object represents user or machine authentication and authorization.
+- The two basic session types are *root* and *client*. 
+  Client sessions can be either *access-token-based* or *cookie-based*. 
+  Furthermore, there are special session types: *machine-to-machine* and *anonymous* session.
+
+## Root session
+
+- Root session is created at user login. 
+- Used as a proof of user authentication (Single Sign-On) for OAuth authorization requests.
+- Uniquely identified by a browser cookie (called `SeaCatSCI` by default).
+
+## Client session (subsession)
+
+- Used as a proof of user and client authorization.
+- Created as a result of a successful OAuth authorization request at `/openidconnect/authorize` endpoint.
+- Descends from a root session; user root session is a prerequisite to creating a client session for that user.
+- Uniquely identified either by OAuth 2.0 Access Token or by browser cookie.
+
+### Access-token-based client session
+
+- Created by authorization request at `/openidconnect/authorize` with `openid` in scope.
+- Suitable for clients that support the OAuth 2.0 protocol.
+- Uniquely identified by OAuth 2.0 Access Token.
+
+### Cookie-based client session
+
+- Created by authorization request at `/openidconnect/authorize` with `cookie` in scope.
+- Suitable for clients that do not support the OAuth 2.0 protocol.
+- Uniquely identified by browser cookie.
+
+## Machine-to-machine (M2M) session
+
+- Special type of root session that includes client authentication and authorization.
+- Serves as a proof of authentication and authorization in machine-to-machine communication (no human user is involved).
+
+## Anonymous session
+
+- Special type of session that identifies an unauthenticated user.
+- Used for tracking visitors at client locations that can be accessed without authentication.
+- It is a client session that can exists without a root session. Anonymous root session is created only when
+  multiple anonymous client sessions need to be linked together.

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -118,7 +118,7 @@ class ResourceService(asab.Service):
 		for resource_id, resource_config in self._BuiltinResources.items():
 			description = resource_config.get("description")
 
-			L.info("Checking for built-in resource {!r}".format(resource_id))
+			L.debug("Checking for built-in resource {!r}".format(resource_id))
 			try:
 				db_resource = await self.get(resource_id)
 			except KeyError:

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -384,22 +384,18 @@ class SessionService(asab.Service):
 		return await collection.count_documents(query_filter)
 
 
-	async def touch(self, session: SessionAdapter, expiration: int = None):
+	async def touch(self, session: SessionAdapter, expires: datetime.datetime = None):
 		"""
 		Update session modification time to record activity.
 		Also extend session expiration if possible.
 
 		Return the updated session object.
 		"""
-		# Extend parent session
-		if session.Session.ParentSessionId is not None:
-			await self.touch(await self.get(session.Session.ParentSessionId))
-
 		if datetime.datetime.now(datetime.timezone.utc) < session.Session.ModifiedAt + self.TouchCooldown:
 			# Session has been touched recently
 			return session
 
-		expires = self._calculate_extended_expiration(session, expiration)
+		expires = self._calculate_extended_expiration(session, expires)
 
 		# Update session
 		version = session.Session.Version
@@ -417,26 +413,28 @@ class SessionService(asab.Service):
 		except KeyError:
 			L.warning("Conflict: Session already extended.", struct_data={"sid": session.Session.Id})
 
+		# Extend parent session
+		if session.Session.ParentSessionId is not None:
+			await self.touch(await self.get(session.Session.ParentSessionId), expires)
+
 		return await self.get(session.SessionId)
 
 
-	def _calculate_extended_expiration(self, session: SessionAdapter, expiration: int = None):
+	def _calculate_extended_expiration(self, session: SessionAdapter, expires: datetime.datetime = None):
 		if session.Session.Expiration >= session.Session.MaxExpiration:
 			return None
 
-		if expiration is not None:
-			expiration = datetime.timedelta(seconds=expiration)
-		elif session.Session.ExpirationExtension is not None:
-			expiration = datetime.timedelta(seconds=session.Session.ExpirationExtension)
-		else:
-			# May be a legacy "machine credentials session". Do not extend.
-			return None
-		expires = datetime.datetime.now(datetime.timezone.utc) + expiration
+		if expires is None:
+			if session.Session.ExpirationExtension is None:
+				# May be a legacy "machine credentials session". Do not extend.
+				return None
+			expires = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+				seconds=session.Session.ExpirationExtension)
 
 		if expires < session.Session.Expiration:
 			# Do not shorten the session!
 			return None
-		if expires > session.Session.MaxExpiration:
+		if session.Session.MaxExpiration is not None and expires > session.Session.MaxExpiration:
 			# Do not cross maximum expiration
 			expires = session.Session.MaxExpiration
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -416,12 +416,13 @@ class SessionService(asab.Service):
 		)
 		if expires is not None:
 			upsertor.set(SessionAdapter.FN.Session.Expiration, expires)
-			L.info("Extending session expiration.", struct_data={"sid": session.Session.Id, "exp": expires})
+			L.info("Extending session expiration.", struct_data={
+				"sid": session.Session.Id, "exp": expires, "v": version})
 
 		try:
 			await upsertor.execute(event_type=EventTypes.SESSION_EXTENDED)
 		except KeyError:
-			L.warning("Conflict: Session already extended.", struct_data={"sid": session.Session.Id})
+			L.warning("Conflict: Session already extended.", struct_data={"sid": session.Session.Id, "v": version})
 
 		return await self.get(session.SessionId)
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -422,7 +422,7 @@ class SessionService(asab.Service):
 		try:
 			await upsertor.execute(event_type=EventTypes.SESSION_EXTENDED)
 		except KeyError:
-			L.warning("Conflict: Session already extended.", struct_data={"sid": session.Session.Id, "v": version})
+			L.warning("Conflict: Session already touched.", struct_data={"sid": session.Session.Id, "v": version})
 
 		return await self.get(session.SessionId)
 


### PR DESCRIPTION
- `SessionService.touch()` makes sure that the parent session is at least as long as the current subsession.
- Added session type overview to docs.