### PR TITLE
Support MongoDB version 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix private key provisioning (#267, @vosmol)
 
 ### Features
-- Fix tenant search for old MongoDB versions (#268, PLUM Sprint 230908)
+- Support tenant search in old MongoDB versions (#268, PLUM Sprint 230908)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fix
 - Fix private key provisioning (#267, @vosmol)
 
+### Features
+- Fix tenant search for old MongoDB versions (#268, PLUM Sprint 230908)
+
 ---
 
 

--- a/seacatauth/tenant/providers/mongodb.py
+++ b/seacatauth/tenant/providers/mongodb.py
@@ -56,14 +56,14 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 				#  -1 if tenant does not contain substring
 				#   0 if tenant starts with substring
 				#   1 if tenant contains substring but not at the start
-				{"$set": {"_match": {"$min": [
+				{"$addFields": {"_match": {"$min": [
 					{"$indexOfCP": [{"$toLower": "$_id"}, filter.lower()]}, 1
 				]}}},
 				# Exclude tenants that do not contain substring at all
 				{"$match": {"$expr": {"$gte": ["$_match", 0]}}},
 				# Sort matches so that tenants that start with substring come first
 				# Secondary sort is alphabetical
-				{"$sort": collections.OrderedDict({"_match": 1, "_id": 1})},
+				{"$sort": {"_match": 1, "_id": 1}},
 			]
 			if limit is not None:
 				pipeline.append({"$skip": limit * page})

--- a/seacatauth/tenant/providers/mongodb.py
+++ b/seacatauth/tenant/providers/mongodb.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 from typing import Optional
 


### PR DESCRIPTION
Command `$set` is not available until MongoDB version 4.2. Use `$addFields` instead.