### PR TITLE
Unified SMTP config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Release candidate
 
+## Breaking changes
+- Config option `sender_email_address` is now called `from` (#257, PLUM Sprint 230825)
+
 ### Fix
-- Add id_token_signing_alg_values_supported in OIDC discovery (#260)
+- Add `id_token_signing_alg_values_supported` in OIDC discovery (#260)
 
 ### Features
 - Unified SMTP config (#257, PLUM Sprint 230825)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fix
 - Add id_token_signing_alg_values_supported in OIDC discovery (#260)
 
+### Features
+- Unified SMTP config (#257, PLUM Sprint 230825)
+
 ---
 
 

--- a/seacatauth/communication/email_smtp.py
+++ b/seacatauth/communication/email_smtp.py
@@ -30,6 +30,8 @@ class SMTPProvider(CommunicationProviderABC):
 	def __init__(self, provider_id, config_section_name):
 		super().__init__(provider_id, config_section_name)
 
+		if "smtp" in asab.Config:
+			self.Config.update(asab.Config["smtp"])
 		self.SSL = self.Config.getboolean("ssl")
 		self.StartTLS = self.Config.getboolean("starttls")
 		self.Host = self.Config.get("host")


### PR DESCRIPTION
# Breaking changes
- `sender_email_address` config option renamed to `from`.

# Changes
- Config section `[seacatauth:communication:email:smtp]` is now updated with the content of section `[smtp]`. 
- **NOTE**: The `[seacatauth:communication:email:smtp]` section must still be included (even if empty) for the SMTP provider to be enabled.

Example config:
```ini
[seacatauth:communication:email:smtp]

[smtp]
from=info@example.com
host=smtp.sendgrid.net
user=apikey
password=abcdef123456
ssl=no
starttls=yes
```
