### PR TITLE
Webauthn user_name can be either email address or phone number

### DIFF
--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -268,12 +268,17 @@ class WebAuthnService(asab.Service):
 		https://www.w3.org/TR/webauthn/#dictdef-publickeycredentialcreationoptions
 		"""
 		credentials = await self.CredentialsService.get(session.Credentials.Id)
+		# User_name should be a unique human-palatable identifier (typically email, phone)
+		user_name = credentials.get("email") or credentials.get("phone")
+		if not user_name:
+			raise Exception("Credentials have no email address nor phone number.")
+
 		challenge = await self.create_registration_challenge(session.Session.Id)
 		options = webauthn.generate_registration_options(
 			rp_id=self.RelyingPartyId,
 			rp_name=self.RelyingPartyName,
 			user_id=session.Credentials.Id,
-			user_name=credentials.get("email"),
+			user_name=user_name,
 			user_display_name=credentials.get("username"),
 			challenge=challenge,
 			timeout=self.RegistrationTimeout,


### PR DESCRIPTION
ISSUE: The `GET /public/webauthn/register-options` fails with error for users without email, because the webauthn `user_name` attribute (commonly the email address) cannot be `None`.

FIX: When no email is available, the `user_name` falls back to phone number. If still none, a comprehensive error is raised.