### PR TITLE
Synchronize Kibana spaces to Seacat tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## v23.47
+
+### Pre-releases
+- `v23.47-alpha`
+
+### Breaking changes
+- Batman for Kibana now also requires `kibana_url` (#281, `v23.47-alpha`)
+- Batman does no longer create Seacat resources from all Kibana roles (#281, `v23.47-alpha`)
+- Config section 'batman:elk' renamed to 'batman:kibana' (#281, `v23.47-alpha`)
+
+### Features
+- Kibana spaces and roles are now synchronized with Seacat tenants (#281, `v23.47-alpha`)
+
+---
+
+
 ## v23.44-beta
 
 ### Pre-releases
@@ -10,9 +26,6 @@
 
 ### Breaking changes
 - Dropped support for authorize query params `ldid` and `expiration` (#296, PLUM Sprint 231006)
-- Batman for Kibana now also requires `kibana_url` (#281, PLUM Sprint 231027)
-- Batman does no longer create Seacat resources from all Kibana roles (#281, PLUM Sprint 231027)
-- Config section 'batman:elk' renamed to 'batman:kibana' (#281, PLUM Sprint 231027)
 
 ### Fix
 - Fix client cookie introspection (#322, INDIGO Sprint 231110, `v23.44-alpha5`)
@@ -29,7 +42,6 @@
 - External login registration webhook (#286, PLUM Sprint 231006)
 - OAuth Authorize ignores all unknown parameters (#296, PLUM Sprint 231006)
 - Log failure reasons in introspection and authorization flow (#315, INDIGO Sprint 231027)
-- Kibana spaces and roles are now synchronized with Seacat tenants (#281, PLUM Sprint 231027)
 
 ### Refactoring
 - Do not log "unhappy flow" as errors (#315, INDIGO Sprint 231027)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Breaking changes
 - Dropped support for authorize query params `ldid` and `expiration` (#296, PLUM Sprint 231006)
+- Batman for Kibana now also requires `kibana_url` (#281, PLUM Sprint 231027)
+- Batman does no longer create Seacat resources from all Kibana roles (#281, PLUM Sprint 231027)
+- Config section 'batman:elk' renamed to 'batman:kibana' (#281, PLUM Sprint 231027)
 
 ### Fix
 - Handle missing webauthn data in login request (#314, INDIGO Sprint 231027, `v23.44-alpha4`)
@@ -21,6 +24,7 @@
 - External login registration webhook (#286, PLUM Sprint 231006)
 - OAuth Authorize ignores all unknown parameters (#296, PLUM Sprint 231006)
 - Log failure reasons in introspection and authorization flow (#315, INDIGO Sprint 231027)
+- Kibana spaces and roles are now synchronized with Seacat tenants (#281, PLUM Sprint 231027)
 
 ### Refactoring
 - Do not log "unhappy flow" as errors (#315, INDIGO Sprint 231027)

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -181,7 +181,7 @@ class ResourceService(asab.Service):
 			await upsertor.execute(event_type=EventTypes.RESOURCE_CREATED)
 		except asab.storage.exceptions.DuplicateError as e:
 			if e.KeyValue is not None:
-				key, value = e.KeyValue
+				key, value = e.KeyValue.popitem()
 				raise asab.exceptions.Conflict(key=key, value=value)
 			else:
 				raise asab.exceptions.Conflict()

--- a/seacatauth/authz/utils.py
+++ b/seacatauth/authz/utils.py
@@ -1,6 +1,9 @@
+import typing
+
+
 async def build_credentials_authz(
-	tenant_service, role_service, credentials_id,
-	tenants=None, exclude_resources=None
+	tenant_service, role_service, credentials_id: str,
+	tenants: typing.Iterable = None, exclude_resources: typing.Iterable = None
 ):
 	"""
 	Creates a nested 'authz' dict with tenant:resource structure:

--- a/seacatauth/batman/elk.py
+++ b/seacatauth/batman/elk.py
@@ -27,13 +27,15 @@ class ELKIntegration(asab.config.Configurable):
 	"""
 
 	ConfigDefaults = {
-		"url": "http://localhost:9200/",
-		# Credentials/api key (mutualy exclusive)
+		"url": "http://localhost:9200",
+		"kibana_url": "http://localhost:5601",
+
+		# Basic credentials / API key (mutually exclusive)
 		"username": "",
 		"password": "",
 		"api_key": "",
 
-		# For SSL options such as `cafile`, please refer to asab SSLContextBuilder
+		# For SSL options such as `cafile`, please refer to the config of asab.tls.SSLContextBuilder
 
 		# List of elasticsearch system users
 		# If Seacat Auth has users with one of these usernames, it will not sync them
@@ -131,8 +133,8 @@ class ELKIntegration(asab.config.Configurable):
 	async def _create_kibana_role(self, tenant_id, space_id):
 		role_name = "tenant_{}".format(tenant_id)
 		role = {
-			# Add read-only privileges for the new space (for now)
-			"kibana": [{"spaces": [space_id], "base": ["read"]}]
+			# Add all privileges for the new space
+			"kibana": [{"spaces": [space_id], "base": ["all"]}]
 		}
 
 		try:

--- a/seacatauth/batman/elk.py
+++ b/seacatauth/batman/elk.py
@@ -294,7 +294,7 @@ class ELKIntegration(asab.config.Configurable):
 		try:
 			async with self._elasticsearch_session() as session:
 				async with session.get("{}/api/spaces/space".format(self.KibanaUrl)) as resp:
-					if resp.status // 100 != 2:
+					if resp.status != 200:
 						text = await resp.text()
 						L.error("Failed to fetch Kibana spaces:\n{}".format(text[:1000]))
 						return
@@ -414,7 +414,7 @@ class ELKIntegration(asab.config.Configurable):
 			"{}/_xpack/security/user/{}".format(self.ElasticSearchUrl, username),
 			json=elastic_user
 		) as resp:
-			if resp.status // 100 == 2:
+			if 200 <= resp.status < 300:
 				# Everything is alright here
 				pass
 			else:

--- a/seacatauth/batman/elk.py
+++ b/seacatauth/batman/elk.py
@@ -47,6 +47,9 @@ class ELKIntegration(asab.config.Configurable):
 		# This role 'flags' users in ElasticSearch/Kibana that is managed by Seacat Auth
 		# There should be a role created in the ElasticSearch that grants no rights
 		"seacat_user_flag": "seacat_managed",
+
+		# Enable automatic synchronization of Kibana spaces with Seacat tenants
+		"enable_space_sync": True
 	}
 
 	EssentialKibanaResources = {
@@ -79,6 +82,7 @@ class ELKIntegration(asab.config.Configurable):
 		self.RoleService = self.App.get_service("seacatauth.RoleService")
 		self.ResourceService = self.App.get_service("seacatauth.ResourceService")
 
+		self.EnableSpaceSync = self.Config.getboolean("enable_space_sync")
 		self.KibanaUrl = self.Config.get("kibana_url").rstrip("/")
 		self.ElasticSearchUrl = self.Config.get("url").rstrip("/")
 		self.Headers = {"kbn-xsrf": "kibana"}
@@ -163,6 +167,9 @@ class ELKIntegration(asab.config.Configurable):
 		Create a Kibana space for specified tenant or update its metadata if necessary.
 		Also create a read-only and a read-write Kibana role for that space.
 		"""
+		if not self.EnableSpaceSync:
+			return
+
 		if isinstance(tenant, str):
 			tenant_id = tenant
 			tenant = await self.TenantService.get_tenant(tenant_id)

--- a/seacatauth/batman/elk.py
+++ b/seacatauth/batman/elk.py
@@ -333,5 +333,5 @@ class ELKIntegration(asab.config.Configurable):
 		return "tenant_{}".format(tenant)
 
 
-	def _kibana_space_id_from_tenant(self, tenant:str):
+	def _kibana_space_id_from_tenant(self, tenant: str):
 		return tenant.replace(".", "-")

--- a/seacatauth/batman/elk.py
+++ b/seacatauth/batman/elk.py
@@ -118,6 +118,8 @@ class ELKIntegration(asab.config.Configurable):
 		self.App.PubSub.subscribe("Role.assigned!", self._on_authz_change)
 		self.App.PubSub.subscribe("Role.unassigned!", self._on_authz_change)
 		self.App.PubSub.subscribe("Role.updated!", self._on_authz_change)
+		self.App.PubSub.subscribe("Tenant.assigned!", self._on_authz_change)
+		self.App.PubSub.subscribe("Tenant.unassigned!", self._on_authz_change)
 		self.App.PubSub.subscribe("Tenant.created!", self._on_tenant_created)
 		self.App.PubSub.subscribe("Tenant.updated!", self._on_tenant_updated)
 		self.App.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)

--- a/seacatauth/batman/kibana.py
+++ b/seacatauth/batman/kibana.py
@@ -142,6 +142,10 @@ class KibanaIntegration(asab.config.Configurable):
 
 	async def _on_init(self, event_name):
 		await self._initialize_resources()
+		# Ensure sync on startup even if housekeeping does not happen; prevent syncing twice
+		if not asab.Config.getboolean("housekeeping", "run_at_startup"):
+			await self._sync_all_tenants_and_spaces()
+			await self.sync_all_credentials()
 
 
 	async def _on_housekeeping(self, event_name):

--- a/seacatauth/batman/kibana.py
+++ b/seacatauth/batman/kibana.py
@@ -337,8 +337,7 @@ class KibanaIntegration(asab.config.Configurable):
 
 
 	async def initialize(self):
-		await self._initialize_resources()
-		await self.sync_all_credentials()
+		pass
 
 
 	async def _initialize_resources(self):

--- a/seacatauth/batman/kibana.py
+++ b/seacatauth/batman/kibana.py
@@ -136,13 +136,13 @@ class KibanaIntegration(asab.config.Configurable):
 				await self._sync_all_tenants_and_spaces()
 			except aiohttp.client_exceptions.ClientConnectionError as e:
 				L.error("Cannot connect to Kibana: {}".format(str(e)))
-				self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+				self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 				return
 			try:
 				await self.sync_all_credentials()
 			except aiohttp.client_exceptions.ClientConnectionError as e:
 				L.error("Cannot connect to ElasticSearch: {}".format(str(e)))
-				self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+				self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 				return
 
 	async def _on_housekeeping(self, event_name):
@@ -150,13 +150,13 @@ class KibanaIntegration(asab.config.Configurable):
 			await self._sync_all_tenants_and_spaces()
 		except aiohttp.client_exceptions.ClientConnectionError as e:
 			L.error("Cannot connect to Kibana: {}".format(str(e)))
-			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 			return
 		try:
 			await self.sync_all_credentials()
 		except aiohttp.client_exceptions.ClientConnectionError as e:
 			L.error("Cannot connect to ElasticSearch: {}".format(str(e)))
-			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 			return
 
 
@@ -168,13 +168,11 @@ class KibanaIntegration(asab.config.Configurable):
 			await self._sync_all_tenants_and_spaces()
 		except aiohttp.client_exceptions.ClientConnectionError as e:
 			L.error("Cannot connect to Kibana: {}".format(str(e)))
-			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 			return
 		try:
 			await self.sync_all_credentials()
 		except aiohttp.client_exceptions.ClientConnectionError as e:
 			L.error("Cannot connect to ElasticSearch: {}".format(str(e)))
-			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 			return
 
 	async def _on_authz_change(self, event_name, credentials_id=None, **kwargs):
@@ -185,7 +183,7 @@ class KibanaIntegration(asab.config.Configurable):
 				await self.sync_all_credentials()
 		except aiohttp.client_exceptions.ClientConnectionError as e:
 			L.error("Cannot connect to ElasticSearch: {}".format(str(e)))
-			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 			return
 
 
@@ -195,7 +193,7 @@ class KibanaIntegration(asab.config.Configurable):
 			await self._create_or_update_kibana_space(tenant_id, space_id)
 		except aiohttp.client_exceptions.ClientConnectionError as e:
 			L.error("Cannot connect to Kibana: {}".format(str(e)))
-			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 			return
 
 
@@ -205,7 +203,7 @@ class KibanaIntegration(asab.config.Configurable):
 			await self._create_or_update_kibana_space(tenant_id, space_id)
 		except aiohttp.client_exceptions.ClientConnectionError as e:
 			L.error("Cannot connect to Kibana: {}".format(str(e)))
-			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30)
+			self.RetrySyncAll = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=60)
 			return
 
 

--- a/seacatauth/batman/kibana.py
+++ b/seacatauth/batman/kibana.py
@@ -442,7 +442,7 @@ class KibanaIntegration(asab.config.Configurable):
 	def _kibana_space_id_from_tenant_id(self, tenant_id: str):
 		if tenant_id == "default":
 			# "default" is a reserved space name in Kibana
-			return "seacat-default"
+			return "tenant-default"
 		# Replace forbidden characters with "--"
 		# NOTE: Tenant ID can contain "." while space ID can not
 		return re.sub("[^a-z0-9_-]", "--", tenant_id)

--- a/seacatauth/batman/service.py
+++ b/seacatauth/batman/service.py
@@ -28,10 +28,10 @@ class BatmanService(asab.Service):
 			# TODO: There should be no hardcoded encryption password
 			self.Key = b"12345678901234567890123456789012"
 
-		if "batman:elk" in asab.Config.sections():
-			from .elk import ELKIntegration
+		if "batman:kibana" in asab.Config.sections() or "batman:elk" in asab.Config.sections():
+			from .kibana import KibanaIntegration
 			self.Integrations.append(
-				ELKIntegration(self)
+				KibanaIntegration(self)
 			)
 
 		if "batman:grafana" in asab.Config.sections():

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -341,6 +341,8 @@ class CredentialsService(asab.Service):
 			credentials_id=credentials_id,
 			by_cid=agent_cid)
 
+		self.App.PubSub.publish("Credentials.created!", credentials_id=credentials_id)
+
 		return {
 			"status": "OK",
 			"credentials_id": credentials_id,
@@ -457,6 +459,8 @@ class CredentialsService(asab.Service):
 			by_cid=agent_cid,
 			attributes=list(validated_data.keys()))
 
+		self.App.PubSub.publish("Credentials.updated!", credentials_id=credentials_id)
+
 		return {"status": "OK"}
 
 
@@ -505,6 +509,8 @@ class CredentialsService(asab.Service):
 			AuditCode.CREDENTIALS_DELETED,
 			credentials_id=credentials_id,
 			by_cid=agent_cid)
+
+		self.App.PubSub.publish("Credentials.deleted!", credentials_id=credentials_id)
 
 		return {
 			"status": result,

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -56,11 +56,7 @@ class TenantHandler(object):
 		"""
 		List all registered tenant IDs
 		"""
-		# TODO: This has to be cached agressivelly
-		provider = self.TenantService.get_provider()
-		result = []
-		async for tenant in provider.iterate():
-			result.append(tenant["_id"])
+		result = await self.TenantService.list_tenant_ids()
 		return asab.web.rest.json_response(request, data=result)
 
 

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -54,11 +54,16 @@ class TenantService(asab.Service):
 			L.error("Tenant with this ID already exists.", struct_data={"tenant": tenant_id})
 			raise asab.exceptions.Conflict(value=tenant_id)
 
+		self.App.PubSub.publish("Tenant.created!", tenant_id=tenant_id)
+
 		return tenant_id
 
 
 	async def update_tenant(self, tenant_id: str, **kwargs):
 		result = await self.TenantsProvider.update(tenant_id, **kwargs)
+
+		self.App.PubSub.publish("Tenant.updated!", tenant_id=tenant_id)
+
 		return {"result": result}
 
 
@@ -84,6 +89,8 @@ class TenantService(asab.Service):
 
 		# Delete tenant from provider
 		await self.TenantsProvider.delete(tenant_id)
+
+		self.App.PubSub.publish("Tenant.deleted!", tenant_id=tenant_id)
 
 		# Delete sessions that have the tenant in scope
 		await session_service.delete_sessions_by_tenant_in_scope(tenant_id)

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -225,6 +225,7 @@ class TenantService(asab.Service):
 			"cid": credentials_id,
 			"tenant": tenant,
 		})
+		self.App.PubSub.publish("Credentials.tenant_assigned!", credentials_id=credentials_id, tenant_id=tenant)
 
 
 	async def unassign_tenant(self, credentials_id: str, tenant: str):
@@ -243,6 +244,7 @@ class TenantService(asab.Service):
 		)
 
 		await self.TenantsProvider.unassign_tenant(credentials_id, tenant)
+		self.App.PubSub.publish("Credentials.tenant_unassigned!", credentials_id=credentials_id, tenant_id=tenant)
 
 
 	def is_enabled(self):

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -37,6 +37,18 @@ class TenantService(asab.Service):
 		self.TenantsProvider = provider
 
 
+	async def list_tenant_ids(self):
+		"""
+		List all registered tenant IDs
+		"""
+		# TODO: This has to be cached agressivelly
+		provider = self.get_provider()
+		result = []
+		async for tenant in provider.iterate():
+			result.append(tenant["_id"])
+		return result
+
+
 	async def get_tenant(self, tenant_id: str):
 		return await self.TenantsProvider.get(tenant_id)
 

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -254,7 +254,7 @@ class TenantService(asab.Service):
 			"cid": credentials_id,
 			"tenant": tenant,
 		})
-		self.App.PubSub.publish("Credentials.tenant_assigned!", credentials_id=credentials_id, tenant_id=tenant)
+		self.App.PubSub.publish("Tenant.assigned!", credentials_id=credentials_id, tenant_id=tenant)
 
 
 	async def unassign_tenant(self, credentials_id: str, tenant: str):
@@ -273,7 +273,7 @@ class TenantService(asab.Service):
 		)
 
 		await self.TenantsProvider.unassign_tenant(credentials_id, tenant)
-		self.App.PubSub.publish("Credentials.tenant_unassigned!", credentials_id=credentials_id, tenant_id=tenant)
+		self.App.PubSub.publish("Tenant.unassigned!", credentials_id=credentials_id, tenant_id=tenant)
 
 
 	def is_enabled(self):

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -49,6 +49,16 @@ class TenantService(asab.Service):
 		return result
 
 
+	async def iterate(self):
+		"""
+		Iterate over all tenants
+		"""
+		# TODO: Limit, page, filter
+		provider = self.get_provider()
+		async for tenant in provider.iterate():
+			yield tenant
+
+
 	async def get_tenant(self, tenant_id: str):
 		return await self.TenantsProvider.get(tenant_id)
 


### PR DESCRIPTION
# Breaking changes
- Batman for Kibana now also requires `kibana_url`. If this is empty, Kibana space sync is disabled.
- Batman does no longer create Seacat resources from all Kibana roles. However, existing `elk:`-prefixed resources are still mapped to corresponding Kibana roles for backward compatibility.
- Config section`batman:elk` has been renamed to `batman:kibana`. The old config still works as fallback.

# Changes
- When a new tenant (tenant_id=`my-company`) is created in Seacat Auth, Batman service creates a space in Kibana (space_id=`my-company`) and two Elastic roles with access to that space: 
  - `tenant_my-company_read` with read-only privileges,
  - `tenant_my-company_all` with read-write privileges.
- Spaces are synced primarily on housekeeping, plus on tenant creation or update. This can be disabled by setting 
- Users are synced primarily on housekeeping, plus on authorization changes (role un/assignment).
- Batman does no longer create Seacat resources from all Kibana roles.
- Instead of creating resources from all Kibana roles, only the following fixed resources are used:
  - `kibana:access` maps to specific role that grants **read-only** access to corresponding tenant space (e.g. `tenant_my-company_read`),
  - `kibana:edit` maps to specific role that grants **read-write** access to corresponding tenant space (e.g. `tenant_my-company_all`),
  - `kibana:admin` maps to Kibana `kibana_admin` role,
  - `authz:superuser` maps to Elastic `superuser`.
- To ensure backward compatibility, existing `elk:`-prefixed resources are still mapped to corresponding Kibana roles (e.g. resource `elk:analyst` will be mapped to Kibana's `analyst` role as before).
- Seacat Auth **DOES NOT** automatically create ElasticSearch index patterns and map them to their respective tenant spaces.
