### PR TITLE
Upgrade to Python 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Release candidate
+
+### Features
+- Upgrade to Alpine 3.18 and Python 3.11 (#245, PLUM Sprint 230728)
+
+---
+
+
 ## v23.32-beta
 
 ### Breaking changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17 AS stage1
+FROM alpine:3.18 AS stage1
 LABEL maintainer="TeskaLabs Ltd (support@teskalabs.com)"
 
 ENV LANG C.UTF-8
@@ -59,14 +59,14 @@ COPY ./.git /app/seacat-auth/.git
 RUN asab-manifest.py ./MANIFEST.json
 
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN apk add --no-cache \
   python3 \
   openssl \
   openldap
 
-COPY --from=stage1 /usr/lib/python3.10/site-packages /usr/lib/python3.10/site-packages
+COPY --from=stage1 /usr/lib/python3.11/site-packages /usr/lib/python3.11/site-packages
 
 COPY ./seacatauth            /app/seacat-auth/seacatauth
 COPY ./seacatauth.py         /app/seacat-auth/seacatauth.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,7 @@ RUN apk add --no-cache  \
     webauthn \
     pyyaml \
     pymongo \
-    pydantic==1.10 \
     git+https://github.com/TeskaLabs/asab.git
-# There is a broken pydantic dependency in py_webauthn.
-# Remove the "pydantic==1.10" requirement once this is fixed.
-# https://github.com/duo-labs/py_webauthn/issues/156
 
 RUN mkdir -p /app/seacat-auth
 WORKDIR /app/seacat-auth

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -140,7 +140,7 @@ class CredentialsService(asab.Service):
 		ident = ident.strip()
 		credentials_ids = []
 		pending = [
-			provider.locate(ident, self.IdentFields, login_dict)
+			asyncio.create_task(provider.locate(ident, self.IdentFields, login_dict))
 			for provider in self.CredentialProviders.values()]
 		while len(pending) > 0:
 			done, pending = await asyncio.wait(pending)


### PR DESCRIPTION
- Fixed obsolete coroutine handling.
- Dockerfile upgraded to Alpine 3.18 and Python 3.11.