### PR TITLE
Expiration removed from login query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Breaking changes
 - Old Batman sessions are invalidated (#230, PLUM Sprint 230630)
+- Expiration removed from login query params (#233, PLUM Sprint 230630)
 
 ### Fix
 - Root session must be as long as its longest subsession (#228, PLUM Sprint 230630)
 - Webauthn `user_name` can be either email address or phone number (#229, PLUM Sprint 230630)
 - Batman token uses native ASAB Storage encryption (#230, PLUM Sprint 230630)
+- Expiration removed from login query params (#233, PLUM Sprint 230630)
 
 ### Features
 - Added alternative POST endpoint for Batman introspection (#230, PLUM Sprint 230630)

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -88,7 +88,6 @@ class AuthenticationHandler(object):
 		ident = json_data.get("ident")
 
 		# Get arguments specified in login URL query
-		expiration = None
 		login_preferences = None
 		query_string = json_data.get("qs")
 		if query_string is None:
@@ -103,15 +102,6 @@ class AuthenticationHandler(object):
 						L.error("Repeated query parameters are not supported", struct_data={"qs": query_string})
 						raise asab.exceptions.ValidationError("Invalid request")
 					login_dict[k] = v[0]
-
-			# Get requested session expiration
-			# TODO: This option should be moved to client config or removed completely
-			expiration = query_dict.get("expiration")
-			if expiration is not None:
-				try:
-					expiration = float(expiration[0])
-				except Exception as e:
-					L.warning("Error when parsing expiration: {}".format(e))
 
 			# Get preferred login descriptor IDs
 			# TODO: This option should be moved to client config or removed completely
@@ -159,7 +149,6 @@ class AuthenticationHandler(object):
 			client_public_key=key.get_op_key("encrypt"),  # extract EC public key from JWT
 			login_descriptors=login_descriptors,
 			ident=ident,
-			requested_session_expiration=expiration,
 		)
 
 		key = jwcrypto.jwk.JWK.from_pyca(login_session.PublicKey)

--- a/seacatauth/authn/login_session.py
+++ b/seacatauth/authn/login_session.py
@@ -26,7 +26,6 @@ class LoginSession(object):
 		remaining_login_attempts,
 		expires_at,
 		ident,
-		requested_session_expiration=None,
 		public_key=None,
 		data=None
 	):
@@ -44,7 +43,6 @@ class LoginSession(object):
 
 		# Login descriptor that successfully authenticated the login session
 		self.AuthenticatedVia = None
-		self.RequestedSessionExpiration = requested_session_expiration
 
 
 	@classmethod
@@ -56,7 +54,6 @@ class LoginSession(object):
 		login_descriptors,
 		login_attempts,
 		timeout,
-		requested_session_expiration=None,
 		data=None
 	):
 		# Generate shared encryption key
@@ -83,7 +80,6 @@ class LoginSession(object):
 			remaining_login_attempts=login_attempts,
 			expires_at=expires_at,
 			public_key=server_login_key.public_key(),
-			requested_session_expiration=requested_session_expiration,
 			data=data,
 		)
 
@@ -104,7 +100,6 @@ class LoginSession(object):
 				for descriptor in self.LoginDescriptors
 			],
 			"idt": self.Ident,
-			"rse": self.RequestedSessionExpiration,
 			"d": self.Data,
 		}
 		return db_object
@@ -124,7 +119,6 @@ class LoginSession(object):
 			remaining_login_attempts=db_object["la"],
 			expires_at=db_object["exp"],
 			public_key=cryptography.hazmat.primitives.serialization.load_pem_public_key(db_object["pk"]),
-			requested_session_expiration=db_object["rse"],
 			data=db_object["d"],
 		)
 

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -140,7 +140,6 @@ class AuthenticationService(asab.Service):
 		client_public_key,
 		ident,
 		login_descriptors=None,
-		requested_session_expiration=None,
 		data=None,
 	):
 		# Prepare the login session
@@ -151,7 +150,6 @@ class AuthenticationService(asab.Service):
 			login_descriptors=login_descriptors,
 			login_attempts=self.LoginAttempts,
 			timeout=self.LoginSessionExpiration,
-			requested_session_expiration=requested_session_expiration,
 			data=data,
 		)
 
@@ -332,7 +330,6 @@ class AuthenticationService(asab.Service):
 
 		session = await self.SessionService.create_session(
 			session_type="root",
-			expiration=login_session.RequestedSessionExpiration,
 			session_builders=session_builders,
 		)
 		L.log(

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -198,9 +198,10 @@ class AuthorizeHandler(object):
 		# Check the presence of required parameters
 		self._validate_request_parameters(request_parameters)
 
+		# TODO: Remove this. These extra options should either be in scope or in client config.
 		login_parameters = {
 			k: v for k, v in request_parameters.items()
-			if k in frozenset(("ldid", "expiration"))
+			if k in frozenset(("ldid",))
 		}
 
 		# Authentication Code Flow


### PR DESCRIPTION
Expiration removed from login and authorize query params for security reasons. Client attribute `session_expiration` should be used instead.