### PR TITLE
Well-known default ports

### DIFF
--- a/etc/seacatauth.conf
+++ b/etc/seacatauth.conf
@@ -7,21 +7,13 @@ type=mongodb
 mongodb_uri=mongodb://localhost:27017/
 mongodb_database=auth
 # A non-empty AES encryption key is required
-aes_key=
+# aes_key=
 
 [seacatauth:credentials:mongodb:default]
 mongodb_uri=mongodb://localhost:27017
 mongodb_database=auth
 tenants=yes
 register=no
-
-# Auth API container (public)
-[web:public]
-listen=0.0.0.0 3081
-
-# Admin API container (non-public)
-[web]
-listen=0.0.0.0 8900
 
 # Set up SMTP provider for sending activation emails
 # [seacatauth:communication:email:smtp]

--- a/etc/seacatauth.conf
+++ b/etc/seacatauth.conf
@@ -6,6 +6,8 @@ auth_webui_base_url=http://localhost/auth
 type=mongodb
 mongodb_uri=mongodb://localhost:27017/
 mongodb_database=auth
+# A non-empty AES encryption key is required
+aes_key=
 
 [seacatauth:credentials:mongodb:default]
 mongodb_uri=mongodb://localhost:27017
@@ -13,23 +15,19 @@ mongodb_database=auth
 tenants=yes
 register=no
 
-[seacatauth:session]
-; A non-empty AES encryption key is required
-aes_key=
-
+# Auth API container (public)
 [web:public]
-; Public Seacat Auth container
-listen=0.0.0.0 8081
+listen=0.0.0.0 3081
 
+# Admin API container (non-public)
 [web]
-; Non-public Seacat API container
-listen=0.0.0.0 8082
+listen=0.0.0.0 8900
 
-; Set up SMTP provider for sending password reset links
-; [seacatauth:communication:email:smtp]
-; sender_email_address=info@teskalabs.com
-; host=
-; user=
-; password=
-; ssl=no
-; starttls=yes
+# Set up SMTP provider for sending activation emails
+# [seacatauth:communication:email:smtp]
+# sender_email_address=info@teskalabs.com
+# host=
+# user=
+# password=
+# ssl=no
+# starttls=yes

--- a/etc/seacatauth.conf
+++ b/etc/seacatauth.conf
@@ -6,7 +6,8 @@ auth_webui_base_url=http://localhost/auth
 type=mongodb
 mongodb_uri=mongodb://localhost:27017/
 mongodb_database=auth
-# A non-empty AES encryption key is required
+# A non-empty AES encryption key is required.
+# It should be a random string at least 16 characters long.
 # aes_key=
 
 [seacatauth:credentials:mongodb:default]

--- a/example/docker/nginx-conf/nginx.conf
+++ b/example/docker/nginx-conf/nginx.conf
@@ -19,10 +19,10 @@ upstream my_app_api {
     server  localhost:8080;
 }
 upstream seacat_auth_api {
-    server  localhost:8081;
+    server  localhost:3081;
 }
 upstream seacat_admin_api {
-    server  localhost:8082;
+    server  localhost:8900;
 }
 
 server {
@@ -55,8 +55,8 @@ server {
     }
 
     # Public API
-    location /auth/api/seacat_auth {
-        rewrite ^/auth/api/seacat_auth/(.*) /$1 break;
+    location /auth/api/seacat-auth {
+        rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
         proxy_pass http://seacat_auth_api;
     }
 
@@ -75,8 +75,8 @@ server {
     }
 
     # Admin API
-    location /seacat/api/seacat_auth {
-        rewrite ^/seacat/api/seacat_auth/(.*) /$1 break;
+    location /seacat/api/seacat-auth {
+        rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
         proxy_pass http://seacat_admin_api;
 
         auth_request       /_seacat_admin_introspect;
@@ -94,8 +94,8 @@ server {
     }
 
     # Public API
-    location /seacat/api/seacat_auth/public {
-        rewrite ^/seacat/api/seacat_auth/(.*) /$1 break;
+    location /seacat/api/seacat-auth/public {
+        rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
         proxy_pass http://seacat_auth_api;
     }
 

--- a/example/docker/seacatauth-conf/seacatauth.conf
+++ b/example/docker/seacatauth-conf/seacatauth.conf
@@ -6,24 +6,14 @@ auth_webui_base_url=http://localhost/auth
 type=mongodb
 mongodb_uri=mongodb://localhost:27017/
 mongodb_database=auth
+# A non-empty AES encryption key is required
+aes_key=
 
 [seacatauth:credentials:mongodb:default]
 mongodb_uri=mongodb://localhost:27017
 mongodb_database=auth
 tenants=yes
 register=no
-
-[seacatauth:session]
-# A non-empty AES encryption key is required
-aes_key=
-
-[web:public]
-# Seacat Auth API
-listen=0.0.0.0 8081
-
-[web]
-# Seacat Admin API
-listen=0.0.0.0 8082
 
 [logging:file]
 path=/log/seacat-auth.log

--- a/example/docker/seacatauth-conf/seacatauth.conf
+++ b/example/docker/seacatauth-conf/seacatauth.conf
@@ -7,7 +7,7 @@ type=mongodb
 mongodb_uri=mongodb://localhost:27017/
 mongodb_database=auth
 # A non-empty AES encryption key is required
-aes_key=
+# aes_key=
 
 [seacatauth:credentials:mongodb:default]
 mongodb_uri=mongodb://localhost:27017

--- a/example/docker/seacatauth-conf/seacatauth.conf
+++ b/example/docker/seacatauth-conf/seacatauth.conf
@@ -6,7 +6,8 @@ auth_webui_base_url=http://localhost/auth
 type=mongodb
 mongodb_uri=mongodb://localhost:27017/
 mongodb_database=auth
-# A non-empty AES encryption key is required
+# A non-empty AES encryption key is required.
+# It should be a random string at least 16 characters long.
 # aes_key=
 
 [seacatauth:credentials:mongodb:default]

--- a/example/nginx-config/nginx-anonymous.conf
+++ b/example/nginx-config/nginx-anonymous.conf
@@ -73,9 +73,9 @@ server {
 	}
 
     # SeaCat Auth Public API
-	location /auth/api/seacat_auth {
+	location /auth/api/seacat-auth {
 	    # SCA webUI uses only the public part of the API, no authentication required
-		rewrite ^/auth/api/seacat_auth/(.*) /$1 break;
+		rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
 		proxy_pass http://auth_api;
 	}
 

--- a/example/nginx-config/nginx-http.conf
+++ b/example/nginx-config/nginx-http.conf
@@ -67,16 +67,16 @@ server {
 	}
 
     # Public API
-	location /auth/api/seacat_auth {
+	location /auth/api/seacat-auth {
 	    # SCA web UI uses only the public part of the API, no authentication required
-		rewrite ^/auth/api/seacat_auth/(.*) /$1 break;
-		proxy_pass http://localhost:8081;
+		rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
+		proxy_pass http://localhost:3081;
 	}
 
     # OpenIDConnect
 	location /auth/api/openidconnect {
 		rewrite ^/auth/api/(.*) /$1 break;
-		proxy_pass http://localhost:8081;
+		proxy_pass http://localhost:3081;
 	}
 
 
@@ -88,24 +88,24 @@ server {
 	}
 
     # Seacat API
-	location /seacat/api/seacat_auth {
+	location /seacat/api/seacat-auth {
 		# Exchange Access token for ID token
 		auth_request       /_oauth2_introspect;
 		auth_request_set   $authorization $upstream_http_authorization;
 		proxy_set_header   Authorization $authorization;
-		rewrite ^/seacat/api/seacat_auth/(.*) /$1 break;
-		proxy_pass http://localhost:8082;
+		rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
+		proxy_pass http://localhost:8900;
 	}
 
-	location /seacat/api/seacat_auth/public {
-        rewrite ^/seacat/api/seacat_auth/(.*) /$1 break;
-        proxy_pass http://localhost:8081;
+	location /seacat/api/seacat-auth/public {
+        rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
+        proxy_pass http://localhost:3081;
     }
 
     # OpenIDConnect
 	location /seacat/api/openidconnect {
 		rewrite ^/seacat/api/(.*) /$1 break;
-		proxy_pass http://localhost:8081;
+		proxy_pass http://localhost:3081;
 	}
 
 
@@ -115,7 +115,7 @@ server {
 		internal;
 		proxy_method          POST;
 		proxy_set_body        "$http_authorization";
-		proxy_pass            http://localhost:8081/cookie/nginx;
+		proxy_pass            http://localhost:3081/cookie/nginx;
 		proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 	}
 
@@ -124,7 +124,7 @@ server {
 		proxy_method          POST;
 		proxy_set_body        "$http_authorization";
 		proxy_set_header      X-Request-URI "$request_uri";
-		proxy_pass            http://localhost:8081/openidconnect/introspect/nginx;
+		proxy_pass            http://localhost:3081/openidconnect/introspect/nginx;
 		proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 	}
 

--- a/example/nginx-config/nginx-multisubdomain.conf
+++ b/example/nginx-config/nginx-multisubdomain.conf
@@ -32,7 +32,7 @@ server {
         proxy_method          POST;
         proxy_set_body        "$http_authorization";
         proxy_set_header      X-Request-URI "$request_uri";
-        proxy_pass            http://localhost:8081/openidconnect/introspect/nginx?add=credentials&add=tenants&add=roles;
+        proxy_pass            http://localhost:3081/openidconnect/introspect/nginx?add=credentials&add=tenants&add=roles;
         proxy_cache           app_token_responses;
         proxy_cache_key       $http_authorization;
         proxy_cache_lock      on;
@@ -72,15 +72,15 @@ server {
         index index.html;
     }
 
-    location /auth/api/seacat_auth {
+    location /auth/api/seacat-auth {
         # SCA webUI uses only the public part of the API, no authentication required
-        rewrite ^/auth/api/seacat_auth/(.*) /$1 break;
-        proxy_pass http://localhost:8081;
+        rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
+        proxy_pass http://localhost:3081;
     }
 
     location /auth/api/openidconnect {
         rewrite ^/auth/api/(.*) /$1 break;
-        proxy_pass http://localhost:8081;
+        proxy_pass http://localhost:3081;
     }
 
 
@@ -91,22 +91,22 @@ server {
         index index.html;
     }
 
-    location /seacat/api/seacat_auth {
+    location /seacat/api/seacat-auth {
         auth_request /_oauth2_introspect;
         auth_request_set   $authorization $upstream_http_authorization;
         proxy_set_header   Authorization $authorization;
-        rewrite ^/seacat/api/seacat_auth/(.*) /$1 break;
-        proxy_pass http://localhost:8082;
+        rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
+        proxy_pass http://localhost:8900;
     }
 
-    location /seacat/api/seacat_auth/public {
-        rewrite ^/seacat/api/seacat_auth/(.*) /$1 break;
-        proxy_pass http://localhost:8081;
+    location /seacat/api/seacat-auth/public {
+        rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
+        proxy_pass http://localhost:3081;
     }
 
     location /seacat/api/openidconnect {
         rewrite ^/seacat/api/(.*) /$1 break;
-        proxy_pass http://localhost:8081;
+        proxy_pass http://localhost:3081;
     }
 
     error_page 401 403 /auth/api/openidconnect/authorize?response_type=code&scope=openid%20cookie&client_id=signin&prompt=login&redirect_uri=$request_uri;

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -6,12 +6,24 @@ asab.Config.add_defaults({
 	"general": {
 		# Public API base URL lets the app know from what URL is its public API served.
 		# It is used by the OpenIDConnect authorize handler for generating loopback redirect URIs.
+		# For full feature availability, the use of HTTPS and a proper domain name is recommended.
 		"public_api_base_url": "http://localhost/auth/api",
 
 		# Auth web UI base URL lets the app know where the auth web UI is served to the public.
 		# It is used for building login and password reset URIs.
 		# The domain name is extracted for cookie and authentication purposes.
+		# For full feature availability, the use of HTTPS and a proper domain name is recommended.
 		"auth_webui_base_url": "http://localhost/auth",
+	},
+
+	# Admin API (non-public)
+	"web": {
+		"listen": "8900",  # Well-known port
+	},
+
+	# Auth API (public)
+	"web:public": {
+		"listen": "3081",  # Well-known port
 	},
 
 	"openidconnect": {


### PR DESCRIPTION
- Introducing well-known default ports for Seacat Auth web containers. (http://gitlab.teskalabs.int/lmio/lmio-docs/-/merge_requests/83)
- **`BREAKING`** The public **Auth API** web container listens on port **3081** by default.
- **`BREAKING`** The non-public **Admin API** web container listens on port **8900** by default.
- You **don't have to include the `[web]` and `[web:public]` sections** unless you don't want to use the default well-known ports.
- **`BREAKING`** In nginx examples, `seacat_auth` in location paths are replaced with `seacat-auth`. (TeskaLabs/seacat-auth-webui#38 and TeskaLabs/seacat-admin-webui#51)
