### PR TITLE
Public invitation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 - Support tenant search in old MongoDB versions (#268, PLUM Sprint 230908)
+- Public invitations to tenant (#261, PLUM Sprint 230908)
 
 ---
 

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -71,10 +71,7 @@ class ResourceService(asab.Service):
 			"description": "Delete tenant.",
 		},
 		"seacat:tenant:assign": {
-			"description": "Assign and unassign tenant members.",
-		},
-		"seacat:tenant:invite": {
-			"description": "Invite users to tenant.",
+			"description": "Assign and unassign tenant members, invite new users to tenant.",
 		},
 		"seacat:role:access": {
 			"description": "Search tenant roles, view role detail and list role bearers.",

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -73,6 +73,9 @@ class ResourceService(asab.Service):
 		"seacat:tenant:assign": {
 			"description": "Assign and unassign tenant members.",
 		},
+		"seacat:tenant:invite": {
+			"description": "Invite users to tenant.",
+		},
 		"seacat:role:access": {
 			"description": "Search tenant roles, view role detail and list role bearers.",
 		},

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -60,7 +60,7 @@ class RegistrationHandler(object):
 			"email": {"type": "string"},
 		}
 	})
-	@access_control("seacat:tenant:invite")
+	@access_control("seacat:tenant:assign")
 	async def public_create_invitation(self, request, *, tenant, credentials_id, json_data):
 		"""
 		Common user request to invite a new user to join specified tenant and create an account
@@ -107,7 +107,7 @@ class RegistrationHandler(object):
 				"examples": ["6 h", "3d", "1w", 7200]},
 		},
 	})
-	@access_control("seacat:tenant:invite")
+	@access_control("seacat:tenant:assign")
 	async def admin_create_invitation(self, request, *, tenant, credentials_id, json_data):
 		"""
 		Admin request to register a new user and invite them to the specified tenant.

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -34,8 +34,9 @@ class RegistrationHandler(object):
 		self.AuditService = app.get_service("seacatauth.AuditService")
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_post("/{tenant}/invite", self.create_invitation)
+		web_app.router.add_post("/{tenant}/invite", self.admin_create_invitation)
 		web_app.router.add_post("/invite/{credentials_id}", self.resend_invitation)
+		web_app.router.add_post("/public/{tenant}/invite", self.public_create_invitation)
 		web_app.router.add_post("/public/register", self.request_self_invitation)
 		web_app.router.add_get("/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.get_registration)
 		web_app.router.add_put("/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.update_registration)
@@ -44,10 +45,46 @@ class RegistrationHandler(object):
 
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_post("/public/register", self.request_self_invitation)
+		web_app_public.router.add_post("/public/{tenant}/invite", self.public_create_invitation)
 		web_app_public.router.add_get("/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.get_registration)
 		web_app_public.router.add_put("/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.update_registration)
 		web_app_public.router.add_post(
 			"/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.complete_registration)
+
+
+	@asab.web.rest.json_schema_handler({
+		"type": "object",
+		"required": ["email"],  # TODO: Enable more communication options
+		"additionalProperties": False,
+		"properties": {
+			"email": {"type": "string"},
+		}
+	})
+	@access_control("seacat:tenant:invite")
+	async def public_create_invitation(self, request, *, tenant, credentials_id, json_data):
+		"""
+		Common user request to invite a new user to join specified tenant and create an account
+		if they don't have one yet. The invited user gets a registration link in their email.
+		"""
+		# Get IPs of the invitation issuer
+		access_ips = [request.remote]
+		forwarded_for = request.headers.get("X-Forwarded-For")
+		if forwarded_for is not None:
+			access_ips.extend(forwarded_for.split(", "))
+
+		expiration = json_data.get("expiration")
+		if isinstance(expiration, str):
+			expiration = asab.utils.convert_to_seconds(expiration)
+		else:
+			expiration = self.RegistrationService.RegistrationExpiration
+
+		credential_data = {"email": json_data.get("email")}
+
+		await self._create_invitation(
+			tenant, credential_data, expiration, access_ips,
+			invited_by_cid=credentials_id)
+
+		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
 	@asab.web.rest.json_schema_handler({
@@ -69,8 +106,8 @@ class RegistrationHandler(object):
 				"examples": ["6 h", "3d", "1w", 7200]},
 		},
 	})
-	@access_control("seacat:tenant:assign")  # TODO: Maybe create a dedicated resource for invitations
-	async def create_invitation(self, request, *, tenant, credentials_id, json_data):
+	@access_control("seacat:tenant:invite")
+	async def admin_create_invitation(self, request, *, tenant, credentials_id, json_data):
 		"""
 		Admin request to register a new user and invite them to the specified tenant.
 		Generate a registration code and send a registration link to the user's email.
@@ -89,11 +126,20 @@ class RegistrationHandler(object):
 
 		credential_data = json_data["credentials"]
 
+		# Assign tenant
+		invited_credentials_id = await self._create_invitation(
+			tenant, credential_data, expiration, access_ips,
+			invited_by_cid=credentials_id)
+
+		return asab.web.rest.json_response(request, {"credentials_id": invited_credentials_id})
+
+
+	async def _create_invitation(self, tenant, credential_data, expiration, access_ips, invited_by_cid):
 		# Create invitation
 		invited_credentials_id, registration_code = await self.RegistrationService.draft_credentials(
 			credential_data=credential_data,
 			expiration=expiration,
-			invited_by_cid=credentials_id,
+			invited_by_cid=invited_by_cid,
 			invited_from_ips=access_ips,
 		)
 
@@ -109,11 +155,7 @@ class RegistrationHandler(object):
 			expires_at=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=expiration)
 		)
 
-		payload = {
-			"credentials_id": invited_credentials_id,
-		}
-
-		return asab.web.rest.json_response(request, payload)
+		return invited_credentials_id
 
 
 	@access_control("seacat:tenant:assign")

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -66,6 +66,7 @@ class RegistrationHandler(object):
 		Common user request to invite a new user to join specified tenant and create an account
 		if they don't have one yet. The invited user gets a registration link in their email.
 		"""
+		# TODO: Limit the number of requests
 		# Get IPs of the invitation issuer
 		access_ips = [request.remote]
 		forwarded_for = request.headers.get("X-Forwarded-For")


### PR DESCRIPTION
# Changes
- Anyone authorized for `seacat:tenant:assign` can use `POST /public/{tenant}/invite` to invite a user to the specified tenant. This endpoint is included in the public API.
- Resending invitation automatically extends its expiration.
