### PR TITLE
Re-lock webauthn package version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fix
 - Default OIDC Issuer name set to the value of PUBLIC_AUTH_API (#249, PLUM Sprint 230811)
+- Re-lock webauthn package version (#258, PLUM Sprint 230811)
 
 ### Features
 - Role list supports searching by name (#247, PLUM Sprint 230811)

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,12 @@ RUN apk add --no-cache  \
     aiomysql \
     jinja2 \
     pyotp \
-    webauthn \
+    webauthn==1.9.0 \
     pyyaml \
     pymongo \
     git+https://github.com/TeskaLabs/asab.git
+# There is a broken pydantic dependency in webauthn.
+# Remove the version lock once this is fixed.
 
 RUN mkdir -p /app/seacat-auth
 WORKDIR /app/seacat-auth


### PR DESCRIPTION
the latest webauthn still has the pydantic v2 incompatibility issue
https://github.com/duo-labs/py_webauthn/issues/156