### PR TITLE
Fix webauthn username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fix
 - Preserve nonce when redirecting to login (#294, PLUM Sprint 230908, @elpablos)
+- Allow username for WebAuthn credentials username (#297, PLUM Sprint 230908)
 
 ### Features
 - Login with AppleID (#293, PLUM Sprint 230908, @filipmelik)

--- a/seacatauth/authn/webauthn/handler.py
+++ b/seacatauth/authn/webauthn/handler.py
@@ -5,6 +5,7 @@ import aiohttp.web
 import asab.web
 import asab.web.rest
 
+from ... import exceptions
 from ...decorators import access_control
 
 #
@@ -47,7 +48,10 @@ class WebAuthnHandler(object):
 		"""
 		Get WebAuthn registration options
 		"""
-		options = await self.WebAuthnService.get_registration_options(request.Session)
+		try:
+			options = await self.WebAuthnService.get_registration_options(request.Session)
+		except exceptions.AccessDeniedError:
+			return asab.web.rest.json_response(request, data={"status": "FAILED"}, status=400)
 		return aiohttp.web.Response(body=options, content_type="application/json")
 		# return asab.web.rest.json_response(request, options)
 


### PR DESCRIPTION
- Webauthn credentials `user_name` can be email, phone or newly username.
- If the user has neither, respond with 400.