### PR TITLE
FIDO metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 - Support tenant search in old MongoDB versions (#268, PLUM Sprint 230908)
+- Webauthn authenticator metadata (#256, PLUM Sprint 230908)
 
 ---
 

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -110,6 +110,7 @@ class WebAuthnService(asab.Service):
 		aaguid = int(verified_registration.aaguid.replace("-", ""), 16)
 		if aaguid == 0:
 			# FIXME: Identify using attestationCertificateKeyIdentifiers
+			#   https://fidoalliance.org/fido-technotes-the-truth-about-attestation/
 			metadata = None
 		else:
 			metadata = self.FidoMetadata.get(aaguid)

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -56,7 +56,7 @@ class WebAuthnService(asab.Service):
 
 		self.KeyNameRegex = re.compile(r"^[a-z][a-z0-9._-]{0,128}[a-z0-9]$")
 
-		self.FidoMetadata: typing.Dict[str, dict] | None = None
+		self.FidoMetadata: typing.Dict[int, dict] | None = None
 
 		app.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
 
@@ -70,6 +70,7 @@ class WebAuthnService(asab.Service):
 
 
 	async def _load_fido_metadata(self, speculative=True):
+		# TODO: Consider persistent local cache
 		if speculative and self.FidoMetadata is not None:
 			return
 		# FIXME: try/except

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -26,6 +26,12 @@ L = logging.getLogger(__name__)
 #
 
 
+asab.Config.add_defaults({
+	"seacatauth:webauthn": {
+		"attestation": "direct"
+	}
+})
+
 class WebAuthnService(asab.Service):
 	WebAuthnCredentialCollection = "wa"
 	WebAuthnRegistrationChallengeCollection = "warc"
@@ -51,10 +57,10 @@ class WebAuthnService(asab.Service):
 		if self.RelyingPartyId is None:
 			self.RelyingPartyId = str(urllib.parse.urlparse(self.Origin).hostname)
 
-		self.AttestationPreference = asab.Config.get("seacatauth:webauthn", "attestation", fallback="none")
+		self.AttestationPreference = asab.Config.get("seacatauth:webauthn", "attestation")
 		# Use "indirect" or "direct" attestation to get metadata about registered authenticators.
 		# Doing so may however impose higher trust requirements on your environment though.
-		if self.AttestationPreference not in frozenset(["none", "direct", "indirect", "enterprise"]):
+		if self.AttestationPreference not in {"none", "direct", "indirect", "enterprise"}:
 			raise ValueError("Unsupported WebAuthn 'attestation' value: {!r}".format(self.AttestationPreference))
 
 		self.RegistrationTimeout = asab.Config.getseconds("seacatauth:webauthn", "challenge_timeout") * 1000
@@ -112,7 +118,7 @@ class WebAuthnService(asab.Service):
 		# Other identifiers (AAID, AKI) are not supported at the moment.
 		bulk = []
 		for entry in entries:
-			if not "aaguid" in entry:
+			if "aaguid" not in entry:
 				continue
 			aaguid = bytes.fromhex(entry["aaguid"].replace("-", ""))
 			metadata = entry.get("metadataStatement")


### PR DESCRIPTION
closes #251 

- Registered WebAuthn devices now have a human-readable name (if they are found in the FIDO Metadata Service).
- Preferred attestation changed to `direct`, to request extra weabuthn registration metadata from browsers.