### PR TITLE
Fix Batman token encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Release candidate
 
+### Breaking changes
+- Old Batman sessions are invalidated (#230, PLUM Sprint 230630)
+
 ### Fix
 - Root session must be as long as its longest subsession (#228, PLUM Sprint 230630)
 - Webauthn `user_name` can be either email address or phone number (#229, PLUM Sprint 230630)
+- Batman token uses native ASAB Storage encryption (#230, PLUM Sprint 230630)
+
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Webauthn `user_name` can be either email address or phone number (#229, PLUM Sprint 230630)
 - Batman token uses native ASAB Storage encryption (#230, PLUM Sprint 230630)
 
+### Features
+- Added alternative POST endpoint for Batman introspection (#230, PLUM Sprint 230630)
 
 ---
 

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -315,9 +315,6 @@ class AuthenticationHandler(object):
 				else:
 					set_cookie(self.App, response, impersonator_session)
 
-		if self.BatmanService is not None:
-			response.del_cookie(self.BatmanService.CookieName)
-
 		return response
 
 	async def smslogin(self, request):

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -70,7 +70,7 @@ class M2MIntrospectHandler(object):
 
 		# Find session object
 		try:
-			session = await self.SessionService.get_by({SessionAdapter.FN.Credentials.Id: credentials_id})
+			session = await self.SessionService.get_by(SessionAdapter.FN.Credentials.Id, credentials_id)
 		except KeyError:
 			session = None
 

--- a/seacatauth/batman/handler.py
+++ b/seacatauth/batman/handler.py
@@ -39,11 +39,12 @@ class BatmanHandler(object):
 		**Internal endpoint for Nginx auth_request.**
 		"""
 		cookie_service = self.BatmanService.App.get_service("seacatauth.CookieService")
-		cookie_value = cookie_service.get_session_cookie_value(request, request.query.get("client_id"))
-		if cookie_value is None:
-			return aiohttp.web.HTTPUnauthorized()
 
-		session = await cookie_service.get_session_by_session_cookie_value(cookie_value)
+		client_id = request.query.get("client_id")
+		if client_id is None:
+			raise ValueError("No 'client_id' parameter specified in Batman introspection query.")
+
+		session = await cookie_service.get_session_by_request_cookie(request, request.query.get("client_id"))
 		if session is None or session.Batman is None:
 			return aiohttp.web.HTTPUnauthorized()
 

--- a/seacatauth/batman/handler.py
+++ b/seacatauth/batman/handler.py
@@ -25,9 +25,11 @@ class BatmanHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_put("/batman/nginx", self.batman_nginx)
+		web_app.router.add_post("/batman/nginx", self.batman_nginx)
 
 		# Public endpoints
 		web_app_public.router.add_put("/batman/nginx", self.batman_nginx)
+		web_app_public.router.add_post("/batman/nginx", self.batman_nginx)
 
 
 	async def batman_nginx(self, request):

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -147,7 +147,7 @@ class CookieHandler(object):
 		"""
 		client_id = request.query.get("client_id")
 		if client_id is None:
-			raise ValueError("No 'client_id' parameter specified in anonymous introspection query.")
+			raise ValueError("No 'client_id' parameter specified in cookie introspection query.")
 
 		# TODO: Also check query for scope and validate it
 

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -108,7 +108,7 @@ class CookieService(asab.Service):
 		Get session by cookie value.
 		"""
 		try:
-			session = await self.SessionService.get_by({SessionAdapter.FN.Cookie.Id: cookie_value})
+			session = await self.SessionService.get_by(SessionAdapter.FN.Cookie.Id, cookie_value)
 		except KeyError:
 			L.info("Session not found.", struct_data={"sci": cookie_value})
 			return None

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -201,7 +201,7 @@ class OpenIdConnectService(asab.Service):
 
 		# Locate the session
 		try:
-			session = await self.SessionService.get_by({SessionAdapter.FN.OAuth2.AccessToken: access_token})
+			session = await self.SessionService.get_by(SessionAdapter.FN.OAuth2.AccessToken, access_token)
 		except KeyError:
 			L.info("Session not found by access token: {}".format(access_token))
 			return None

--- a/seacatauth/openidconnect/session.py
+++ b/seacatauth/openidconnect/session.py
@@ -18,4 +18,3 @@ def oauth2_session_builder(oauth2_data):
 	if scope is None or "cookie" not in scope:
 		yield (SessionAdapter.FN.OAuth2.AccessToken, secrets.token_bytes(token_length))
 		yield (SessionAdapter.FN.OAuth2.RefreshToken, secrets.token_bytes(token_length))
-		yield (SessionAdapter.FN.OAuth2.IdToken, None)

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -260,10 +260,10 @@ class SessionService(asab.Service):
 		try:
 			session = SessionAdapter(self, session_dict)
 		except Exception as e:
-			L.error("Failed to create SessionAdapter from database object", struct_data={
+			L.exception("Failed to create SessionAdapter from database object.", struct_data={
 				"sid": session_dict.get("_id"),
 			})
-			raise exceptions.SessionNotFoundError("Session not found in database.", query={key: value}) from e
+			raise exceptions.SessionNotFoundError("Session deserialization failed.", query={key: value}) from e
 
 		return session
 
@@ -281,10 +281,10 @@ class SessionService(asab.Service):
 		try:
 			session = SessionAdapter(self, session_dict)
 		except Exception as e:
-			L.exception("Failed to create SessionAdapter from database object", struct_data={
+			L.exception("Failed to create SessionAdapter from database object.", struct_data={
 				"sid": session_dict.get("_id"),
 			})
-			raise exceptions.SessionNotFoundError("Session not found in database.", session_id=session_id) from e
+			raise exceptions.SessionNotFoundError("Session deserialization failed.", session_id=session_id) from e
 		return session
 
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -205,9 +205,11 @@ class SessionService(asab.Service):
 			session_builders = list()
 		for session_builder in session_builders:
 			for key, value in session_builder:
-				if key in SessionAdapter.SensitiveFields and value is not None:
+				if key in SessionAdapter.EncryptedIdentifierFields and value is not None:
 					value = SessionAdapter.EncryptedPrefix + self.aes_encrypt(value)
-				upsertor.set(key, value)
+					upsertor.set(key, value)
+				else:
+					upsertor.set(key, value, encrypt=(key in SessionAdapter.EncryptedAttributes))
 
 		session_id = await upsertor.execute(event_type=EventTypes.SESSION_CREATED)
 
@@ -234,30 +236,26 @@ class SessionService(asab.Service):
 
 		for session_builder in session_builders:
 			for key, value in session_builder:
-				upsertor.set(key, value)
+				upsertor.set(key, value, encrypt=(key in SessionAdapter.EncryptedAttributes))
 
 		await upsertor.execute(event_type=EventTypes.SESSION_UPDATED)
 
 		return await self.get(session_id)
 
 
-	async def get_by(self, criteria: dict):
+	async def get_by(self, key: str, value):
 		# Encrypt sensitive fields
-		query_filter = {}
-		for key, value in criteria.items():
-			if key in SessionAdapter.SensitiveFields:
-				query_filter[key] = SessionAdapter.EncryptedPrefix + self.aes_encrypt(value)
-			else:
-				query_filter[key] = value
+		if key in SessionAdapter.EncryptedIdentifierFields:
+			value = SessionAdapter.EncryptedPrefix + self.aes_encrypt(value)
 
-		collection = self.StorageService.Database[self.SessionCollection]
-		session_dict = await collection.find_one(query_filter)
+		session_dict = await self.StorageService.get_by(
+			self.SessionCollection, key, value, decrypt=SessionAdapter.EncryptedAttributes)
 		if session_dict is None:
-			raise exceptions.SessionNotFoundError("Session not found in database.", query=criteria)
+			raise exceptions.SessionNotFoundError("Session not found in database.", query={key: value})
 
 		# Do not return expired sessions
 		if session_dict[SessionAdapter.FN.Session.Expiration] < datetime.datetime.now(datetime.timezone.utc):
-			raise exceptions.SessionNotFoundError("Session expired.", query=criteria)
+			raise exceptions.SessionNotFoundError("Session expired.", query={key: value})
 
 		try:
 			session = SessionAdapter(self, session_dict)
@@ -265,7 +263,7 @@ class SessionService(asab.Service):
 			L.error("Failed to create SessionAdapter from database object", struct_data={
 				"sid": session_dict.get("_id"),
 			})
-			raise exceptions.SessionNotFoundError("Session not found in database.", query=criteria) from e
+			raise exceptions.SessionNotFoundError("Session not found in database.", query={key: value}) from e
 
 		return session
 
@@ -273,7 +271,8 @@ class SessionService(asab.Service):
 	async def get(self, session_id):
 		if isinstance(session_id, str):
 			session_id = bson.ObjectId(session_id)
-		session_dict = await self.StorageService.get(self.SessionCollection, session_id)
+		session_dict = await self.StorageService.get(
+			self.SessionCollection, session_id, decrypt=SessionAdapter.EncryptedAttributes)
 
 		# Do not return expired sessions
 		if session_dict[SessionAdapter.FN.Session.Expiration] < datetime.datetime.now(datetime.timezone.utc):


### PR DESCRIPTION
- **`BREAKING`** Old Batman sessions are invalidated.
- Batman token uses native `asab.storage` encryption instead of `seacatauth.session` encryption. This fixes the cryptography error which appears when doing batman introspection for grafana.
- ELK Batman docs updated.
- Added alternative `POST` endpoint for Batman introspection (for consistency with cookie and access token introspection endpoints)