### PR TITLE
Revise logging levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fix
 - Add `id_token_signing_alg_values_supported` in OIDC discovery (#260)
 - Add support for `nonce` authorize parameter (#263, PLUM Sprint 230908)
+- Handle special characters in login ident (#264, PLUM Sprint 230908)
 
 ### Features
 - Unified SMTP config (#257, PLUM Sprint 230825)

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -134,7 +134,6 @@ class AuthenticationHandler(object):
 		if login_descriptors is None:
 			# Prepare fallback login descriptors for fake login session
 			credentials_id = ""
-			L.log(asab.LOG_NOTICE, "Creating fake login session.", struct_data={"ident": ident})
 			login_descriptors = await self.AuthenticationService.prepare_fallback_login_descriptors(
 				credentials_id=credentials_id,
 				request_headers=request.headers
@@ -146,6 +145,10 @@ class AuthenticationHandler(object):
 			login_descriptors=login_descriptors,
 			ident=ident,
 		)
+
+		if login_session.CredentialsId == "":
+			L.log(asab.LOG_NOTICE, "Fake login session created.", struct_data={
+				"ident": ident, "lsid": login_session.Id})
 
 		key = jwcrypto.jwk.JWK.from_pyca(login_session.PublicKey)
 

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -110,7 +110,7 @@ class AuthenticationHandler(object):
 		# Locate credentials
 		credentials_id = await self.CredentialsService.locate(ident, stop_at_first=True, login_dict=login_dict)
 		if credentials_id is None or credentials_id == []:
-			L.warning("Cannot locate credentials.", struct_data={"ident": ident})
+			L.log(asab.LOG_NOTICE, "Cannot locate credentials.", struct_data={"ident": ident})
 			# Empty credentials is used for creating a fake login session
 			credentials_id = ""
 
@@ -134,15 +134,11 @@ class AuthenticationHandler(object):
 		if login_descriptors is None:
 			# Prepare fallback login descriptors for fake login session
 			credentials_id = ""
-			L.warning("Creating fake login session.", struct_data={"ident": ident})
+			L.log(asab.LOG_NOTICE, "Creating fake login session.", struct_data={"ident": ident})
 			login_descriptors = await self.AuthenticationService.prepare_fallback_login_descriptors(
 				credentials_id=credentials_id,
 				request_headers=request.headers
 			)
-
-		if login_descriptors is None:
-			L.error("Fatal error: Failed to prepare fallback login descriptors.", struct_data={"ident": ident})
-			raise aiohttp.web.HTTPInternalServerError()
 
 		login_session = await self.AuthenticationService.create_login_session(
 			credentials_id=credentials_id,

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -133,7 +133,7 @@ class M2MIntrospectHandler(object):
 			try:
 				response = await nginx_introspection(request, session, self.App)
 			except Exception as e:
-				L.warning("Request authorization failed: {}".format(e), exc_info=True)
+				L.exception("Request authorization failed: {}".format(e))
 				response = aiohttp.web.HTTPUnauthorized()
 		else:
 			response = aiohttp.web.HTTPUnauthorized()

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -220,12 +220,15 @@ class AuthenticationService(asab.Service):
 		)
 
 	async def prepare_fallback_login_descriptors(self, credentials_id, request_headers):
-		return await self._prepare_login_descriptors(
+		login_descriptors = await self._prepare_login_descriptors(
 			self.LoginDescriptorFallback,
 			credentials_id,
 			request_headers,
 			login_preferences=None
 		)
+		if login_descriptors is None:
+			raise Exception("Failed to prepare fallback login descriptors.")
+		return login_descriptors
 
 	async def _prepare_login_descriptors(self, login_descriptors, credentials_id, request_headers, login_preferences=None):
 		ready_login_descriptors = []

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -282,7 +282,7 @@ class AuthenticationService(asab.Service):
 		"""
 		# Fail if we have a fake login session
 		if login_session.CredentialsId == "":
-			L.warning("Login failed: Fake login session")
+			L.log(asab.LOG_NOTICE, "Login failed: Fake login session", struct_data={"lsid": login_session.Id})
 			return False
 
 		# First make sure that the user is not suspended

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -168,8 +168,8 @@ class RoleService(asab.Service):
 			# Global-only resources cannot be assigned to a tenant role
 			for resource in resources_to_assign:
 				if self.ResourceService.is_global_only_resource(resource):
-					message = "Cannot assign global-only resources to tenant roles"
-					L.warning(message, struct_data={"resource": resource, "role": role_id})
+					message = "Cannot assign global-only resources to tenant roles."
+					L.error(message, struct_data={"resource": resource, "role": role_id})
 					raise asab.exceptions.ValidationError(message)
 
 		if resources_to_set is None:

--- a/seacatauth/communication/service.py
+++ b/seacatauth/communication/service.py
@@ -68,10 +68,10 @@ class CommunicationService(asab.Service):
 
 			# Assuming there can be only one provider per channel (only one email provider, one sms provider)
 			if channel not in self.CHANNELS:
-				L.warning("Unsupported channel: '{}'".format(channel))
+				L.error("Unsupported channel: '{}'".format(channel))
 				continue
 			if channel in self.CommunicationProviders:
-				L.warning("There is already a '{}' provider".format(channel))
+				L.error("There is already a '{}' provider".format(channel))
 				continue
 			if provider_id == "seacatauth.communication.email.smtp":
 				from . import SMTPProvider
@@ -84,10 +84,10 @@ class CommunicationService(asab.Service):
 				self.CommunicationProviders[channel] = SMSBranaCZProvider(provider_id, section)
 				self.MessageBuilders[channel] = SMSMessageBuilder(section)
 			else:
-				L.warning("Unsupported communication provider: '{}'".format(provider_id))
+				L.error("Unsupported communication provider: '{}'".format(provider_id))
 
 		if len(self.CommunicationProviders) == 0:
-			L.warning("No communication provider configured.")
+			L.error("No communication provider configured.")
 
 	def get_communication_provider(self, channel):
 		provider = self.CommunicationProviders.get(channel)
@@ -138,7 +138,7 @@ class CommunicationService(asab.Service):
 				provider = self.get_communication_provider(channel)
 				message_builder = self.get_message_builder(channel)
 			except KeyError as e:
-				L.warning("Cannot send {} message: {}".format(channel, e))
+				L.error("Cannot send {} message: {}".format(channel, e))
 				continue
 
 			# Template provider produces a message object with "message_body"
@@ -189,7 +189,7 @@ class CommunicationService(asab.Service):
 			provider = self.get_communication_provider(channel)
 			message_builder = self.get_message_builder(channel)
 		except KeyError as e:
-			L.warning("Cannot send {} message: {}".format(channel, e))
+			L.error("Cannot send {} message: {}".format(channel, e))
 			return False
 
 		# Template provider produces a message object with "message_body"
@@ -233,7 +233,7 @@ class CommunicationService(asab.Service):
 				provider = self.get_communication_provider(channel)
 				message_builder = self.get_message_builder(channel)
 			except KeyError as e:
-				L.warning("Cannot send {} message: {}".format(channel, e))
+				L.error("Cannot send {} message: {}".format(channel, e))
 				continue
 
 			try:

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -163,7 +163,7 @@ class CookieHandler(object):
 			try:
 				response = await nginx_introspection(request, session, self.App)
 			except Exception as e:
-				L.warning("Request authorization failed: {}".format(e), exc_info=True)
+				L.error("Request authorization failed: {}".format(e), exc_info=True)
 				response = aiohttp.web.HTTPUnauthorized()
 
 		if response.status_code != 200:
@@ -255,7 +255,7 @@ class CookieHandler(object):
 			try:
 				response = await nginx_introspection(request, session, self.App)
 			except Exception as e:
-				L.warning("Request authorization failed: {}".format(e), exc_info=True)
+				L.error("Request authorization failed: {}".format(e), exc_info=True)
 				response = aiohttp.web.HTTPUnauthorized()
 
 		cookie_domain = client.get("cookie_domain") or None

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -121,7 +121,7 @@ class CookieService(asab.Service):
 		try:
 			cookie_value = base64.urlsafe_b64decode(cookie_value.encode("ascii"))
 		except ValueError:
-			L.warning("Cookie value is not base64", struct_data={"sci": cookie_value})
+			L.error("Cookie value is not base64", struct_data={"sci": cookie_value})
 			return None
 
 		try:
@@ -130,7 +130,7 @@ class CookieService(asab.Service):
 			L.info("Session not found.", struct_data={"sci": cookie_value})
 			return None
 		except ValueError:
-			L.warning("Error retrieving session.", exc_info=True, struct_data={"sci": cookie_value})
+			L.exception("Error retrieving session.", struct_data={"sci": cookie_value})
 			return None
 
 		return session

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -105,7 +105,7 @@ class ChangePasswordService(asab.Service):
 		# Verify if credentials exists
 		creds = await self.CredentialsService.get(credentials_id)
 		if creds is None:
-			L.warning("Cannot find credentials", struct_data={"cid": credentials_id})
+			L.error("Cannot find credentials", struct_data={"cid": credentials_id})
 			return False
 
 		if expiration is None:
@@ -135,7 +135,7 @@ class ChangePasswordService(asab.Service):
 		try:
 			provider = self.CredentialsService.get_provider(credentials_id)
 		except KeyError:
-			L.warning("Provider not found", struct_data={'cid': credentials_id})
+			L.error("Provider not found", struct_data={'cid': credentials_id})
 			return "FAILED"
 
 		assert (provider is not None)
@@ -195,7 +195,7 @@ class ChangePasswordService(asab.Service):
 		try:
 			await self.delete_pwdreset_tokens_by_cid(cid=credentials_id)
 		except Exception as e:
-			L.warning(
+			L.error(
 				"Unable to remove old password change requests: {} ({})".format(type(e), e),
 				struct_data={'cid': credentials_id}
 			)
@@ -227,5 +227,5 @@ class ChangePasswordService(asab.Service):
 		if credentials_id is not None:
 			await self.init_password_change(credentials_id)
 		else:
-			L.warning("No credentials matching '{}'".format(ident))
+			L.log(asab.LOG_NOTICE, "Ident matched no credentials.", struct_data={"ident": ident})
 		return True  # Since this is public, don't disclose the true result

--- a/seacatauth/credentials/providers/abc.py
+++ b/seacatauth/credentials/providers/abc.py
@@ -62,14 +62,6 @@ class CredentialsProviderABC(asab.Configurable, abc.ABC):
 		return []
 
 
-	async def detail(self, credentials_id) -> Optional[dict]:
-		'''
-		Obsolete, use get()
-		'''
-		L.warning("Obsolete method used -> CredentialsProvider.detail :-(")
-		return await self.get(credentials_id)
-
-
 	@abc.abstractmethod
 	async def get(self, credentials_id, include=None) -> Optional[dict]:
 		raise NotImplementedError('in {}'.format(self.Type))

--- a/seacatauth/credentials/providers/htpasswd.py
+++ b/seacatauth/credentials/providers/htpasswd.py
@@ -141,8 +141,3 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 				'_provider_id': self.ProviderID,
 				'username': username,
 			}
-
-
-	async def update(self, credentials_id, credentials: dict) -> Optional[str]:
-		L.warning("Update not supported", struct_data={'cid': credentials_id})
-		raise RuntimeError("Not supported")

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -148,7 +148,7 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 		elif self.Config["tls_require_cert"] == "hard":
 			ldap_client.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_HARD)
 		else:
-			L.warning("Invalid 'tls_require_cert' value: {!r}. Defaulting to 'demand'.".format(
+			L.error("Invalid 'tls_require_cert' value: {!r}. Defaulting to 'demand'.".format(
 				self.Config["tls_require_cert"]
 			))
 			ldap_client.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -222,7 +222,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 			if mode is None:
 				fields.append({field: ident})
 			if mode == "ignorecase":
-				fields.append({field: re.compile("^{}$".format(ident), re.IGNORECASE)})
+				fields.append({field: re.compile("^{}$".format(re.escape(ident)), re.IGNORECASE)})
 
 		query = {"$or": fields}
 		coll = await self.MongoDBStorageService.collection(self.CredentialsCollection)

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -418,5 +418,5 @@ def authn_password(dbcred, credentials):
 		else:
 			return False
 	else:
-		L.warning("Unknown password hash function '{}'".format(dbcred['__password'][:4]))
+		L.error("Unknown password hash function '{}'".format(dbcred['__password'][:4]))
 		return False

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -50,7 +50,7 @@ class ExternalLoginHandler(object):
 
 		state = request.query.get("state")
 		if state is None:
-			L.warning("State parameter not provided in external login response")
+			L.error("State parameter not provided in external login response")
 
 		code = request.query.get("code")
 		if code is None:

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -293,7 +293,7 @@ class AuthorizeHandler(object):
 		root_session = request.Session
 		if root_session is not None:
 			if root_session.Session.Type != "root":
-				L.warning("Session type must be 'root'", struct_data={"sid": root_session.Id, "type": root_session.Session.Type})
+				L.error("Session type must be 'root'", struct_data={"sid": root_session.Id, "type": root_session.Session.Type})
 				root_session = None
 			elif root_session.is_anonymous() and not client_dict.get("authorize_anonymous_users", False):
 				L.warning("Not allowed to authorize with anonymous session.", struct_data={
@@ -534,7 +534,7 @@ class AuthorizeHandler(object):
 			# OpenID Connect requests MUST contain the openid scope value.
 			# Otherwise, the request is not considered OpenID and its behavior is unspecified
 			if "cookie" in scope:
-				L.warning("Scope cannot contain 'openid' and 'cookie' at the same time.", struct_data={
+				L.error("Scope cannot contain 'openid' and 'cookie' at the same time.", struct_data={
 					"scope": " ".join(scope)})
 				raise OAuthAuthorizeError(
 					AuthErrorResponseCode.InvalidScope, client_id,
@@ -546,7 +546,7 @@ class AuthorizeHandler(object):
 			return "cookie"
 
 		else:
-			L.warning("Scope must contain 'openid' or 'cookie'.", struct_data={"scope": " ".join(scope)})
+			L.error("Scope must contain 'openid' or 'cookie'.", struct_data={"scope": " ".join(scope)})
 			raise OAuthAuthorizeError(
 				AuthErrorResponseCode.InvalidScope, client_id,
 				error_description="Scope must contain 'openid' or 'cookie'.",
@@ -864,7 +864,7 @@ class AuthorizeHandler(object):
 		# Check for required parameters
 		client_id = request_parameters.get("client_id") or None
 		if client_id is None:
-			L.warning("Missing or empty required parameter: {}.".format("client_id"), struct_data=request_parameters)
+			L.error("Missing or empty required parameter: {}.".format("client_id"), struct_data=request_parameters)
 			raise OAuthAuthorizeError(
 				AuthErrorResponseCode.InvalidRequest, client_id,
 				redirect_uri=request_parameters.get("redirect_uri"),
@@ -875,7 +875,7 @@ class AuthorizeHandler(object):
 		# NOTE: "redirect_uri" is required only by OIDC, not generic OAuth
 		redirect_uri = request_parameters.get("redirect_uri") or None
 		if redirect_uri is None:
-			L.warning("Missing or empty required parameter: {}.".format("redirect_uri"), struct_data=request_parameters)
+			L.error("Missing or empty required parameter: {}.".format("redirect_uri"), struct_data=request_parameters)
 			raise OAuthAuthorizeError(
 				AuthErrorResponseCode.InvalidRequest, client_id,
 				redirect_uri=redirect_uri,
@@ -885,7 +885,7 @@ class AuthorizeHandler(object):
 
 		response_type = request_parameters.get("response_type") or None
 		if response_type is None:
-			L.warning(
+			L.error(
 				"Missing or empty required parameter: {}.".format("response_type"), struct_data=request_parameters)
 			raise OAuthAuthorizeError(
 				AuthErrorResponseCode.InvalidRequest, client_id,
@@ -894,7 +894,7 @@ class AuthorizeHandler(object):
 				state=state,
 				struct_data={"reason": "missing_query_parameter"})
 		elif response_type != "code":
-			L.warning("Unsupported response type.", struct_data=request_parameters)
+			L.error("Unsupported response type.", struct_data=request_parameters)
 			raise OAuthAuthorizeError(
 				AuthErrorResponseCode.UnsupportedResponseType, client_id,
 				redirect_uri=redirect_uri,
@@ -903,7 +903,7 @@ class AuthorizeHandler(object):
 		# NOTE: "scope" is required only by OIDC, not generic OAuth
 		scope = request_parameters.get("scope") or None
 		if scope is None:
-			L.warning("Missing or empty required parameter: {}.".format("scope"), struct_data=request_parameters)
+			L.error("Missing or empty required parameter: {}.".format("scope"), struct_data=request_parameters)
 			raise OAuthAuthorizeError(
 				AuthErrorResponseCode.InvalidRequest, client_id,
 				redirect_uri=redirect_uri,
@@ -915,7 +915,7 @@ class AuthorizeHandler(object):
 		if prompt is not None:
 			# TODO: Prompt can be a list of multiple values (e.g. "prompt=select_account,consent")
 			if prompt not in frozenset(["none", "login", "select_account"]):
-				L.warning("Unsupported prompt.", struct_data={"prompt": prompt})
+				L.error("Unsupported prompt.", struct_data={"prompt": prompt})
 				raise OAuthAuthorizeError(
 					AuthErrorResponseCode.InvalidRequest, client_id,
 					error_description="Invalid prompt value: {}".format(prompt),

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -134,7 +134,7 @@ class TokenIntrospectionHandler(object):
 			try:
 				response = await nginx_introspection(request, session, self.OpenIdConnectService.App)
 			except Exception as e:
-				L.warning("Request authorization failed: {}".format(e), exc_info=True)
+				L.exception("Request authorization failed: {}".format(e))
 				response = aiohttp.web.HTTPUnauthorized()
 		else:
 			response = aiohttp.web.HTTPUnauthorized()

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -115,7 +115,7 @@ class TokenHandler(object):
 		# Ensure the Authorization Code was issued to the authenticated Client
 		authorization_code = qs_data.get("code", "")
 		if len(authorization_code) == 0:
-			L.warning("Authorization Code not provided")
+			L.error("Authorization Code not provided")
 			return asab.web.rest.json_response(
 				request, {"error": TokenRequestErrorResponseCode.InvalidRequest}, status=400)
 
@@ -124,11 +124,11 @@ class TokenHandler(object):
 			new_session = await self.OpenIdConnectService.pop_session_by_authorization_code(
 				authorization_code, qs_data.get("code_verifier"))
 		except KeyError:
-			L.warning("Session not found.", struct_data={"code": authorization_code})
+			L.error("Session not found.", struct_data={"code": authorization_code})
 			return asab.web.rest.json_response(
 				request, {"error": TokenRequestErrorResponseCode.InvalidGrant}, status=400)
 		except CodeChallengeFailedError as e:
-			L.warning("Code challenge failed.", struct_data={"reason": str(e)})
+			L.error("Code challenge failed.", struct_data={"reason": str(e)})
 			return asab.web.rest.json_response(
 				request, {"error": TokenRequestErrorResponseCode.InvalidGrant}, status=400)
 

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -198,23 +198,23 @@ class OpenIdConnectService(asab.Service):
 			L.warning("ID token expired")
 			return None
 		except jwcrypto.jws.InvalidJWSSignature:
-			L.warning("Invalid ID token signature")
+			L.error("Invalid ID token signature")
 			return None
 
 		try:
 			data_dict = json.loads(token.claims)
 			session_id = data_dict["sid"]
 		except ValueError:
-			L.warning("Cannot read ID token claims")
+			L.error("Cannot read ID token claims")
 			return None
 		except KeyError:
-			L.warning("ID token claims do not contain 'sid'")
+			L.error("ID token claims do not contain 'sid'")
 			return None
 
 		try:
 			session = await self.SessionService.get(session_id)
 		except ValueError:
-			L.warning("Session not found")
+			L.error("Session not found")
 			return None
 
 		return session

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -357,7 +357,7 @@ class SessionAdapter:
 				id_token = id_token.decode("ascii")
 			except UnicodeDecodeError:
 				# Probably old ID token, encoded differently
-				L.warning("Cannot deserialize ID token", struct_data={"id_token": id_token})
+				L.error("Cannot deserialize ID token", struct_data={"id_token": id_token})
 
 		access_token = session_dict.pop(cls.FN.OAuth2.AccessToken, None) or oa2_data.pop("Ta", None)
 		if access_token is not None:

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -424,7 +424,7 @@ class SessionService(asab.Service):
 		try:
 			await upsertor.execute(event_type=EventTypes.SESSION_EXTENDED)
 		except KeyError:
-			L.warning("Conflict: Session already touched.", struct_data={"sid": session.Session.Id, "v": version})
+			L.error("Conflict: Session already touched.", struct_data={"sid": session.Session.Id, "v": version})
 
 		return await self.get(session.SessionId)
 


### PR DESCRIPTION
- Many warning messages changed to error or notice messages.
- Fixed error in Mongo provider's `locate()` method triggered by special characters in ident.