### PR TITLE
Add 'id_token_signing_alg_values_supported' to OIDP discovery endpoint response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Release candidate
+
+### Fix
+- Add id_token_signing_alg_values_supported in OIDC discovery (#260)
+
+---
+
+
 ## v23.36-beta
 
 ### Fix

--- a/seacatauth/openidconnect/handler/discovery.py
+++ b/seacatauth/openidconnect/handler/discovery.py
@@ -54,6 +54,7 @@ class DiscoveryHandler(object):
 			"token_endpoint": "{}{}".format(
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.TokenPath),
 			"token_endpoint_auth_signing_alg_values_supported": ["ES256"],
+			"id_token_signing_alg_values_supported": ["ES256"],
 			"jwks_uri": "{}{}".format(
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.JwksPath),
 			"response_types_supported": ["code"],

--- a/seacatauth/openidconnect/handler/discovery.py
+++ b/seacatauth/openidconnect/handler/discovery.py
@@ -53,7 +53,8 @@ class DiscoveryHandler(object):
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.AuthorizePath),
 			"token_endpoint": "{}{}".format(
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.TokenPath),
-			"token_endpoint_auth_signing_alg_values_supported": ["ES256"],
+			# TODO: The algorithm RS256 MUST be included.
+			#  (https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata)
 			"id_token_signing_alg_values_supported": ["ES256"],
 			"jwks_uri": "{}{}".format(
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.JwksPath),


### PR DESCRIPTION
Context: 
According to [OIDP Discovery documentation](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata), the discovery endpoint must also return `id_token_signing_alg_values_supported` field. 

When using for example client library for OIDP authentication (AppAuth) configured so that it use the discovery document, the client library refuses to read the discovery document because current implementation does not follow the OIDP Discovery specification. This PR fixes that.