### PR TITLE
Endpoint for pruning old audit entries

### DIFF
--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -53,8 +53,9 @@ class SeaCatAuthApplication(asab.Application):
 		self.ApiService = ApiService(self)
 		self.ApiService.initialize_web(self.WebContainer)
 
-		from .audit import AuditService
+		from .audit import AuditService, AuditHandler
 		self.AuditService = AuditService(self)
+		self.AuditHandler = AuditHandler(self, self.AuditService)
 
 		# Load Resource service
 		from .authz import ResourceService, ResourceHandler

--- a/seacatauth/audit/__init__.py
+++ b/seacatauth/audit/__init__.py
@@ -1,7 +1,9 @@
 from .service import AuditService
+from .handler import AuditHandler
 from .codes import AuditCode
 
 __all__ = [
 	"AuditService",
+	"AuditHandler",
 	"AuditCode",
 ]

--- a/seacatauth/audit/handler.py
+++ b/seacatauth/audit/handler.py
@@ -1,0 +1,52 @@
+import datetime
+import logging
+
+import asab
+import asab.utils
+import asab.web.rest
+
+from seacatauth.decorators import access_control
+
+#
+
+L = logging.getLogger(__name__)
+
+#
+
+
+class AuditHandler(object):
+	"""
+	Audit management
+
+	---
+	tags: ["Audit management"]
+	"""
+
+	def __init__(self, app, audit_service):
+		self.AuditService = audit_service
+
+		web_app = app.WebContainer.WebApp
+		web_app.router.add_put("/audit/prune", self.prune_old_audit_entries)
+
+	@asab.web.rest.json_schema_handler({
+		"type": "object",
+		"additionalProperties": False,
+		"properties": {
+			"max_age": {
+				"oneOf": [
+					{"type": "string"},
+					{"type": "number"}],
+				"description":
+					"Duration string or number of seconds specifying the maximum age of audit entries "
+					"which will be retained."}}
+	})
+	@access_control("authz:superuser")
+	async def prune_old_audit_entries(self, request, *, json_data):
+		"""
+		Delete audit entries older than specified age.
+		"""
+		max_age = asab.utils.convert_to_seconds(json_data["max_age"])
+		before_datetime = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=max_age)
+		deleted_count = await self.AuditService.delete_old_entries(before_datetime)
+		return asab.web.rest.json_response(request, {
+			"result": "OK", "count": deleted_count})

--- a/seacatauth/audit/service.py
+++ b/seacatauth/audit/service.py
@@ -14,9 +14,7 @@ L = logging.getLogger(__name__)
 
 class AuditService(asab.Service):
 
-
-	AuditCollection = 'a'
-
+	AuditCollection = "a"
 
 	def __init__(self, app, service_name="seacatauth.AuditService"):
 		super().__init__(app, service_name)
@@ -39,6 +37,16 @@ class AuditService(asab.Service):
 
 		coll = await self.StorageService.collection(self.AuditCollection)
 		await coll.insert_one(attributes)
+
+
+	async def delete_old_entries(self, before_datetime: datetime.datetime):
+		coll = await self.StorageService.collection(self.AuditCollection)
+		result = await coll.delete_many({"_c": {"$lt": before_datetime}})
+		if result.deleted_count > 0:
+			L.log(asab.LOG_NOTICE, "Old audit entries deleted.", struct_data={
+				"count": result.deleted_count
+			})
+		return result.deleted_count
 
 
 	async def _get_latest_entry(self, field_name, **kwargs) -> dict:


### PR DESCRIPTION
closes #255 

# API

Prune audit entries older than specified age.

```
PUT /audit/prune
{
  "max_age": "<duration>"
}
```
 
