### PR TITLE
Allow all standard OIDC authorize params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## Release candidate
 
+### Breaking changes
+- Dropped support for authorize query params `ldid` and `expiration` (#296, PLUM Sprint 231006)
+
 ### Features
 - Authorization for websocket requests (#300, PLUM Sprint 231006)
 - Silence stable log messages (#312, PLUM Sprint 231006)
 - External login registration webhook (#286, PLUM Sprint 231006)
+- OAuth Authorize ignores all unknown parameters (#296, PLUM Sprint 231006)
 
 ---
 

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -14,6 +14,7 @@ import seacatauth.exceptions
 from ..audit import AuditCode
 from ..cookie import set_cookie, delete_cookie
 from ..decorators import access_control
+from ..openidconnect.utils import AUTHORIZE_PARAMETERS
 
 #
 
@@ -475,11 +476,8 @@ class AuthenticationHandler(object):
 		client_dict = await client_service.get(request_data["client_id"])
 		query = {
 			k: v for k, v in request_data.items()
-			if k in frozenset([
-				"redirect_uri", "response_type", "scope", "prompt", "nonce", "state",
-				"code_challenge", "code_challenge_method"])
-		}
-		authorize_uri = oidc_service.build_authorize_uri(client_dict, client_id=request_data["client_id"], **query)
+			if k in AUTHORIZE_PARAMETERS}
+		authorize_uri = oidc_service.build_authorize_uri(client_dict, **query)
 
 		response = aiohttp.web.HTTPFound(
 			authorize_uri,

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -476,7 +476,8 @@ class AuthenticationHandler(object):
 		query = {
 			k: v for k, v in request_data.items()
 			if k in frozenset([
-				"redirect_uri", "response_type", "scope", "prompt", "code_challenge", "code_challenge_method"])
+				"redirect_uri", "response_type", "scope", "prompt", "nonce", "state",
+				"code_challenge", "code_challenge_method"])
 		}
 		authorize_uri = oidc_service.build_authorize_uri(client_dict, client_id=request_data["client_id"], **query)
 

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -481,25 +481,13 @@ class ClientService(asab.Service):
 		L.log(asab.LOG_NOTICE, "Client deleted", struct_data={"client_id": client_id})
 
 
-	async def authorize_client(
+	async def validate_client_authorize_options(
 		self,
 		client: dict,
 		redirect_uri: str,
-		client_secret: str = None,
 		grant_type: str = None,
 		response_type: str = None,
 	):
-		if client_secret is None:
-			# The client MAY omit the parameter if the client secret is an empty string.
-			# [rfc6749#section-2.3.1]
-			client_secret = ""
-		if "client_secret_expires_at" in client \
-			and client["client_secret_expires_at"] != 0 \
-			and client["client_secret_expires_at"] < datetime.datetime.now(datetime.timezone.utc):
-			raise exceptions.InvalidClientSecret(client["_id"])
-		if client_secret != client.get("__client_secret", ""):
-			raise exceptions.InvalidClientSecret(client["_id"])
-
 		if not self.OIDCService.DisableRedirectUriValidation and not validate_redirect_uri(
 			redirect_uri, client["redirect_uris"], client.get("redirect_uri_validation_method")):
 			raise exceptions.InvalidRedirectURI(client_id=client["_id"], redirect_uri=redirect_uri)
@@ -511,6 +499,24 @@ class ClientService(asab.Service):
 			raise exceptions.ClientError(client_id=client["_id"], response_type=response_type)
 
 		return True
+
+
+	async def authenticate_client(self, client: dict, client_secret: str = None):
+		"""
+		Verify client secret
+		"""
+		if client_secret is None:
+			# The client MAY omit the parameter if the client secret is an empty string.
+			# [rfc6749#section-2.3.1]
+			client_secret = ""
+		if "client_secret_expires_at" in client \
+			and client["client_secret_expires_at"] != 0 \
+			and client["client_secret_expires_at"] < datetime.datetime.now(datetime.timezone.utc):
+			L.warning("Client secret expired.", struct_data={"client_id": client["_id"]})
+		if client_secret != client.get("__client_secret", ""):
+			L.warning("Incorrect client secret.", struct_data={"client_id": client["_id"]})
+		return True
+
 
 	def _check_grant_types(self, grant_types, response_types):
 		# https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -488,6 +488,9 @@ class ClientService(asab.Service):
 		grant_type: str = None,
 		response_type: str = None,
 	):
+		"""
+		Verify that the specified authorization parameters are valid for the client.
+		"""
 		if not self.OIDCService.DisableRedirectUriValidation and not validate_redirect_uri(
 			redirect_uri, client["redirect_uris"], client.get("redirect_uri_validation_method")):
 			raise exceptions.InvalidRedirectURI(client_id=client["_id"], redirect_uri=redirect_uri)
@@ -503,8 +506,9 @@ class ClientService(asab.Service):
 
 	async def authenticate_client(self, client: dict, client_secret: str = None):
 		"""
-		Verify client secret
+		Verify client credentials (client_id and client_secret).
 		"""
+		# TODO: Use a client credential provider.
 		if client_secret is None:
 			# The client MAY omit the parameter if the client secret is an empty string.
 			# [rfc6749#section-2.3.1]

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -284,6 +284,7 @@ class AuthorizeHandler(object):
 		prompt: str = None,
 		code_challenge: str = None,
 		code_challenge_method: str = "none",
+		**kwargs
 	):
 		"""
 		https://openid.net/specs/openid-connect-core-1_0.html
@@ -708,7 +709,7 @@ class AuthorizeHandler(object):
 		client_dict = await self.OpenIdConnectService.ClientService.get(client_id)
 
 		# Build redirect uri
-		callback_uri = await self.OpenIdConnectService.build_authorize_uri(
+		callback_uri = self.OpenIdConnectService.build_authorize_uri(
 			client_dict=client_dict,
 			client_id=client_id,
 			response_type=response_type,
@@ -753,7 +754,7 @@ class AuthorizeHandler(object):
 
 		# Gather params which will be passed to the oidc/authorize request called after the OTP setup
 		client_dict = await self.OpenIdConnectService.ClientService.get(client_id)
-		callback_uri = await self.OpenIdConnectService.build_authorize_uri(
+		callback_uri = self.OpenIdConnectService.build_authorize_uri(
 			client_dict=client_dict,
 			client_id=client_id,
 			response_type=response_type,

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -675,12 +675,13 @@ class AuthorizeHandler(object):
 
 
 	async def reply_with_redirect_to_login(
-		self, response_type: str, scope: list, client_id: str, redirect_uri: str,
-		state: str = None,
-		nonce: str = None,
-		code_challenge: str = None,
-		code_challenge_method: str = None,
-		login_parameters: dict = None
+		self,
+		client_id: str,
+		response_type: str,
+		scope: list,
+		redirect_uri: str,
+		login_parameters: dict = None,
+		**authorize_params
 	):
 		"""
 		Reply with 404 and provide a link to the login form with a loopback to OIDC/authorize.
@@ -701,11 +702,8 @@ class AuthorizeHandler(object):
 			client_id=client_id,
 			response_type=response_type,
 			scope=scope,
-			state=state,
-			nonce=nonce,
-			code_challenge=code_challenge,
-			code_challenge_method=code_challenge_method,
 			redirect_uri=redirect_uri,
+			**authorize_params
 		)
 
 		login_query_params.append(("redirect_uri", callback_uri))
@@ -725,11 +723,13 @@ class AuthorizeHandler(object):
 		return response
 
 	async def reply_with_factor_setup_redirect(
-		self, missing_factors: list, response_type: str, scope: list, client_id: str, redirect_uri: str,
-		state: str = None,
-		nonce: str = None,
-		code_challenge: str = None,
-		code_challenge_method: str = None,
+		self,
+		missing_factors: list,
+		client_id: str,
+		response_type: str,
+		scope: list,
+		redirect_uri: str,
+		**authorize_params
 	):
 		"""
 		Redirect to home screen and force factor (re)configuration
@@ -747,11 +747,8 @@ class AuthorizeHandler(object):
 			client_id=client_id,
 			response_type=response_type,
 			scope=scope,
-			state=state,
-			nonce=nonce,
-			code_challenge=code_challenge,
-			code_challenge_method=code_challenge_method,
 			redirect_uri=redirect_uri,
+			**authorize_params
 		)
 
 		auth_url_params = [

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -264,7 +264,7 @@ class AuthorizeHandler(object):
 
 		3.1.2.1.  Authentication Request
 		"""
-
+		print(request_parameters)
 		# Check the presence of required parameters
 		self._validate_request_parameters(request_parameters)
 
@@ -378,38 +378,38 @@ class AuthorizeHandler(object):
 				# Delete current session and redirect to login
 				await self.SessionService.delete(root_session.SessionId)
 				return await self.reply_with_redirect_to_login(
-					response_type="code",
 					scope=scope,
 					client_id=client_id,
 					redirect_uri=redirect_uri,
 					state=state,
 					nonce=nonce,
 					code_challenge=code_challenge,
-					code_challenge_method=code_challenge_method)
+					code_challenge_method=code_challenge_method,
+					**kwargs)
 			elif prompt == "select_account":
 				# Redirect to login without deleting current session
 				return await self.reply_with_redirect_to_login(
-					response_type="code",
 					scope=scope,
 					client_id=client_id,
 					redirect_uri=redirect_uri,
 					state=state,
 					nonce=nonce,
 					code_challenge=code_challenge,
-					code_challenge_method=code_challenge_method)
+					code_challenge_method=code_challenge_method,
+					**kwargs)
 
 		elif allow_anonymous:
 			# Create anonymous session or redirect to login if requested
 			if prompt == "login" or prompt == "select_account":
 				return await self.reply_with_redirect_to_login(
-					response_type="code",
 					scope=scope,
 					client_id=client_id,
 					redirect_uri=redirect_uri,
 					state=state,
 					nonce=nonce,
 					code_challenge=code_challenge,
-					code_challenge_method=code_challenge_method)
+					code_challenge_method=code_challenge_method,
+					**kwargs)
 
 		else:  # NOT authenticated and NOT allowing anonymous access
 			# Redirect to login unless prompt=none requested
@@ -419,14 +419,14 @@ class AuthorizeHandler(object):
 					redirect_uri=redirect_uri,
 					state=state)
 			return await self.reply_with_redirect_to_login(
-				response_type="code",
 				scope=scope,
 				client_id=client_id,
 				redirect_uri=redirect_uri,
 				state=state,
 				nonce=nonce,
 				code_challenge=code_challenge,
-				code_challenge_method=code_challenge_method)
+				code_challenge_method=code_challenge_method,
+				**kwargs)
 
 		# Here the request must be authenticated or anonymous access must be allowed
 		assert authenticated or allow_anonymous

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -270,10 +270,10 @@ class AuthorizeHandler(object):
 
 		# Authentication Code Flow
 		assert request_parameters["response_type"] == "code"
-		return await self.authentication_code_flow(request, **request_parameters)
+		return await self.authorization_code_flow(request, **request_parameters)
 
 
-	async def authentication_code_flow(
+	async def authorization_code_flow(
 		self,
 		request,
 		scope: str,

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -511,7 +511,7 @@ class OpenIdConnectService(asab.Service):
 			**kwargs)
 
 
-	def build_authorize_uri(self, client_dict, **query_params):
+	def build_authorize_uri(self, client_dict: dict, **query_params):
 		"""
 		Check if the client has a registered OAuth Authorize URI. If not, use the default.
 		Extend the URI with query parameters.

--- a/seacatauth/openidconnect/utils.py
+++ b/seacatauth/openidconnect/utils.py
@@ -37,3 +37,26 @@ class InvalidGrantError(Exception):
 	def __init__(self, *args, client_id=None):
 		self.ClientId = client_id
 		super().__init__("Invalid grant.", *args)
+
+
+AUTHORIZE_PARAMETERS = frozenset([
+	# OAuth 2.0 parameters
+	"client_id",
+	"scope",
+	"response_type",
+	"redirect_uri",
+	"state",
+	"response_mode",
+	# OpenID Connect parameters
+	"nonce",
+	"display",
+	"prompt",
+	"max_age",
+	"ui_locales",
+	"id_token_hint",
+	"login_hint",
+	"acr_values",
+	# PKCE parameters
+	"code_challenge",
+	"code_challenge_method"
+])


### PR DESCRIPTION
- OpenID Authorization endpoint should ignore all unknown request parameters.
- Standard OAuth / OpenID parameters are at the least acknowledged and preserved in redirections.
- Client secret parameter does not belong in the authorization request, hence it was removed from the method arguments.
- **`BREAKING`** Dropped support for authorize query params `ldid` and `expiration`.