### PR TITLE
Authorization for websocket requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Release candidate
+
+### Features
+- Authorization for websocket requests (#300, PLUM Sprint 231006)
+
+---
+
+
 ## v23.42-beta
 
 ### Breaking changes
@@ -14,7 +22,6 @@
 - Login with AppleID (#293, PLUM Sprint 230908, @filipmelik)
 - Webauthn authenticator metadata (#256, PLUM Sprint 230908)
 - Configurably disable auditing of anonymous sessions (#304, PLUM Sprint 231006)
-- Authorization for websocket requests (#300, PLUM Sprint 231006)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Login with AppleID (#293, PLUM Sprint 230908, @filipmelik)
 - Webauthn authenticator metadata (#256, PLUM Sprint 230908)
 - Configurably disable auditing of anonymous sessions (#304, PLUM Sprint 231006)
+- Authorization for websocket requests (#300, PLUM Sprint 231006)
 
 ---
 

--- a/example/nginx-config/nginx-websocket-authorization.conf
+++ b/example/nginx-config/nginx-websocket-authorization.conf
@@ -9,7 +9,7 @@ server {
 		internal;
 		proxy_method          POST;
 		proxy_set_body        "$http_authorization";
-		proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=my-app;
+		proxy_pass            http://seacat_private_api/nginx/introspect/openidconnect?client_id=my-app;
 		proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
 		proxy_cache           oauth_responses;

--- a/example/nginx-config/nginx-websocket-authorization.conf
+++ b/example/nginx-config/nginx-websocket-authorization.conf
@@ -1,0 +1,38 @@
+#####################################
+# OAUTH INTROSPECTION FOR WEBSOCKET
+
+# Define introspection cache
+proxy_cache_path on keys_zone=oauth_responses:1m max_size=2m;
+
+server {
+    location = /_oauth_introspect {
+		internal;
+		proxy_method          POST;
+		proxy_set_body        "$http_authorization";
+		proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=my-app;
+		proxy_ignore_headers  Cache-Control Expires Set-Cookie;
+
+		proxy_cache           oauth_responses;
+		# Concatenate the 'Authorization' and 'Sec-WebSocket-Protocol' headers to create the cache key
+		proxy_cache_key       "$http_authorization $http_sec_websocket_protocol";
+		proxy_cache_lock      on;
+		proxy_cache_valid     200 30s;
+	}
+
+	location /my-app {
+        rewrite ^/my-app/(.*) /$1 break;
+        proxy_pass http://my_app_api;
+
+        auth_request       /_seacat_admin_introspect;
+
+        # Let the auth request rewrite the "Authorization" and the "Cookie"
+        # headers to prevent auth token leaks
+        auth_request_set   $authorization $upstream_http_authorization;
+        proxy_set_header   Authorization $authorization;
+        auth_request_set   $cookie $upstream_http_cookie;
+        proxy_set_header   Cookie $cookie;
+
+        # Error 401 will result in a redirect to OAuth Authorize endpoint
+        error_page 401     /auth/api/openidconnect/authorize?client_id=my-app&response_type=code&scope=openid&redirect_uri=https://localhost/my-app/;
+    }
+}

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -21,9 +21,23 @@ def get_bearer_token_value(request):
 		return None
 	if auth_header.startswith(bearer_prefix):
 		return auth_header[len(bearer_prefix):]
-	else:
-		L.info("No Bearer token in Authorization header")
+
+	L.info("No Bearer token in Authorization header")
+	return None
+
+
+def get_access_token_value_from_webhook(request):
+	token_prefix = "access_token_"
+	ws_protocol_header: str = request.headers.get("Sec-WebSocket-Protocol")
+	if ws_protocol_header is None:
+		L.info("Request has no 'Sec-WebSocket-Protocol' header")
 		return None
+	for value in ws_protocol_header.split(", "):
+		if value.startswith(token_prefix):
+			return value[len(token_prefix):]
+	
+	L.info("No access token in Sec-WebSocket-Protocol header")
+	return None
 
 
 async def add_to_header(headers, attributes_to_add, session, requested_tenant=None):

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -35,7 +35,7 @@ def get_access_token_value_from_websocket(request):
 	for value in ws_protocol_header.split(", "):
 		if value.startswith(token_prefix):
 			return value[len(token_prefix):]
-	
+
 	L.info("No access token in Sec-WebSocket-Protocol header")
 	return None
 

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -26,7 +26,7 @@ def get_bearer_token_value(request):
 	return None
 
 
-def get_access_token_value_from_webhook(request):
+def get_access_token_value_from_websocket(request):
 	token_prefix = "access_token_"
 	ws_protocol_header: str = request.headers.get("Sec-WebSocket-Protocol")
 	if ws_protocol_header is None:

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -78,7 +78,7 @@ class TokenIntrospectionHandler(object):
 		if token_value is None:
 			token_value = get_access_token_value_from_websocket(request)
 		if token_value is None:
-			L.log(asab.LOG_NOTICE, "No Bearer token in Authorization header.")
+			L.log(asab.LOG_NOTICE, "Access token not found in 'Authorization' nor 'Sec-WebSocket-Protocol' header")
 			return None
 		session = await self.OpenIdConnectService.get_session_by_access_token(token_value)
 		if session is None:

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -5,7 +5,7 @@ import aiohttp.web
 import asab
 import asab.web.rest
 
-from ...generic import nginx_introspection, get_bearer_token_value, get_access_token_value_from_webhook
+from ...generic import nginx_introspection, get_bearer_token_value, get_access_token_value_from_websocket
 
 #
 
@@ -76,7 +76,7 @@ class TokenIntrospectionHandler(object):
 	async def _authenticate_request(self, request):
 		token_value = get_bearer_token_value(request)
 		if token_value is None:
-			token_value = get_access_token_value_from_webhook(request)
+			token_value = get_access_token_value_from_websocket(request)
 		if token_value is None:
 			L.log(asab.LOG_NOTICE, "No Bearer token in Authorization header.")
 			return None

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -6,7 +6,7 @@ import asab
 import asab.log
 import asab.web.rest
 
-from ...generic import nginx_introspection, get_bearer_token_value
+from ...generic import nginx_introspection, get_bearer_token_value, get_access_token_value_from_webhook
 
 #
 
@@ -76,6 +76,8 @@ class TokenIntrospectionHandler(object):
 
 	async def _authenticate_request(self, request):
 		token_value = get_bearer_token_value(request)
+		if token_value is None:
+			token_value = get_access_token_value_from_webhook(request)
 		if token_value is None:
 			L.log(asab.LOG_NOTICE, "No Bearer token in Authorization header.")
 			return None


### PR DESCRIPTION
see http://gitlab.teskalabs.int/ateska/webui-microfrontends-poc/-/merge_requests/85

# Changes

- Nginx OAuth introspection checks the `Sec-WebSocket-Protocol` header for access token if no `Authorization` header is present.


# Auth request caching

Nginx `proxy_cache_key` should concatenate the `Authorization` and `Sec-WebSocket-Protocol` headers:

```nginx
proxy_cache_key       "$http_authorization $http_sec_websocket_protocol";
```

Full introspection location example:

```nginx
location = /_oauth_introspect {
	internal;
	proxy_method          POST;
	proxy_set_body        "$http_authorization";
	proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
	proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=some-client;
	proxy_ignore_headers  Cache-Control Expires Set-Cookie;

	# Cache successful introspection responses
	proxy_cache           oauth_responses;
	proxy_cache_key       "$http_authorization $http_sec_websocket_protocol";
	proxy_cache_lock      on;
	proxy_cache_valid     200 30s;
}
```