### PR TITLE
External login JWT validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Human-readable tenant label (#285, PLUM Sprint 230908)
 - Log failed password change requests (#291, PLUM Sprint 230908)
 - Get Github user email address (#289, PLUM Sprint 230908)
+- External login ID token validation (#292, PLUM Sprint 230908)
 
 ---
 

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -48,15 +48,17 @@ class ExternalLoginHandler(object):
 		cookie_svc = self.App.get_service("seacatauth.CookieService")
 		client_svc = self.App.get_service("seacatauth.ClientService")
 
+		authorize_data = request.query
+
 		# TODO: Implement state parameter for XSRF prevention
-		# state = request.query.get("state")
+		# state = authorize_data.get("state")
 		# if state is None:
 		# 	L.error("State parameter not provided in external login response")
 		state = None
 
 		login_provider_type = request.match_info["ext_login_provider"]
 		provider = self.ExternalLoginService.get_provider(login_provider_type)
-		user_info = await provider.do_external_login(request)
+		user_info = await provider.do_external_login(authorize_data)
 
 		if user_info is None:
 			L.error("Cannot obtain user info from external login provider")
@@ -141,8 +143,10 @@ class ExternalLoginHandler(object):
 		"""
 		Register a new external login provider account
 		"""
+		authorize_data = request.query
+
 		# TODO: Implement state parameter for XSRF prevention
-		# state = request.query.get("state")
+		# state = authorize_data.get("state")
 		# if state is None:
 		# 	L.error("State parameter not provided in external login response")
 		state = None
@@ -167,7 +171,7 @@ class ExternalLoginHandler(object):
 			return response
 
 		login_provider = self.ExternalLoginService.get_provider(login_provider_type)
-		user_info = await login_provider.add_external_login(request)
+		user_info = await login_provider.add_external_login(authorize_data)
 		if user_info is None:
 			L.error("Cannot obtain user info from external login provider")
 			return self._my_account_redirect_response(state=state, error="external_login_failed")

--- a/seacatauth/external_login/providers/facebook.py
+++ b/seacatauth/external_login/providers/facebook.py
@@ -26,8 +26,8 @@ class FacebookOAuth2Login(GenericOAuth2Login):
 		"authorization_endpoint": "https://www.facebook.com/v18.0/dialog/oauth",
 		"token_endpoint": "https://graph.facebook.com/v18.0/oauth/access_token",
 		"userinfo_endpoint": "https://graph.facebook.com/me",
-		"response_type": "code granted_scopes",
-		"scope": "public_profile",
+		"response_type": "code",
+		"scope": "public_profile,email",
 		"fields": "id,name,email",
 		"label": "Sign in with Facebook",
 	}

--- a/seacatauth/external_login/providers/facebook.py
+++ b/seacatauth/external_login/providers/facebook.py
@@ -57,16 +57,16 @@ class FacebookOAuth2Login(GenericOAuth2Login):
 			query_string=urllib.parse.urlencode(query_params)
 		)
 
-	async def _get_user_info(self, authorize_callback, redirect_uri):
+	async def _get_user_info(self, authorize_data, redirect_uri):
 		"""
 		Info is not contained in token response, call to userinfo_endpoint is needed.
 		See the Facebook API Explorer here: https://developers.facebook.com/tools/explorer
 		"""
-		code = authorize_callback.query.get("code")
+		code = authorize_data.get("code")
 		if code is None:
 			L.error("Code parameter not provided in authorize response.", struct_data={
 				"provider": self.Type,
-				"query": dict(authorize_callback.query)})
+				"query": dict(authorize_data)})
 			return None
 
 		async with self.token_request(code, redirect_uri=redirect_uri) as resp:

--- a/seacatauth/external_login/providers/facebook.py
+++ b/seacatauth/external_login/providers/facebook.py
@@ -16,18 +16,21 @@ class FacebookOAuth2Login(GenericOAuth2Login):
 	This app must be registered at Facebook:
 	https://developers.facebook.com/docs/facebook-login/web
 
+	# Facebook uses a custom OAuth implementation. The flow is described here:
+	https://developers.facebook.com/docs/facebook-login/guides/advanced/manual-flow
+
 	Redirect URI should be set to the following:
-	https://{my_domain}/seacat_auth/public/ext-login/facebook
-	https://{my_domain}/seacat_auth/public/ext-login-add/facebook
+	https://{my_domain}/seacat-auth/public/ext-login/facebook
+	https://{my_domain}/seacat-auth/public/ext-login-add/facebook
 	"""
 	Type = "facebook"
 	ConfigDefaults = {
 		# Facebook uses a custom OAuth implementation. There is no OpenID discovery_uri.
-		"authorization_endpoint": "https://www.facebook.com/v18.0/dialog/oauth",
-		"token_endpoint": "https://graph.facebook.com/v18.0/oauth/access_token",
+		"authorization_endpoint": "https://www.facebook.com/v15.0/dialog/oauth",
+		"token_endpoint": "https://graph.facebook.com/v15.0/oauth/access_token",
 		"userinfo_endpoint": "https://graph.facebook.com/me",
 		"response_type": "code",
-		"scope": "public_profile,email",
+		"scope": "public_profile",
 		"fields": "id,name,email",
 		"label": "Sign in with Facebook",
 	}

--- a/seacatauth/external_login/providers/facebook.py
+++ b/seacatauth/external_login/providers/facebook.py
@@ -54,16 +54,24 @@ class FacebookOAuth2Login(GenericOAuth2Login):
 			query_string=urllib.parse.urlencode(query_params)
 		)
 
-	async def _get_user_info(self, code, redirect_uri):
+	async def _get_user_info(self, authorize_callback, redirect_uri):
 		"""
 		Info is not contained in token response, call to userinfo_endpoint is needed.
 		See the Facebook API Explorer here: https://developers.facebook.com/tools/explorer
 		"""
+		code = authorize_callback.query.get("code")
+		if code is None:
+			L.error("Code parameter not provided in authorize response.", struct_data={
+				"provider": self.Type,
+				"query": dict(authorize_callback.query)})
+			return None
+
 		async with self.token_request(code, redirect_uri=redirect_uri) as resp:
 			token_data = await resp.json()
 
 		if "access_token" not in token_data:
-			L.error("Token response does not contain 'access_token'", struct_data={"resp": token_data})
+			L.error("Token response does not contain 'access_token'.", struct_data={
+				"provider": self.Type, "resp": token_data})
 			return None
 
 		access_token = token_data["access_token"]
@@ -73,7 +81,8 @@ class FacebookOAuth2Login(GenericOAuth2Login):
 			async with session.get(self.UserInfoEndpoint, params=qparams) as resp:
 				data = await resp.json()
 				if resp.status != 200:
-					L.error("Error response from external auth provider", struct_data={
+					L.error("Error response from external auth provider.", struct_data={
+						"provider": self.Type,
 						"status": resp.status,
 						"data": data,
 						"url": resp.url

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -1,5 +1,6 @@
 import json
 import re
+import typing
 import urllib.parse
 import logging
 import contextlib
@@ -180,12 +181,12 @@ class GenericOAuth2Login(asab.Configurable):
 				else:
 					yield resp
 
-	async def _get_user_info(self, authorize_callback: aiohttp.web.Request, redirect_uri):
-		code = authorize_callback.query.get("code")
+	async def _get_user_info(self, authorize_data: typing.Mapping, redirect_uri):
+		code = authorize_data.get("code")
 		if code is None:
 			L.error("Code parameter not provided in authorize response.", struct_data={
 				"provider": self.Type,
-				"query": dict(authorize_callback.query)})
+				"query": dict(authorize_data)})
 			return None
 
 		async with self.token_request(code, redirect_uri=redirect_uri) as resp:
@@ -228,8 +229,8 @@ class GenericOAuth2Login(asab.Configurable):
 		return self._get_authorize_uri(self.AddExternalLoginURI, state)
 
 	# TODO: These two methods do the exact same thing. Refactor.
-	async def do_external_login(self, authorize_callback: aiohttp.web.Request):
-		return await self._get_user_info(authorize_callback, redirect_uri=self.LoginURI)
+	async def do_external_login(self, authorize_data: typing.Mapping):
+		return await self._get_user_info(authorize_data, redirect_uri=self.LoginURI)
 
-	async def add_external_login(self, authorize_callback: aiohttp.web.Request):
-		return await self._get_user_info(authorize_callback, redirect_uri=self.AddExternalLoginURI)
+	async def add_external_login(self, authorize_data: typing.Mapping):
+		return await self._get_user_info(authorize_data, redirect_uri=self.AddExternalLoginURI)

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -27,9 +27,12 @@ class GenericOAuth2Login(asab.Configurable):
 	client_id=308u2fXEBUTolb.provider.auth
 	client_secret=5TfIjab8EZtixx3XkmFLfdXiHxkU2KlU
 
-	discovery_uri=https://provider.auth/.well-known/openid-configuration
-	authorize_uri=https://provider.auth/login/oauth/authorize
-	access_token_uri=https://provider.auth/login/oauth/access_token
+	issuer=https://provider.auth/login
+	discovery_uri=https://provider.auth/login/.well-known/openid-configuration
+	jwks_uri=https://provider.auth/login/.well-known/jwks.json
+	authorization_endpoint=https://provider.auth/login/oauth/authorize
+	token_endpoint=https://provider.auth/login/oauth/token
+	userinfo_endpoint=https://provider.auth/login/oauth/userinfo
 
 	scope=openid name email
 	label=Login via provider.auth
@@ -44,6 +47,33 @@ class GenericOAuth2Login(asab.Configurable):
 		if self.Type is None:
 			match = re.match("seacatauth:oauth2:([_a-zA-Z0-9]+)", config_section_name)
 			self.Type = match.group(1)
+
+		# Adopt proper OAuth/OpenID terminology
+		if "authorize_uri" in self.Config:
+			asab.LogObsolete.warning(
+				"The 'authorize_uri' config option will be obsoleted. Use 'authorization_endpoint' instead. ",
+				struct_data={"eol": "2024-01-31"})
+			self.Config["authorization_endpoint"] = self.Config["authorize_uri"]
+		if "access_token_uri" in self.Config:
+			asab.LogObsolete.warning(
+				"The 'access_token_uri' config option will be obsoleted. Use 'token_endpoint' instead. ",
+				struct_data={"eol": "2024-01-31"})
+			self.Config["token_endpoint"] = self.Config["access_token_uri"]
+		if "userinfo_uri" in self.Config:
+			asab.LogObsolete.warning(
+				"The 'userinfo_uri' config option will be obsoleted. Use 'userinfo_endpoint' instead. ",
+				struct_data={"eol": "2024-01-31"})
+			self.Config["userinfo_endpoint"] = self.Config["userinfo_uri"]
+
+		self.Issuer = self.Config.get("issuer")
+		self.DiscoveryUri = self.Config.get("discovery_uri")
+		self.JwksUri = self.Config.get("jwks_uri")
+
+		self.AuthorizationEndpoint = self.Config.get("authorization_endpoint")
+		assert self.AuthorizationEndpoint is not None
+
+		self.TokenEndpoint = self.Config.get("token_endpoint")
+		assert self.TokenEndpoint is not None
 
 		self.ClientId = self.Config.get("client_id")
 		assert self.ClientId is not None
@@ -95,7 +125,7 @@ class GenericOAuth2Login(asab.Configurable):
 		if state is not None:
 			query_params.append(("state", state))
 		return "{authorize_uri}?{query_string}".format(
-			authorize_uri=self.AuthorizeURI,
+			authorize_uri=self.AuthorizationEndpoint,
 			query_string=urllib.parse.urlencode(query_params)
 		)
 
@@ -115,7 +145,7 @@ class GenericOAuth2Login(asab.Configurable):
 			"content-type": "application/x-www-form-urlencoded"
 		}
 		async with aiohttp.ClientSession() as session:
-			async with session.post(self.AccessTokenURI, data=query_string, headers=headers) as resp:
+			async with session.post(self.TokenEndpoint, data=query_string, headers=headers) as resp:
 				if resp.status != 200:
 					text = await resp.text()
 					L.error("Error response from external auth provider", struct_data={
@@ -131,33 +161,32 @@ class GenericOAuth2Login(asab.Configurable):
 		async with self.token_request(code, redirect_uri=redirect_uri) as resp:
 			if resp is None:
 				return None
-			access_token_dict = await resp.json()
+			token_data = await resp.json()
 
-		if "id_token" not in access_token_dict:
-			L.error("Token response does not contain 'id_token'", struct_data={"at_resp": access_token_dict})
+		if "id_token" not in token_data:
+			L.error("Token response does not contain 'id_token'", struct_data={"resp": token_data})
 			return None
 
-		id_token = access_token_dict["id_token"]
+		id_token = token_data["id_token"]
+		await self._prepare_jwks()
 
 		try:
-			id_info = jwcrypto.jwt.JWT(jwt=id_token)
-			# TODO: Validate the token using the keys from jwks_uri
-			payload = id_info.token.objects.get("payload")
-			data_dict = json.loads(payload)
+			id_info = jwcrypto.jwt.JWT(jwt=id_token, key=self.Jwks)
+			claims = id_info.token.objects.get("payload")
+			claims = json.loads(claims)
 		except Exception as e:
-			L.error("Error reading id_token payload", struct_data={
+			L.error("Error reading id_token claims.", struct_data={
 				"err": str(e),
-				"at_resp": access_token_dict,
-			})
+				"resp": token_data})
 			return None
 
 		user_info = {}
-		if "sub" in data_dict.keys():
-			user_info["sub"] = data_dict["sub"]
-		if "email" in data_dict.keys():
-			user_info["email"] = data_dict["email"]
-		if self.Ident in data_dict.keys():
-			user_info["ident"] = data_dict[self.Ident]
+		if "sub" in claims.keys():
+			user_info["sub"] = claims["sub"]
+		if "email" in claims.keys():
+			user_info["email"] = claims["email"]
+		if self.Ident in claims.keys():
+			user_info["ident"] = claims[self.Ident]
 		return user_info
 
 	def get_login_authorize_uri(self, state=None):

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -124,8 +124,9 @@ class GenericOAuth2Login(asab.Configurable):
 				if resp.status != 200:
 					text = await resp.text()
 					L.error(
-						"Failed to fetch server JWKS: External identity provider responded with error.",
+						"Failed to fetch server JWK set: External identity provider responded with error.",
 						struct_data={
+							"provider": self.Type,
 							"status": resp.status,
 							"url": resp.url,
 							"text": text})

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -79,13 +79,6 @@ class GenericOAuth2Login(asab.Configurable):
 		assert self.ClientId is not None
 
 		self.ClientSecret = self.Config.get("client_secret")
-		assert self.ClientSecret is not None
-
-		self.AuthorizeURI = self.Config.get("authorize_uri")
-		assert self.AuthorizeURI is not None
-
-		self.AccessTokenURI = self.Config.get("access_token_uri")
-		assert self.AccessTokenURI is not None
 
 		self.Scope = self.Config.get("scope")
 		assert self.Scope is not None
@@ -134,13 +127,15 @@ class GenericOAuth2Login(asab.Configurable):
 		"""
 		Send auth code to token request endpoint and return access token
 		"""
-		query_string = urllib.parse.urlencode([
+		request_params = [
 			("grant_type", "authorization_code"),
 			("code", code),
 			("client_id", self.ClientId),
-			("client_secret", self.ClientSecret),
-			("redirect_uri", redirect_uri)
-		])
+			("redirect_uri", redirect_uri)]
+		if self.ClientSecret:
+			request_params.append(("client_secret", self.ClientSecret))
+		query_string = urllib.parse.urlencode(request_params)
+
 		headers = {
 			"content-type": "application/x-www-form-urlencoded"
 		}

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -24,7 +24,7 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 		# Github does not implement OpenID Connect, only OAuth. There is no OpenID discovery_uri.
 		"authorization_endpoint": "https://github.com/login/oauth/authorize",
 		"token_endpoint": "https://github.com/login/oauth/access_token",
-		"userinfo_uri": "https://api.github.com/user",
+		"userinfo_endpoint": "https://api.github.com/user",
 		"scope": "",  # Scope is not required
 		"label": "Sign in with Github",
 		"ident": "login",
@@ -32,8 +32,8 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 
 	def __init__(self, external_login_svc, config_section_name):
 		super().__init__(external_login_svc, config_section_name)
-		self.UserInfoURI = self.Config.get("userinfo_uri")
-		assert self.UserInfoURI not in (None, "")
+		self.UserInfoEndpoint = self.Config.get("userinfo_endpoint")
+		assert self.UserInfoEndpoint not in (None, "")
 
 	async def _get_user_info(self, code, redirect_uri):
 		"""
@@ -56,7 +56,7 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 		}
 
 		async with aiohttp.ClientSession() as session:
-			async with session.get(self.UserInfoURI, headers=headers) as resp:
+			async with session.get(self.UserInfoEndpoint, headers=headers) as resp:
 				data = await resp.json()
 				if resp.status != 200:
 					L.error("Error response from external auth provider", struct_data={

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -21,11 +21,11 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "github"
 	ConfigDefaults = {
-		# Github does not implement OpenID Connect, only OAuth. There is no OpenID discovery_uri.
+		# Github uses a custom OAuth implementation. There is no OpenID discovery_uri.
 		"authorization_endpoint": "https://github.com/login/oauth/authorize",
 		"token_endpoint": "https://github.com/login/oauth/access_token",
 		"userinfo_endpoint": "https://api.github.com/user",
-		"scope": "",  # Scope is not required
+		"scope": "",  # Scope is not used
 		"label": "Sign in with Github",
 		"ident": "login",
 	}

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -22,8 +22,8 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 	Type = "github"
 	ConfigDefaults = {
 		# Github does not implement OpenID Connect, only OAuth. There is no OpenID discovery_uri.
-		"authorize_uri": "https://github.com/login/oauth/authorize",
-		"access_token_uri": "https://github.com/login/oauth/access_token",
+		"authorization_endpoint": "https://github.com/login/oauth/authorize",
+		"token_endpoint": "https://github.com/login/oauth/access_token",
 		"userinfo_uri": "https://api.github.com/user",
 		"scope": "",  # Scope is not required
 		"label": "Sign in with Github",

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -37,16 +37,16 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 		assert self.UserInfoEndpoint not in (None, "")
 		self.UserEmailsURI = self.Config.get("user_emails_endpoint")
 
-	async def _get_user_info(self, authorize_callback, redirect_uri):
+	async def _get_user_info(self, authorize_data, redirect_uri):
 		"""
 		Info is not contained in access_token,
 		call to https://api.github.com/user is needed.
 		"""
-		code = authorize_callback.query.get("code")
+		code = authorize_data.get("code")
 		if code is None:
 			L.error("Code parameter not provided in authorize response.", struct_data={
 				"provider": self.Type,
-				"query": dict(authorize_callback.query)})
+				"query": dict(authorize_data)})
 			return None
 
 		async with self.token_request(code, redirect_uri=redirect_uri) as resp:

--- a/seacatauth/external_login/providers/google.py
+++ b/seacatauth/external_login/providers/google.py
@@ -14,9 +14,9 @@ class GoogleOAuth2Login(GenericOAuth2Login):
 	ConfigDefaults = {
 		"issuer": "https://accounts.google.com",
 		"discovery_uri": "https://accounts.google.com/.well-known/openid-configuration",
+		"jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
 		"authorization_endpoint": "https://accounts.google.com/o/oauth2/auth",
 		"token_endpoint": "https://accounts.google.com/o/oauth2/token",
 		"scope": "openid profile email",
-		"jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
 		"label": "Sign in with Google",
 	}

--- a/seacatauth/external_login/providers/google.py
+++ b/seacatauth/external_login/providers/google.py
@@ -12,10 +12,11 @@ class GoogleOAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "google"
 	ConfigDefaults = {
+		"issuer": "https://accounts.google.com",
 		"discovery_uri": "https://accounts.google.com/.well-known/openid-configuration",
-		"authorize_uri": "https://accounts.google.com/o/oauth2/auth",
-		"access_token_uri": "https://accounts.google.com/o/oauth2/token",
-		"scope": "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email",
-		"jwt_public_keys": "",  # For id_token validation
+		"authorization_endpoint": "https://accounts.google.com/o/oauth2/auth",
+		"token_endpoint": "https://accounts.google.com/o/oauth2/token",
+		"scope": "openid profile email",
+		"jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
 		"label": "Sign in with Google",
 	}

--- a/seacatauth/external_login/providers/mojeid.py
+++ b/seacatauth/external_login/providers/mojeid.py
@@ -12,11 +12,10 @@ class MojeIDOAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "mojeid"
 	ConfigDefaults = {
+		"issuer": "https://mojeid.cz",
 		"discovery_uri": "https://mojeid.cz/.well-known/openid-configuration",
-		"authorize_uri": "https://mojeid.cz/oidc/authorization/",
-		# "authorize_uri": "https://mojeid.cz/oidc/authorization/",  # test environment
-		"access_token_uri": "https://mojeid.cz/oidc/token/",
-		# "access_token_uri": "https://mojeid.cz/oidc/token/",       # test environment
+		"authorization_endpoint": "https://mojeid.cz/oidc/authorization/",
+		"token_endpoint": "https://mojeid.cz/oidc/token/",
 		"scope": "openid email phone",
 		"label": "Sign in with MojeID",
 	}

--- a/seacatauth/external_login/providers/mojeid.py
+++ b/seacatauth/external_login/providers/mojeid.py
@@ -14,6 +14,7 @@ class MojeIDOAuth2Login(GenericOAuth2Login):
 	ConfigDefaults = {
 		"issuer": "https://mojeid.cz",
 		"discovery_uri": "https://mojeid.cz/.well-known/openid-configuration",
+		"jwks_uri": "https://mojeid.cz/oidc/key.jwk",
 		"authorization_endpoint": "https://mojeid.cz/oidc/authorization/",
 		"token_endpoint": "https://mojeid.cz/oidc/token/",
 		"scope": "openid email phone",

--- a/seacatauth/external_login/providers/office365.py
+++ b/seacatauth/external_login/providers/office365.py
@@ -15,11 +15,11 @@ class Office365OAuth2Login(GenericOAuth2Login):
 		"issuer": "https://sts.windows.net/{tenant_id}",
 		"discovery_uri": "https://sts.windows.net/{tenant_id}/.well-known/openid-configuration",
 		# also available at "https://login.microsoftonline.com/{tenant_id}/.well-known/openid-configuration",
+		"jwks_uri": "https://login.microsoftonline.com/common/discovery/keys",
 		"authorization_endpoint": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize",
 		"token_endpoint": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
 		"tenant_id": "",
 		"scope": "openid",
-		"jwt_public_keys": "",  # For id_token validation
 		"label": "Sign in with Office365",
 	}
 

--- a/seacatauth/external_login/providers/office365.py
+++ b/seacatauth/external_login/providers/office365.py
@@ -12,10 +12,11 @@ class Office365OAuth2Login(GenericOAuth2Login):
 	"""
 	Type = "office365"
 	ConfigDefaults = {
+		"issuer": "https://sts.windows.net/{tenant_id}",
 		"discovery_uri": "https://sts.windows.net/{tenant_id}/.well-known/openid-configuration",
 		# also available at "https://login.microsoftonline.com/{tenant_id}/.well-known/openid-configuration",
-		"authorize_uri": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize",
-		"access_token_uri": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+		"authorization_endpoint": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize",
+		"token_endpoint": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
 		"tenant_id": "",
 		"scope": "openid",
 		"jwt_public_keys": "",  # For id_token validation
@@ -27,5 +28,6 @@ class Office365OAuth2Login(GenericOAuth2Login):
 		self.TenantID = self.Config.get("tenant_id")
 		assert self.TenantID not in (None, "")
 
-		self.AuthorizeURI = self.AuthorizeURI.format(tenant_id=self.TenantID)
-		self.AccessTokenURI = self.AccessTokenURI.format(tenant_id=self.TenantID)
+		self.Issuer = self.Issuer.format(tenant_id=self.TenantID)
+		self.AuthorizationEndpoint = self.AuthorizationEndpoint.format(tenant_id=self.TenantID)
+		self.TokenEndpoint = self.TokenEndpoint.format(tenant_id=self.TenantID)

--- a/seacatauth/external_login/service.py
+++ b/seacatauth/external_login/service.py
@@ -55,6 +55,8 @@ class ExternalLoginService(asab.Service):
 
 
 	async def initialize(self, app):
+		for provider in self.Providers.values():
+			await provider.initialize(app)
 		coll = await self.StorageService.collection(self.ExternalLoginCollection)
 		await coll.create_index(
 			[


### PR DESCRIPTION
- Add ID token signature validation for identity providers that support it (Google, Office365 and MojeID).
- Rename config options to match OpenID terminology (backwards compatibility preserved):
  - `authorize_uri` -> `authorization_endpoint`
  - `access_token_uri` -> `token_endpoint`
  - `userinfo_uri` -> `userinfo_endpoint`