### PR TITLE
Don't use upsertor in Audit service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fix
 - Fix private key provisioning (#267, @vosmol)
 - Handle missing fields in credential creation (#290, PLUM Sprint 230908)
+- Remove upsertor from audit service (#269, PLUM Sprint 230908)
 
 ### Features
 - Support tenant search in old MongoDB versions (#268, PLUM Sprint 230908)

--- a/seacatauth/audit/service.py
+++ b/seacatauth/audit/service.py
@@ -4,7 +4,6 @@ import logging
 import asab.storage.exceptions
 
 from .codes import AuditCode
-from ..events import EventTypes
 
 #
 

--- a/seacatauth/events.py
+++ b/seacatauth/events.py
@@ -39,6 +39,3 @@ class EventTypes:
 	TENANT_ASSIGNED = "tenant_assigned"
 
 	BOUNCER_URI_STORED = "bouncer_uri_stored"
-
-	AUDIT_ENTRY_CREATED = "audit_entry_created"
-	LAST_CREDENTIALS_EVENT_UPDATED = "last_credentials_event_updated"


### PR DESCRIPTION
- The `version` parameter in upsertor should have been `None`, not zero.
- Remove upsertor because it can trigger webhook, which is unwanted in audit.