### PR TITLE
Validate redirect URI in authorize request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 - Config option `sender_email_address` is now called `from` (#257, PLUM Sprint 230825)
 - Invalid redirect URI or client ID in Authorize request results in an error response without redirect (#266, PLUM Sprint 230908)
+- Config section `[seacat_auth]` renamed to `[seacatauth]` (#266, PLUM Sprint 230908)
 
 ### Fix
 - Add `id_token_signing_alg_values_supported` in OIDC discovery (#260)
@@ -17,6 +18,7 @@
 - Algorithmic (stateless) anonymous sessions (#232, PLUM Sprint 230825)
 - Initialize Zookeeper service (#265, PLUM Sprint 230908)
 - Initialize Sentry service (#262, PLUM Sprint 230908)
+- Config option to disable all redirect URI validations (#266, PLUM Sprint 230908)
 
 ### Refactoring
 - Last login info moved to a dedicated collection (#259, PLUM Sprint 230825)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 - Config option `sender_email_address` is now called `from` (#257, PLUM Sprint 230825)
+- Invalid redirect URI or client ID in Authorize request results in an error response without redirect (#266, PLUM Sprint 230908)
 
 ### Fix
 - Add `id_token_signing_alg_values_supported` in OIDC discovery (#260)

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -26,10 +26,13 @@ asab.Config.add_defaults({
 		"listen": "3081",  # Well-known port
 	},
 
+	"seacatauth": {
+		"private_key": "",
+	},
+
 	"openidconnect": {
 		"bearer_realm": "asab",
 		"auth_code_timeout": "60 s",
-		"private_key": "",
 	},
 
 	"seacatauth:client": {

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -216,10 +216,10 @@ class SeaCatAuthApplication(asab.Application):
 		"""
 		# TODO: Add encryption option
 		# TODO: Multiple key support
-		private_key_path = asab.Config.get("seacat_auth", "private_key", fallback="")
+		private_key_path = asab.Config.get("seacatauth", "private_key", fallback="")
 		if len(private_key_path) == 0 and "private_key" in asab.Config["openidconnect"]:
 			asab.LogObsolete.warning(
-				"The 'private_key' option has been moved from the 'openidconnect' to the 'seacat_auth' section. "
+				"The 'private_key' option has been moved from the 'openidconnect' to the 'seacatauth' section. "
 				"Please update your configuration file.",
 				struct_data={"eol": "2024-01-31"})
 			private_key_path = asab.Config.get("openidconnect", "private_key", fallback="")

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -216,6 +216,12 @@ class SeaCatAuthApplication(asab.Application):
 		"""
 		# TODO: Add encryption option
 		# TODO: Multiple key support
+		if "seacat_auth" in asab.Config:
+			asab.LogObsolete.warning(
+				"Config section '[seacat_auth]' has been renamed to '[seacatauth]'. "
+				"Please update your configuration file.",
+				struct_data={"eol": "2024-01-31"})
+			asab.Config["seacatauth"].update(asab.Config["seacat_auth"])
 		private_key_path = asab.Config.get("seacatauth", "private_key", fallback="")
 		if len(private_key_path) == 0 and "private_key" in asab.Config["openidconnect"]:
 			asab.LogObsolete.warning(

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -500,7 +500,7 @@ class ClientService(asab.Service):
 		if client_secret != client.get("__client_secret", ""):
 			raise exceptions.InvalidClientSecret(client["_id"])
 
-		if not validate_redirect_uri(
+		if not self.OIDCService.DisableRedirectUriValidation and not validate_redirect_uri(
 			redirect_uri, client["redirect_uris"], client.get("redirect_uri_validation_method")):
 			raise exceptions.InvalidRedirectURI(client_id=client["_id"], redirect_uri=redirect_uri)
 

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -502,12 +502,7 @@ class ClientService(asab.Service):
 
 		if not validate_redirect_uri(
 			redirect_uri, client["redirect_uris"], client.get("redirect_uri_validation_method")):
-			# TODO: Raise error instead of warning
-			# raise exceptions.InvalidRedirectURI(client_id=client["_id"], redirect_uri=redirect_uri)
-			L.warning(
-				"Invalid redirect URI. NOTICE: In future releases, authorize requests with invalid "
-				"redirect URI will result in error response!",
-				struct_data={"client_id": client["_id"], "redirect_uri": redirect_uri})
+			raise exceptions.InvalidRedirectURI(client_id=client["_id"], redirect_uri=redirect_uri)
 
 		if grant_type is not None and grant_type not in client["grant_types"]:
 			raise exceptions.ClientError(client_id=client["_id"], grant_type=grant_type)

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -182,6 +182,14 @@ def add_params_to_url_query(url, **params):
 	return urlunparse(**parsed)
 
 
+def get_request_access_ips(request) -> list:
+	access_ips = [request.remote]
+	ff = request.headers.get("X-Forwarded-For")
+	if ff is not None:
+		access_ips.extend(ff.split(", "))
+	return access_ips
+
+
 def generate_ergonomic_token(length: int):
 	'''
 	This function generates random string that is "ergonomic".

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -88,6 +88,12 @@ class OpenIdConnectService(asab.Service):
 			seconds=asab.Config.getseconds("openidconnect", "auth_code_timeout")
 		)
 
+		self.DisableRedirectUriValidation = asab.Config.getboolean(
+			"openidconnect", "_disable_redirect_uri_validation", fallback=False)
+		if self.DisableRedirectUriValidation:
+			# This is a dev-only option
+			L.warning("Redirect URI validation in OpenID Authorize requests is disabled.")
+
 		# TODO: Derive the private key
 		self.PrivateKey = app.PrivateKey
 

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -138,6 +138,7 @@ class ProvisioningService(asab.Service):
 		if admin_ui_url is None:
 			auth_webui_base_url = asab.Config.get("general", "auth_webui_base_url")
 			url = urllib.parse.urlparse(auth_webui_base_url)
+			# Use the base URL without path by default, to fit all common deployments
 			admin_ui_url = url._replace(path="", fragment="", query="", params="").geturl()
 			L.log(
 				asab.LOG_NOTICE,
@@ -156,7 +157,6 @@ class ProvisioningService(asab.Service):
 			if client is None or client.get(k) != v}
 
 		# Check if the client has the correct redirect URI
-		# Use default URI if none is specified and the client doesn't exist yet
 		if client is None:
 			redirect_uris = set()
 		else:

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -133,6 +133,9 @@ class ProvisioningService(asab.Service):
 
 
 	async def _initialize_admin_ui_client(self):
+		"""
+		Registers/updates the ASAB web UI client.
+		"""
 		admin_ui_client_id = self.Config["admin_ui_client_id"]
 		admin_ui_url = self.Config["admin_ui_url"].rstrip("/") or None
 		if admin_ui_url is None:


### PR DESCRIPTION
# Breaking changes
- Invalid redirect URI in OAuth Authorize request now results in error response.
- As per [rfc6749#section-4.1.2.1](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1), invalid redirect URI or client ID results in an error response **without redirect**.
- Config section `[seacat_auth]` renamed to `[seacatauth]` to unify with all the other sections.

# Changes
- Authorize audit messages include access IPs.
- Disable all redirect URI validations by toggling the `_disable_redirect_uri_validation` switch in the `[openidconnect]` section.