### PR TITLE
Add openid discovery uris to config defaults

### DIFF
--- a/seacatauth/external_login/providers/facebook.py
+++ b/seacatauth/external_login/providers/facebook.py
@@ -21,6 +21,7 @@ class FacebookOAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "facebook"
 	ConfigDefaults = {
+		"discovery_uri": "https://www.facebook.com/.well-known/openid-configuration",
 		"authorize_uri": "https://www.facebook.com/v15.0/dialog/oauth",
 		"access_token_uri": "https://graph.facebook.com/v15.0/oauth/access_token",
 		"userinfo_uri": "https://graph.facebook.com/me",

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -27,6 +27,7 @@ class GenericOAuth2Login(asab.Configurable):
 	client_id=308u2fXEBUTolb.provider.auth
 	client_secret=5TfIjab8EZtixx3XkmFLfdXiHxkU2KlU
 
+	discovery_uri=https://provider.auth/.well-known/openid-configuration
 	authorize_uri=https://provider.auth/login/oauth/authorize
 	access_token_uri=https://provider.auth/login/oauth/access_token
 

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -18,7 +18,7 @@ L = logging.getLogger(__name__)
 
 class GenericOAuth2Login(asab.Configurable):
 	"""
-	Generic OAuth2 login provider
+	Generic OAuth2 (OpenID) login provider
 
 	Example config:
 	```conf
@@ -31,7 +31,7 @@ class GenericOAuth2Login(asab.Configurable):
 	authorize_uri=https://provider.auth/login/oauth/authorize
 	access_token_uri=https://provider.auth/login/oauth/access_token
 
-	scope=openidconnect
+	scope=openid name email
 	label=Login via provider.auth
 	```
 	"""
@@ -39,6 +39,7 @@ class GenericOAuth2Login(asab.Configurable):
 	Type = None
 
 	def __init__(self, external_login_svc, config_section_name, config=None):
+		# TODO: Get the URLs automatically from the discovery_uri (or issuer name)
 		super().__init__(config_section_name, config)
 		if self.Type is None:
 			match = re.match("seacatauth:oauth2:([_a-zA-Z0-9]+)", config_section_name)
@@ -140,6 +141,7 @@ class GenericOAuth2Login(asab.Configurable):
 
 		try:
 			id_info = jwcrypto.jwt.JWT(jwt=id_token)
+			# TODO: Validate the token using the keys from jwks_uri
 			payload = id_info.token.objects.get("payload")
 			data_dict = json.loads(payload)
 		except Exception as e:

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -21,6 +21,8 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "github"
 	ConfigDefaults = {
+		"discovery_uri": "https://token.actions.githubusercontent.com/.well-known/openid-configuration",
+		# TODO: Update the rest of the config to the new Github OpenID configuration
 		"authorize_uri": "https://github.com/login/oauth/authorize",
 		"access_token_uri": "https://github.com/login/oauth/access_token",
 		"userinfo_uri": "https://api.github.com/user",

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -21,8 +21,7 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "github"
 	ConfigDefaults = {
-		"discovery_uri": "https://token.actions.githubusercontent.com/.well-known/openid-configuration",
-		# TODO: Update the rest of the config to the new Github OpenID configuration
+		# Github does not implement OpenID Connect, only OAuth. There is no OpenID discovery_uri.
 		"authorize_uri": "https://github.com/login/oauth/authorize",
 		"access_token_uri": "https://github.com/login/oauth/access_token",
 		"userinfo_uri": "https://api.github.com/user",

--- a/seacatauth/external_login/providers/google.py
+++ b/seacatauth/external_login/providers/google.py
@@ -12,6 +12,7 @@ class GoogleOAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "google"
 	ConfigDefaults = {
+		"discovery_uri": "https://accounts.google.com/.well-known/openid-configuration",
 		"authorize_uri": "https://accounts.google.com/o/oauth2/auth",
 		"access_token_uri": "https://accounts.google.com/o/oauth2/token",
 		"scope": "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email",

--- a/seacatauth/external_login/providers/mojeid.py
+++ b/seacatauth/external_login/providers/mojeid.py
@@ -12,6 +12,7 @@ class MojeIDOAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "mojeid"
 	ConfigDefaults = {
+		"discovery_uri": "https://mojeid.cz/.well-known/openid-configuration",
 		"authorize_uri": "https://mojeid.cz/oidc/authorization/",
 		# "authorize_uri": "https://mojeid.cz/oidc/authorization/",  # test environment
 		"access_token_uri": "https://mojeid.cz/oidc/token/",

--- a/seacatauth/external_login/providers/office365.py
+++ b/seacatauth/external_login/providers/office365.py
@@ -12,6 +12,8 @@ class Office365OAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "office365"
 	ConfigDefaults = {
+		"discovery_uri": "https://sts.windows.net/{tenant_id}/.well-known/openid-configuration",
+		# also available at "https://login.microsoftonline.com/{tenant_id}/.well-known/openid-configuration",
 		"authorize_uri": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize",
 		"access_token_uri": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
 		"tenant_id": "",


### PR DESCRIPTION
The discovery URI is currently only for documentation purposes. It is not actively used yet.