### PR TITLE
Implement tenant label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Features
 - Support tenant search in old MongoDB versions (#268, PLUM Sprint 230908)
 - Public invitations to tenant (#261, PLUM Sprint 230908)
+- Human-readable tenant label (#285, PLUM Sprint 230908)
 
 ---
 

--- a/seacatauth/tenant/providers/mongodb.py
+++ b/seacatauth/tenant/providers/mongodb.py
@@ -84,8 +84,20 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 		return await coll.count_documents(filter=filter)
 
 
-	async def create(self, tenant_id: str, creator_id: str = None) -> Optional[str]:
+	async def create(
+		self, tenant_id: str, *,
+		label: str = None,
+		description: str = None,
+		data: dict = None,
+		creator_id: str = None
+	) -> Optional[str]:
 		u = self.MongoDBStorageService.upsertor(self.TenantsCollection, obj_id=tenant_id, version=0)
+		if label is not None:
+			u.set("label", label)
+		if description is not None:
+			u.set("description", description)
+		if data is not None:
+			u.set("data", data)
 		if creator_id is not None:
 			u.set("created_by", creator_id)
 		tenant_id = await u.execute()
@@ -93,13 +105,20 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 		return tenant_id
 
 
-	async def update(self, tenant_id: str, *, description: str = None, data: dict = None) -> Optional[str]:
+	async def update(
+		self, tenant_id: str, *,
+		label: str = None,
+		description: str = None,
+		data: dict = None
+	) -> Optional[str]:
 		tenant = await self.get(tenant_id)
 		u = self.MongoDBStorageService.upsertor(
 			self.TenantsCollection,
 			obj_id=tenant_id,
 			version=tenant["_v"]
 		)
+		if label is not None:
+			u.set("label", label)
 		if description is not None:
 			u.set("description", description)
 		if data is not None:

--- a/seacatauth/tenant/schemas.py
+++ b/seacatauth/tenant/schemas.py
@@ -1,0 +1,125 @@
+_EDITABLE_TENANT_PROPERTIES = {
+	"label": {
+		"type": "string",
+		"description": "Human-palatable tenant name."},
+	"description": {
+		"type": "string",
+		"description": "Extended tenant details."},
+	"data": {
+		"type": "object",
+		"description":
+			"Custom tenant data. Shallow JSON object that maps string keys "
+			"to non-structured values.",
+		"patternProperties": {
+			"^[a-zA-Z][a-zA-Z0-9_-]{0,126}[a-zA-Z0-9]$": {"anyOf": [
+				{"type": "string"},
+				{"type": "number"},
+				{"type": "boolean"},
+				{"type": "null"}]}}}}
+
+CREATE_TENANT = {
+	"type": "object",
+	"required": ["id"],
+	"additionalProperties": False,
+	"properties": {
+		"id": {
+			"type": "string",
+			"description": "Unique tenant ID. Can't be changed once the tenant has been created."},
+		**_EDITABLE_TENANT_PROPERTIES},
+	"example": {
+		"id": "acme-corp"}
+}
+
+UPDATE_TENANT = {
+	"type": "object",
+	"additionalProperties": False,
+	"properties": _EDITABLE_TENANT_PROPERTIES,
+	"example": {
+		"label": "ACME Corp Inc.",
+		"data": {
+			"email": "support@acmecorp.test",
+			"very_corporate": True,
+			"schema": "ECS"}}
+}
+
+SET_TENANTS = {
+	"type": "object",
+	"required": ["tenants"],
+	"properties": {
+		"tenants": {
+			"type": "array",
+			"description": "List of the IDs of tenants to be set",
+			"items": {"type": "string"}}},
+	"example": {
+		"tenants": ["acme-corp", "my-eshop"]}
+}
+
+GET_TENANTS_BATCH = {
+	"type": "array",
+	"description": "List of credential IDs",
+	"items": {"type": "string"},
+	"example": ["mongodb:default:abc123def456", "htpasswd:local:zdenek"],
+}
+
+BULK_ASSIGN_TENANTS = {
+	"type": "object",
+	"required": ["credential_ids", "tenants"],
+	"properties": {
+		"credential_ids": {
+			"type": "array",
+			"description": "List of the IDs of credentials to manage.",
+			"items": {"type": "string"}},
+		"tenants": {
+			"type": "object",
+			"description":
+				"Tenants and roles to be assigned. \n\n"
+				"The keys are the IDs of tenants to be granted access to. The values are arrays of the respective "
+				"tenant's roles to be assigned. \n\n"
+				"To grant tenant access without assigning any roles, "
+				"leave the role array empty. \n\n"
+				"To assign global roles, list them under the `'*'` key.",
+			"patternProperties": {
+				r"^\*$|^[a-z][a-z0-9._-]{2,31}$": {
+					"type": "array",
+					"description": "List of the tenant's roles to be assigned",
+					"items": {"type": "string"}}}}},
+	"example": {
+		"credential_ids": [
+			"mongodb:default:abc123def456", "htpasswd:local:zdenek"],
+		"tenants": {
+			"*": ["*/global-editor"],
+			"acme-corp": ["acme-corp/user", "acme-corp/supervisor"],
+			"my-eshop": []}},
+}
+
+BULK_UNASSIGN_TENANTS = {
+	"type": "object",
+	"required": ["credential_ids", "tenants"],
+	"properties": {
+		"credential_ids": {
+			"type": "array",
+			"description": "List of the IDs of credentials to manage.",
+			"items": {"type": "string"}},
+		"tenants": {
+			"type": "object",
+			"description":
+				"Tenants and roles to be unassigned. \n\n"
+				"The keys are the IDs of tenants to be revoked access to. The values are arrays of the respective "
+				"tenant's roles to be unassigned. \n\n"
+				"To completely revoke credentials' access to the tenant, provide `\"UNASSIGN-TENANT\"` as the "
+				"tenant value, instead of the array of roles. \n\n"
+				"To unassign global roles, list them under the `\"*\"` key.",
+			"patternProperties": {
+				r"^\*$|^[a-z][a-z0-9._-]{2,31}$": {
+					"anyOf": [
+						{"type": "array", "items": {"type": "string"}},
+						{"type": "string", "enum": ["UNASSIGN-TENANT"]}
+					]}}}},
+	"example": {
+		"credential_ids": [
+			"mongodb:default:abc123def456", "htpasswd:local:zdenek"],
+		"tenants": {
+			"*": ["*/global-editor"],
+			"acme-corp": ["acme-corp/user", "acme-corp/supervisor"],
+			"my-eshop": "UNASSIGN-TENANT"}},
+}

--- a/seacatauth/tenant/schemas.py
+++ b/seacatauth/tenant/schemas.py
@@ -1,7 +1,8 @@
 _EDITABLE_TENANT_PROPERTIES = {
 	"label": {
 		"type": "string",
-		"description": "Human-palatable tenant name."},
+		"description": "Human-palatable tenant name.",
+		"maxLength": 48},
 	"description": {
 		"type": "string",
 		"description": "Extended tenant details."},

--- a/seacatauth/tenant/schemas.py
+++ b/seacatauth/tenant/schemas.py
@@ -2,7 +2,7 @@ _EDITABLE_TENANT_PROPERTIES = {
 	"label": {
 		"type": "string",
 		"description": "Human-palatable tenant name.",
-		"maxLength": 48},
+		"pattern": "^.{,64}$"},  # no newlines allowed
 	"description": {
 		"type": "string",
 		"description": "Extended tenant details."},

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -41,7 +41,13 @@ class TenantService(asab.Service):
 		return await self.TenantsProvider.get(tenant_id)
 
 
-	async def create_tenant(self, tenant_id: str, creator_id: str = None):
+	async def create_tenant(
+		self, tenant_id: str, *,
+		label: str = None,
+		description: str = None,
+		data: dict = None,
+		creator_id: str = None
+	):
 		if not self.TenantNameRegex.match(tenant_id):
 			raise asab.exceptions.ValidationError(
 				"Invalid tenant ID {!r}. "
@@ -49,7 +55,8 @@ class TenantService(asab.Service):
 				"start with a letter, and be between 3 and 32 characters long.".format(tenant_id))
 
 		try:
-			tenant_id = await self.TenantsProvider.create(tenant_id, creator_id)
+			tenant_id = await self.TenantsProvider.create(
+				tenant_id, label=label, description=description, data=data, creator_id=creator_id)
 		except asab.storage.exceptions.DuplicateError:
 			L.error("Tenant with this ID already exists.", struct_data={"tenant": tenant_id})
 			raise asab.exceptions.Conflict(value=tenant_id)


### PR DESCRIPTION
closes #246 

# Changes

- Tenants now have an optional `label` attribute, which should contain a human-palatable name of the tenant. This attribute (unlike `tenant_id`) supports Unicode.
- Tenant `label` and `data` can now also be set in the tenant creation request.