### PR TITLE
OpenID Connect Discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Release candidate
 
+### Fix
+- Default OIDC Issuer name set to the value of PUBLIC_AUTH_API (#249, PLUM Sprint 230811)
+
 ### Features
 - Role list supports searching by name (#247, PLUM Sprint 230811)
+- OIDC/OAuth discovery endpoint (#249, PLUM Sprint 230811)
+- Token revocation endpoint (#249, PLUM Sprint 230811)
+- Added /.well-known/jwks.json endpoint (#249, PLUM Sprint 230811)
 
 ---
 

--- a/example/docker/nginx-conf/nginx.conf
+++ b/example/docker/nginx-conf/nginx.conf
@@ -66,6 +66,12 @@ server {
         proxy_pass http://seacat_auth_api;
     }
 
+    # Well-known (OAuth 2.0)
+    location /auth/api/.well-known {
+        rewrite ^/auth/api/(.*) /$1 break;
+        proxy_pass http://seacat_auth_api;
+    }
+
 
     ######################
     # SeaCat Admin WebUI

--- a/example/docker/nginx-conf/nginx.conf
+++ b/example/docker/nginx-conf/nginx.conf
@@ -55,7 +55,7 @@ server {
     }
 
     # Public API
-    location /auth/api/seacat-auth {
+    location /auth/api/seacat-auth/public {
         rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
         proxy_pass http://seacat_auth_api;
     }

--- a/seacatauth/openidconnect/__init__.py
+++ b/seacatauth/openidconnect/__init__.py
@@ -8,6 +8,7 @@ from .handler.userinfo import UserInfoHandler
 from .handler.introspect import TokenIntrospectionHandler
 from .handler.session import SessionHandler
 from .handler.public_keys import PublicKeysHandler
+from .handler.discovery import DiscoveryHandler
 
 
 class OpenIdConnectModule(asab.Module):
@@ -44,3 +45,4 @@ class OpenIdConnectModule(asab.Module):
 		)
 		self.SessionHandler = SessionHandler(app, self.OpenIdConnectService, self.SessionService)
 		self.PublicKeysHandler = PublicKeysHandler(app, self.OpenIdConnectService)
+		self.DiscoveryHandler = DiscoveryHandler(app, self.OpenIdConnectService)

--- a/seacatauth/openidconnect/handler/discovery.py
+++ b/seacatauth/openidconnect/handler/discovery.py
@@ -65,7 +65,7 @@ class DiscoveryHandler(object):
 			# "registration_endpoint": "{}/public/client/register",  # TODO: Implement a PUBLIC client registration API
 			"scopes_supported": [
 				"openid", "profile", "email", "phone",
-				"cookie", "batman", "anonymous", "impersonate:"],
+				"cookie", "batman", "anonymous", "impersonate:", "tenant:"],
 			"claims_supported": [
 				"sub", "iss", "exp", "iat", "aud", "azp",
 				"preferred_username", "email", "phone_number",

--- a/seacatauth/openidconnect/handler/discovery.py
+++ b/seacatauth/openidconnect/handler/discovery.py
@@ -1,0 +1,84 @@
+import logging
+
+import asab.web.rest
+
+from .. import OpenIdConnectService
+
+#
+
+L = logging.getLogger(__name__)
+
+
+#
+
+
+class DiscoveryHandler(object):
+	"""
+	OpenID Connect Discovery
+
+	https://openid.net/specs/openid-connect-discovery-1_0.html
+
+	---
+	tags: ["OAuth 2.0 / OpenID Connect"]
+	"""
+
+	def __init__(self, app, oidc_svc):
+		self.App = app
+		self.OpenIdConnectService: OpenIdConnectService = oidc_svc
+
+		web_app = app.WebContainer.WebApp
+		web_app.router.add_get("/openidconnect/configuration", self.configuration)
+		web_app.router.add_get("/.well-known/openid-configuration", self.configuration)
+
+		# Public endpoints
+		web_app_public = app.PublicWebContainer.WebApp
+		web_app_public.router.add_get("/openidconnect/configuration", self.configuration)
+		web_app_public.router.add_get("/.well-known/openid-configuration", self.configuration)
+
+
+	async def configuration(self, request):
+		"""
+		OpenID Connect Discovery
+
+		OpenID Providers supporting Discovery MUST make a JSON document available at the path formed by
+		concatenating the string /.well-known/openid-configuration to the Issuer.
+		"""
+		# TODO: Refactor. Extract all this data from OpenIdConnectService.
+		data = {
+			# REQUIRED
+			"issuer": self.OpenIdConnectService.Issuer,
+			"authorization_endpoint": "{}{}".format(
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.AuthorizePath),
+			"token_endpoint": "{}{}".format(
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.TokenPath),
+			"token_endpoint_auth_signing_alg_values_supported": ["ES256"],
+			"jwks_uri": "{}{}".format(
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.JwksPath),
+			"response_types_supported": ["code"],
+			"subject_types_supported": ["public"],
+
+			# RECOMMENDED
+			"userinfo_endpoint": "{}{}".format(
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.UserInfoPath),
+			# "registration_endpoint": "{}/public/client/register",  # TODO: Consider a PUBLIC client registration API
+			"scopes_supported": [
+				"openid", "profile", "email", "phone",
+				"cookie", "batman", "anonymous", "impersonate:"],
+			"claims_supported": [
+				"sub", "iss", "exp", "iat", "aud", "azp",
+				"preferred_username", "email", "phone_number",
+				"sid", "psid", "track_id",
+				"resources", "tenants", "impersonator_sid", "impersonator_cid", "anonymous"],
+
+			# OPTIONAL
+			"end_session_endpoint": "{}{}".format(
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.EndSessionPath),
+			"grant_types_supported": ["authorization_code"],
+			"token_endpoint_auth_methods_supported": ["none"],
+			"prompt_values_supported": ["none", "login", "select_account"],
+			"claim_types_supported": ["normal"],
+			"service_documentation": "https://docs.teskalabs.com/seacat-auth",
+			"ui_locales_supported": ["en-US", "cs-CZ"]
+		}
+
+		return asab.web.rest.json_response(request, data)

--- a/seacatauth/openidconnect/handler/discovery.py
+++ b/seacatauth/openidconnect/handler/discovery.py
@@ -65,7 +65,7 @@ class DiscoveryHandler(object):
 			# "registration_endpoint": "{}/public/client/register",  # TODO: Implement a PUBLIC client registration API
 			"scopes_supported": [
 				"openid", "profile", "email", "phone",
-				"cookie", "batman", "anonymous", "impersonate:", "tenant:"],
+				"cookie", "batman", "anonymous", "impersonate:<credentials_id>", "tenant:<tenant_id>"],
 			"claims_supported": [
 				"sub", "iss", "exp", "iat", "aud", "azp",
 				"preferred_username", "email", "phone_number",

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -32,12 +32,12 @@ class TokenIntrospectionHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/openidconnect/introspect", self.introspect)
-		web_app.router.add_post("/openidconnect/introspect/nginx", self.introspect_nginx)
+		web_app.router.add_post(self.OpenIdConnectService.NginxIntrospectionPath, self.introspect_nginx)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_post("/openidconnect/introspect", self.introspect)
-		web_app_public.router.add_post("/openidconnect/introspect/nginx", self.introspect_nginx)
+		web_app_public.router.add_post(self.OpenIdConnectService.NginxIntrospectionPath, self.introspect_nginx)
 
 
 	async def introspect(self, request):

--- a/seacatauth/openidconnect/handler/public_keys.py
+++ b/seacatauth/openidconnect/handler/public_keys.py
@@ -24,10 +24,12 @@ class PublicKeysHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/openidconnect/public_keys", self.public_keys)
+		web_app.router.add_get("/.well-known/jwks.json", self.public_keys)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_get("/openidconnect/public_keys", self.public_keys)
+		web_app_public.router.add_get("/.well-known/jwks.json", self.public_keys)
 
 
 	async def public_keys(self, request):

--- a/seacatauth/openidconnect/handler/public_keys.py
+++ b/seacatauth/openidconnect/handler/public_keys.py
@@ -23,13 +23,14 @@ class PublicKeysHandler(object):
 		self.OpenIdConnectService = oidc_svc
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_get("/openidconnect/public_keys", self.public_keys)
+		# It is a convention to expose the JWKS at /.well-known/jwks.json
 		web_app.router.add_get("/.well-known/jwks.json", self.public_keys)
+		web_app.router.add_get(self.OpenIdConnectService.JwksPath, self.public_keys)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_get("/openidconnect/public_keys", self.public_keys)
 		web_app_public.router.add_get("/.well-known/jwks.json", self.public_keys)
+		web_app_public.router.add_get(self.OpenIdConnectService.JwksPath, self.public_keys)
 
 
 	async def public_keys(self, request):

--- a/seacatauth/openidconnect/handler/session.py
+++ b/seacatauth/openidconnect/handler/session.py
@@ -26,11 +26,11 @@ class SessionHandler(object):
 		self.SessionService = session_svc
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_get('/openidconnect/logout', self.session_logout)
+		web_app.router.add_get(self.OpenIdConnectService.EndSessionPath, self.session_logout)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_get('/openidconnect/logout', self.session_logout)
+		web_app_public.router.add_get(self.OpenIdConnectService.EndSessionPath, self.session_logout)
 
 
 	async def session_logout(self, request):

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -39,14 +39,14 @@ class TokenHandler(object):
 		self.CookieService = app.get_service("seacatauth.CookieService")
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_post("/openidconnect/token", self.token_request)
-		web_app.router.add_post("/openidconnect/token/revoke", self.token_revoke)
+		web_app.router.add_post(self.OpenIdConnectService.TokenPath, self.token_request)
+		web_app.router.add_post(self.OpenIdConnectService.TokenRevokePath, self.token_revoke)
 		web_app.router.add_put("/openidconnect/token/validate", self.validate_id_token)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_post("/openidconnect/token", self.token_request)
-		web_app_public.router.add_post("/openidconnect/token/revoke", self.token_revoke)
+		web_app_public.router.add_post(self.OpenIdConnectService.TokenPath, self.token_request)
+		web_app_public.router.add_post(self.OpenIdConnectService.TokenRevokePath, self.token_revoke)
 		web_app_public.router.add_put("/openidconnect/token/validate", self.validate_id_token)
 
 

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -1,5 +1,4 @@
 import logging
-import urllib.parse
 import datetime
 
 import aiohttp.web

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -215,28 +215,15 @@ class TokenHandler(object):
 	})
 	async def token_revoke(self, request, *, json_data):
 		"""
-		OAuth 2.0 Access Token Revoke
-		"""
-		# TODO: this is not implemented
-
-		if not self.OpenIdConnectService.check_access_token(request.headers["Authorization"].split()[1]):
-			raise aiohttp.web.HTTPForbidden(reason="User is not authenticated")
-
-		"""
 		https://tools.ietf.org/html/rfc7009
 
 		2.1.  Revocation Request
 		"""
+		if request.Session is None:
+			raise aiohttp.web.HTTPUnauthorized()
 
 		token_type_hint = json_data.get("token_type_hint")  # Optional `access_token` or `refresh_token`
-		if token_type_hint:
-			if token_type_hint == "access_token":
-				self.OpenIdConnectService.invalidate_access_token(json_data["token"])
-			elif token_type_hint == "refresh_token":
-				self.OpenIdConnectService.invalidate_refresh_token(json_data["token"])
-			else:
-				return await self.token_error_response(request, "Unknown token_type_hint {}".format(token_type_hint))
-		self.OpenIdConnectService.invalidate_token(json_data["token"])
+		await self.OpenIdConnectService.revoke_token(json_data["token"], token_type_hint)
 		return aiohttp.web.HTTPOk()
 
 

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -24,13 +24,13 @@ class UserInfoHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		# The Client sends the UserInfo Request using either HTTP GET or HTTP POST.
-		web_app.router.add_get("/openidconnect/userinfo", self.userinfo)
-		web_app.router.add_post("/openidconnect/userinfo", self.userinfo)
+		web_app.router.add_get(self.OpenIdConnectService.UserInfoPath, self.userinfo)
+		web_app.router.add_post(self.OpenIdConnectService.UserInfoPath, self.userinfo)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_get("/openidconnect/userinfo", self.userinfo)
-		web_app_public.router.add_post("/openidconnect/userinfo", self.userinfo)
+		web_app_public.router.add_get(self.OpenIdConnectService.UserInfoPath, self.userinfo)
+		web_app_public.router.add_post(self.OpenIdConnectService.UserInfoPath, self.userinfo)
 
 
 	async def userinfo(self, request):

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -47,6 +47,10 @@ class OpenIdConnectService(asab.Service):
 	# Chapter 2.1. Authorization Request Header Field
 	AuthorizationCodeCollection = "ac"
 	AuthorizePath = "/openidconnect/authorize"
+	TokenPath = "/openidconnect/token"
+	UserInfoPath = "/openidconnect/userinfo"
+	JwksPath = "/openidconnect/public_keys"
+	EndSessionPath = "/openidconnect/logout"
 
 	def __init__(self, app, service_name="seacatauth.OpenIdConnectService"):
 		super().__init__(app, service_name)
@@ -421,15 +425,13 @@ class OpenIdConnectService(asab.Service):
 			userinfo["scope"] = session.OAuth2.Scope
 
 		if session.Credentials.Username is not None:
-			userinfo["username"] = session.Credentials.Username
-			userinfo["preferred_username"] = session.Credentials.Username  # BACK COMPAT, remove after 2023-01-31
+			userinfo["preferred_username"] = session.Credentials.Username
 
 		if session.Credentials.Email is not None:
 			userinfo["email"] = session.Credentials.Email
 
 		if session.Credentials.Phone is not None:
-			userinfo["phone"] = session.Credentials.Phone
-			userinfo["phone_number"] = session.Credentials.Phone   # BACK COMPAT, remove after 2023-01-31
+			userinfo["phone_number"] = session.Credentials.Phone
 
 		if session.Credentials.CustomData is not None:
 			userinfo["custom"] = session.Credentials.CustomData
@@ -576,6 +578,7 @@ class OpenIdConnectService(asab.Service):
 		Check if the client has a registered OAuth Authorize URI. If not, use the default.
 		Extend the URI with query parameters.
 		"""
+		# TODO: This should be removed. There must be only one authorize endpoint.
 		authorize_uri = client_dict.get("authorize_uri")
 		if authorize_uri is None:
 			authorize_uri = "{}{}".format(self.PublicApiBaseUrl, self.AuthorizePath)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -48,9 +48,11 @@ class OpenIdConnectService(asab.Service):
 	AuthorizationCodeCollection = "ac"
 	AuthorizePath = "/openidconnect/authorize"
 	TokenPath = "/openidconnect/token"
+	TokenRevokePath = "/openidconnect/token/revoke"
 	UserInfoPath = "/openidconnect/userinfo"
 	JwksPath = "/openidconnect/public_keys"
 	EndSessionPath = "/openidconnect/logout"
+	NginxIntrospectionPath = "/openidconnect/introspect/nginx"
 
 	def __init__(self, app, service_name="seacatauth.OpenIdConnectService"):
 		super().__init__(app, service_name)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -15,7 +15,7 @@ import jwcrypto.jwt
 import jwcrypto.jwk
 import jwcrypto.jws
 
-from ..generic import add_params_to_url_query, urlparse, urlunparse
+from ..generic import add_params_to_url_query
 from ..session import SessionAdapter
 from ..session import (
 	credentials_session_builder,

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -73,6 +73,10 @@ class OpenIdConnectService(asab.Service):
 			self.PublicApiBaseUrl = public_api_base_url
 
 		self.BearerRealm = asab.Config.get("openidconnect", "bearer_realm")
+
+		# The Issuer value must be an URL, such that when "/.well-known/openid-configuration" is appended to it,
+		# we obtain a valid URL containing the issuer's OpenID configuration metadata.
+		# (https://www.rfc-editor.org/rfc/rfc8414#section-3)
 		self.Issuer = asab.Config.get("openidconnect", "issuer", fallback=None)
 		if self.Issuer is not None:
 			parsed = urllib.parse.urlparse(self.Issuer)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -580,3 +580,12 @@ class OpenIdConnectService(asab.Service):
 		if authorize_uri is None:
 			authorize_uri = "{}{}".format(self.PublicApiBaseUrl, self.AuthorizePath)
 		return add_params_to_url_query(authorize_uri, **query_params)
+
+
+	async def revoke_token(self, token, token_type_hint=None):
+		"""
+		Invalidate a valid token. Currently only access_token type is supported.
+		"""
+		session: SessionAdapter = await self.get_session_by_access_token(token)
+		if session is not None:
+			await self.SessionService.delete(session.SessionId)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -428,12 +428,14 @@ class OpenIdConnectService(asab.Service):
 
 		if session.Credentials.Username is not None:
 			userinfo["preferred_username"] = session.Credentials.Username
+			userinfo["username"] = session.Credentials.Username  # BACK-COMPAT, remove after 2023-01-31
 
 		if session.Credentials.Email is not None:
 			userinfo["email"] = session.Credentials.Email
 
 		if session.Credentials.Phone is not None:
 			userinfo["phone_number"] = session.Credentials.Phone
+			userinfo["phone"] = session.Credentials.Phone  # BACK-COMPAT, remove after 2023-01-31
 
 		if session.Credentials.CustomData is not None:
 			userinfo["custom"] = session.Credentials.CustomData


### PR DESCRIPTION
# Summary
- Default OIDC Issuer name set to the value of `PUBLIC_AUTH_API`.
- OIDC/OAuth discovery endpoint available at `<PUBLIC_AUTH_API>/.well-known/openid-configuration`. 
- JWKS (public keys) now also available at `<PUBLIC_AUTH_API>/.well-known/jwks.json`.
- Added token revocation endpoint.
- Removed refresh token endpoint.
- Updated example NGINX config accordingly.

# OIDC Discovery endpoint

- Returns Authorization server metadata as defined in [RFC8414 (OAuth 2.0 Authorization Server Metadata)](https://www.rfc-editor.org/rfc/rfc8414#section-2) and [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html).

Example response:
```json
{
	"issuer": "https://auth.local.loc/seacat-auth/api",
	"authorization_endpoint": "https://auth.local.loc/seacat-auth/api/openidconnect/authorize",
	"token_endpoint": "https://auth.local.loc/seacat-auth/api/openidconnect/token",
	"token_endpoint_auth_signing_alg_values_supported": [
		"ES256"
	],
	"jwks_uri": "https://auth.local.loc/seacat-auth/api/openidconnect/public_keys",
	"response_types_supported": [
		"code"
	],
	"subject_types_supported": [
		"public"
	],
	"userinfo_endpoint": "https://auth.local.loc/seacat-auth/api/openidconnect/userinfo",
	"scopes_supported": [
		"openid",
		"profile",
		"email",
		"phone",
		"cookie",
		"batman",
		"anonymous",
		"impersonate:",
		"tenant:"
	],
	"claims_supported": [
		"sub",
		"iss",
		"exp",
		"iat",
		"aud",
		"azp",
		"preferred_username",
		"email",
		"phone_number",
		"sid",
		"psid",
		"track_id",
		"resources",
		"tenants",
		"impersonator_sid",
		"impersonator_cid",
		"anonymous"
	],
	"end_session_endpoint": "https://auth.local.loc/seacat-auth/api/openidconnect/logout",
	"revocation_endpoint": "https://auth.local.loc/seacat-auth/api/openidconnect/token/revoke",
	"grant_types_supported": [
		"authorization_code"
	],
	"token_endpoint_auth_methods_supported": [
		"none"
	],
	"prompt_values_supported": [
		"none",
		"login",
		"select_account"
	],
	"claim_types_supported": [
		"normal"
	],
	"service_documentation": "https://docs.teskalabs.com/seacat-auth",
	"ui_locales_supported": [
		"en-US",
		"cs-CZ"
	],
	"code_challenge_methods_supported": [
		"plain",
		"S256"
	],
	"nginx_introspection_endpoint": "https://auth.local.loc/seacat-auth/api/openidconnect/introspect/nginx"
}
```