### PR TITLE
Move NGINX introspection endpoints to private API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Release candidate
 
+### Breaking changes
+- NGINX introspection endpoints paths changed and moved to private API (#301, PLUM Sprint 231006)
+
 ### Fix
 - Preserve nonce when redirecting to login (#294, PLUM Sprint 230908, @elpablos)
 - Allow username for WebAuthn credentials username (#297, PLUM Sprint 230908)
+- NGINX introspection endpoints removed from public API (#301, PLUM Sprint 231006)
 
 ### Features
 - Login with AppleID (#293, PLUM Sprint 230908, @filipmelik)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Fix
 - Preserve nonce when redirecting to login (#294, PLUM Sprint 230908, @elpablos)
 - Allow username for WebAuthn credentials username (#297, PLUM Sprint 230908)
-- NGINX introspection endpoints removed from public API (#301, PLUM Sprint 231006)
+- NGINX introspection endpoints moved to private API (#301, PLUM Sprint 231006)
 
 ### Features
 - Login with AppleID (#293, PLUM Sprint 230908, @filipmelik)

--- a/docs/config/cookies.md
+++ b/docs/config/cookies.md
@@ -46,7 +46,7 @@ When it does, the request continues to the protected location.
 When it does not have a valid cookie, a `HTTP 401 Not Authorized` response is sent back to the user. 
 Or the user can be directly forwarded to an authorization endpoint.
 
-The cookie introspection endpoint is found at path `/cookie/nginx` and uses `POST` requests.
+The cookie introspection endpoint is found at path `/nginx/cookie` and uses `POST` requests.
 Furthermore, it has the capability to add certain information about the user into HTTP X-headers, 
 such as username, roles or tenants.
 This is done using `add=` query parameters in the introspection call.
@@ -59,7 +59,7 @@ location = /_cookie_introspect {
     internal;
     proxy_method          POST;
     proxy_set_body        "$http_authorization";
-    proxy_pass            <SEACAT_AUTH_SERVICE_URL>/cookie/nginx;
+    proxy_pass            <SEACAT_AUTH_SERVICE_URL>/nginx/cookie;
     proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 }
 ```
@@ -146,7 +146,7 @@ location = /_cookie_introspect {
     internal;
     proxy_method          POST;
     proxy_set_body        "$http_authorization";
-    proxy_pass            <SEACAT_AUTH_PUBLIC_API_INTERNAL_URL>/cookie/nginx;
+    proxy_pass            <SEACAT_AUTH_PUBLIC_API_INTERNAL_URL>/nginx/cookie;
     proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 }
 ```

--- a/docs/config/cookies.md
+++ b/docs/config/cookies.md
@@ -46,7 +46,7 @@ When it does, the request continues to the protected location.
 When it does not have a valid cookie, a `HTTP 401 Not Authorized` response is sent back to the user. 
 Or the user can be directly forwarded to an authorization endpoint.
 
-The cookie introspection endpoint is found at path `/nginx/cookie` and uses `POST` requests.
+The cookie introspection endpoint is found at path `/nginx/introspect/cookie` and uses `POST` requests.
 Furthermore, it has the capability to add certain information about the user into HTTP X-headers, 
 such as username, roles or tenants.
 This is done using `add=` query parameters in the introspection call.
@@ -59,7 +59,7 @@ location = /_cookie_introspect {
     internal;
     proxy_method          POST;
     proxy_set_body        "$http_authorization";
-    proxy_pass            <SEACAT_AUTH_SERVICE_URL>/nginx/cookie;
+    proxy_pass            <SEACAT_AUTH_SERVICE_URL>/nginx/introspect/cookie;
     proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 }
 ```
@@ -146,7 +146,7 @@ location = /_cookie_introspect {
     internal;
     proxy_method          POST;
     proxy_set_body        "$http_authorization";
-    proxy_pass            <SEACAT_AUTH_PUBLIC_API_INTERNAL_URL>/nginx/cookie;
+    proxy_pass            <SEACAT_AUTH_PUBLIC_API_INTERNAL_URL>/nginx/introspect/cookie;
     proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 }
 ```

--- a/docs/integrations/elk.md
+++ b/docs/integrations/elk.md
@@ -16,8 +16,8 @@ synchronizes Kibana/ElasticSearch users with Seacat Auth credentials and their a
 
 The flow for using Batman auth is almost the same as the [cookie auth flow](index#cookie-authorization-flow), 
 the only difference being in the type of introspection used. 
-Instead of the `PUT /nginx/cookie` endpoint (which exchanges Seacat client cookie for ID token), 
-Batman auth uses `PUT /nginx/batman` (which exchanges Seacat client cookie for Basic auth header).
+Instead of the `PUT /nginx/introspect/cookie` endpoint (which exchanges Seacat client cookie for ID token), 
+Batman auth uses `PUT /nginx/introspect/batman` (which exchanges Seacat client cookie for Basic auth header).
 
 
 ## Configuration example
@@ -124,7 +124,7 @@ location = /_kibana_introspection {
 	# Seacat Auth Batman introspection upstream
 	# !! Use your client's actual client_id !!
 	proxy_method          POST;
-	proxy_pass            http://seacat_auth_api/nginx/batman?client_id=RZhlE-D4yuJxoKitYVL4dg;
+	proxy_pass            http://seacat_auth_api/nginx/introspect/batman?client_id=RZhlE-D4yuJxoKitYVL4dg;
 
 	proxy_set_header      X-Request-URI "$request_uri";
 	proxy_ignore_headers  Cache-Control Expires Set-Cookie;

--- a/docs/integrations/elk.md
+++ b/docs/integrations/elk.md
@@ -16,8 +16,8 @@ synchronizes Kibana/ElasticSearch users with Seacat Auth credentials and their a
 
 The flow for using Batman auth is almost the same as the [cookie auth flow](index#cookie-authorization-flow), 
 the only difference being in the type of introspection used. 
-Instead of the `PUT /cookie/nginx` endpoint (which exchanges Seacat client cookie for ID token), 
-Batman auth uses `PUT /batman/nginx` (which exchanges Seacat client cookie for Basic auth header).
+Instead of the `PUT /nginx/cookie` endpoint (which exchanges Seacat client cookie for ID token), 
+Batman auth uses `PUT /nginx/batman` (which exchanges Seacat client cookie for Basic auth header).
 
 
 ## Configuration example
@@ -123,8 +123,8 @@ location = /_kibana_introspection {
 
 	# Seacat Auth Batman introspection upstream
 	# !! Use your client's actual client_id !!
-	proxy_method          PUT;
-	proxy_pass            http://seacat_auth_api/batman/nginx?client_id=RZhlE-D4yuJxoKitYVL4dg;
+	proxy_method          POST;
+	proxy_pass            http://seacat_auth_api/nginx/batman?client_id=RZhlE-D4yuJxoKitYVL4dg;
 
 	proxy_set_header      X-Request-URI "$request_uri";
 	proxy_ignore_headers  Cache-Control Expires Set-Cookie;

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -14,8 +14,8 @@ Thanks to such integration, you may use your Active Directory, LDAP or social lo
 
 ## Cookie authorization for non-OAuth clients
 
-Seacat Auth provides cookie-based authorization for older web sites and apps that do not support OAuth 2.0.
-Its `PUT /cookie/nginx` endpoint is designed to work with Nginx reverse proxy and its `auth_request` directive.
+Seacat Auth provides cookie-based authorization for older websites and apps that do not support OAuth 2.0.
+Its `PUT /nginx/cookie` endpoint is designed to work with Nginx reverse proxy and its `auth_request` directive.
 
 ### Cookie authorization flow
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -15,7 +15,7 @@ Thanks to such integration, you may use your Active Directory, LDAP or social lo
 ## Cookie authorization for non-OAuth clients
 
 Seacat Auth provides cookie-based authorization for older websites and apps that do not support OAuth 2.0.
-Its `PUT /nginx/cookie` endpoint is designed to work with Nginx reverse proxy and its `auth_request` directive.
+Its `PUT /nginx/introspect/cookie` endpoint is designed to work with Nginx reverse proxy and its `auth_request` directive.
 
 ### Cookie authorization flow
 

--- a/example/docker/nginx-conf/nginx.conf
+++ b/example/docker/nginx-conf/nginx.conf
@@ -18,10 +18,10 @@ proxy_cache_path /data/nginx/seacat-admin_cache  keys_zone=seacat_admin_oauth_re
 upstream my_app_api {
     server  localhost:8080;
 }
-upstream seacat_auth_api {
+upstream seacat_public_api {
     server  localhost:3081;
 }
-upstream seacat_admin_api {
+upstream seacat_private_api {
     server  localhost:8900;
 }
 
@@ -57,19 +57,19 @@ server {
     # Public API
     location /auth/api/seacat-auth/public {
         rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
-        proxy_pass http://seacat_auth_api;
+        proxy_pass http://seacat_public_api;
     }
 
     # OpenIDConnect
     location /auth/api/openidconnect {
         rewrite ^/auth/api/(.*) /$1 break;
-        proxy_pass http://seacat_auth_api;
+        proxy_pass http://seacat_public_api;
     }
 
     # Well-known (OAuth 2.0)
     location /auth/api/.well-known {
         rewrite ^/auth/api/(.*) /$1 break;
-        proxy_pass http://seacat_auth_api;
+        proxy_pass http://seacat_public_api;
     }
 
 
@@ -83,7 +83,7 @@ server {
     # Admin API
     location /seacat/api/seacat-auth {
         rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
-        proxy_pass http://seacat_admin_api;
+        proxy_pass http://seacat_private_api;
 
         auth_request       /_seacat_admin_introspect;
 
@@ -102,13 +102,13 @@ server {
     # Public API
     location /seacat/api/seacat-auth/public {
         rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
-        proxy_pass http://seacat_auth_api;
+        proxy_pass http://seacat_public_api;
     }
 
     # OpenIDConnect
     location /seacat/api/openidconnect {
         rewrite ^/seacat/api/(.*) /$1 break;
-        proxy_pass http://seacat_auth_api;
+        proxy_pass http://seacat_public_api;
     }
 
     # OAuth introspection
@@ -117,7 +117,7 @@ server {
         proxy_method          POST;
         proxy_set_body        "$http_authorization";
         proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
-        proxy_pass            http://seacat_auth_api/openidconnect/introspect/nginx?client_id=asab-webui-auth;
+        proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=asab-webui-auth;
         proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
         # Cache successful introspection responses
@@ -155,7 +155,7 @@ server {
         proxy_method          POST;
         proxy_set_body        "$http_authorization";
         proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
-        proxy_pass            http://seacat_auth_api/cookie/nginx?client_id=my-app-cookie;
+        proxy_pass            http://seacat_private_api/nginx/cookie?client_id=my-app-cookie;
         proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
         # Cache successful introspection responses
@@ -170,7 +170,7 @@ server {
         proxy_method          POST;
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "client_id=my-app-cookie&grant_type=authorization_code&code=$arg_code&state=$arg_state";
-        proxy_pass            http://seacat_auth_api/cookie/entry;
+        proxy_pass            http://seacat_public_api/cookie/entry;
     }
 
 
@@ -201,7 +201,7 @@ server {
         proxy_method          POST;
         proxy_set_body        $http_authorization;
         proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
-        proxy_pass            http://seacat_auth_api/openidconnect/introspect/nginx?client_id=my-app-oauth;
+        proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=my-app-oauth;
         proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
         # Cache successful introspection responses

--- a/example/docker/nginx-conf/nginx.conf
+++ b/example/docker/nginx-conf/nginx.conf
@@ -117,7 +117,7 @@ server {
         proxy_method          POST;
         proxy_set_body        "$http_authorization";
         proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
-        proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=asab-webui-auth;
+        proxy_pass            http://seacat_private_api/nginx/introspect/openidconnect?client_id=asab-webui-auth;
         proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
         # Cache successful introspection responses
@@ -155,7 +155,7 @@ server {
         proxy_method          POST;
         proxy_set_body        "$http_authorization";
         proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
-        proxy_pass            http://seacat_private_api/nginx/cookie?client_id=my-app-cookie;
+        proxy_pass            http://seacat_private_api/nginx/introspect/cookie?client_id=my-app-cookie;
         proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
         # Cache successful introspection responses
@@ -201,7 +201,7 @@ server {
         proxy_method          POST;
         proxy_set_body        $http_authorization;
         proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
-        proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=my-app-oauth;
+        proxy_pass            http://seacat_private_api/nginx/introspect/openidconnect?client_id=my-app-oauth;
         proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
         # Cache successful introspection responses

--- a/example/nginx-config/nginx-anonymous.conf
+++ b/example/nginx-config/nginx-anonymous.conf
@@ -64,7 +64,7 @@ server {
 
 		# Call the cookie introspection with a credential ID in the `cid` parameter
 		# Anonymous sessions will have this ID in the `subject` field
-		proxy_pass            http://seacat_private_api/nginx/cookie/anonymous?client_id=my-application&cid=mongodb:default:abc123def546;
+		proxy_pass            http://seacat_private_api/nginx/introspect/cookie/anonymous?client_id=my-application&cid=mongodb:default:abc123def546;
 
 		# Successful introspection responses should be cached
 		proxy_cache           my_app_auth_responses;

--- a/example/nginx-config/nginx-anonymous.conf
+++ b/example/nginx-config/nginx-anonymous.conf
@@ -5,8 +5,15 @@
 proxy_cache_path on keys_zone=my_app_auth_responses:1m max_size=2m;
 
 # Define upstreams
-upstream my_app_api {...}
-upstream auth_api {...}
+upstream my_app_api {
+    server  localhost:8080;
+}
+upstream seacat_public_api {
+    server  localhost:3081;
+}
+upstream seacat_private_api {
+    server  localhost:8900;
+}
 
 server {
 	listen 443 ssl;
@@ -57,7 +64,7 @@ server {
 
 		# Call the cookie introspection with a credential ID in the `cid` parameter
 		# Anonymous sessions will have this ID in the `subject` field
-		proxy_pass            http://auth_api/cookie/nginx/anonymous?client_id=my-application&cid=mongodb:default:abc123def546;
+		proxy_pass            http://seacat_private_api/nginx/cookie/anonymous?client_id=my-application&cid=mongodb:default:abc123def546;
 
 		# Successful introspection responses should be cached
 		proxy_cache           my_app_auth_responses;
@@ -76,13 +83,13 @@ server {
 	location /auth/api/seacat-auth {
 	    # SCA webUI uses only the public part of the API, no authentication required
 		rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
-		proxy_pass http://auth_api;
+		proxy_pass http://seacat_public_api;
 	}
 
     # SeaCat Auth OpenIDConnect API
 	location /auth/api/openidconnect {
 		rewrite ^/auth/api/(.*) /$1 break;
-		proxy_pass http://auth_api;
+		proxy_pass http://seacat_public_api;
 	}
 }
 

--- a/example/nginx-config/nginx-http.conf
+++ b/example/nginx-config/nginx-http.conf
@@ -11,6 +11,16 @@
 # See the "nginx-https.conf.example" configuration for details.
 #
 
+# Define upstreams
+upstream my_app_api {
+    server  localhost:8080;
+}
+upstream seacat_public_api {
+    server  localhost:3081;
+}
+upstream seacat_private_api {
+    server  localhost:8900;
+}
 
 server {
     listen 80;
@@ -70,13 +80,13 @@ server {
 	location /auth/api/seacat-auth {
 	    # SCA web UI uses only the public part of the API, no authentication required
 		rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
-		proxy_pass http://localhost:3081;
+		proxy_pass http://seacat_public_api;
 	}
 
     # OpenIDConnect
 	location /auth/api/openidconnect {
 		rewrite ^/auth/api/(.*) /$1 break;
-		proxy_pass http://localhost:3081;
+		proxy_pass http://seacat_public_api;
 	}
 
 
@@ -94,18 +104,18 @@ server {
 		auth_request_set   $authorization $upstream_http_authorization;
 		proxy_set_header   Authorization $authorization;
 		rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
-		proxy_pass http://localhost:8900;
+		proxy_pass http://seacat_private_api;
 	}
 
 	location /seacat/api/seacat-auth/public {
         rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
-        proxy_pass http://localhost:3081;
+        proxy_pass http://seacat_public_api;
     }
 
     # OpenIDConnect
 	location /seacat/api/openidconnect {
 		rewrite ^/seacat/api/(.*) /$1 break;
-		proxy_pass http://localhost:3081;
+		proxy_pass http://seacat_public_api;
 	}
 
 
@@ -115,7 +125,7 @@ server {
 		internal;
 		proxy_method          POST;
 		proxy_set_body        "$http_authorization";
-		proxy_pass            http://localhost:3081/cookie/nginx;
+		proxy_pass            http://seacat_private_api/nginx/cookie?client_id=my-app-cookie;
 		proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 	}
 
@@ -124,7 +134,7 @@ server {
 		proxy_method          POST;
 		proxy_set_body        "$http_authorization";
 		proxy_set_header      X-Request-URI "$request_uri";
-		proxy_pass            http://localhost:3081/openidconnect/introspect/nginx;
+		proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=my-app-oauth;
 		proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 	}
 

--- a/example/nginx-config/nginx-http.conf
+++ b/example/nginx-config/nginx-http.conf
@@ -125,7 +125,7 @@ server {
 		internal;
 		proxy_method          POST;
 		proxy_set_body        "$http_authorization";
-		proxy_pass            http://seacat_private_api/nginx/cookie?client_id=my-app-cookie;
+		proxy_pass            http://seacat_private_api/nginx/introspect/cookie?client_id=my-app-cookie;
 		proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 	}
 
@@ -134,7 +134,7 @@ server {
 		proxy_method          POST;
 		proxy_set_body        "$http_authorization";
 		proxy_set_header      X-Request-URI "$request_uri";
-		proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect?client_id=my-app-oauth;
+		proxy_pass            http://seacat_private_api/nginx/introspect/openidconnect?client_id=my-app-oauth;
 		proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 	}
 

--- a/example/nginx-config/nginx-multisubdomain.conf
+++ b/example/nginx-config/nginx-multisubdomain.conf
@@ -42,7 +42,7 @@ server {
         proxy_method          POST;
         proxy_set_body        "$http_authorization";
         proxy_set_header      X-Request-URI "$request_uri";
-        proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect;
+        proxy_pass            http://seacat_private_api/nginx/introspect/openidconnect;
         proxy_cache           app_token_responses;
         proxy_cache_key       $http_authorization;
         proxy_cache_lock      on;
@@ -124,7 +124,7 @@ server {
         proxy_method          POST;
         proxy_set_body        "$http_authorization";
         proxy_set_header      X-Request-URI "$request_uri";
-        proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect;
+        proxy_pass            http://seacat_private_api/nginx/introspect/openidconnect;
         proxy_cache           app_token_responses;
         proxy_cache_key       $http_authorization;
         proxy_cache_lock      on;

--- a/example/nginx-config/nginx-multisubdomain.conf
+++ b/example/nginx-config/nginx-multisubdomain.conf
@@ -8,6 +8,16 @@ log_format include_hostname '$remote_addr - $remote_user [$time_local] '
 
 proxy_cache_path on keys_zone=app_token_responses:1m max_size=2m;
 
+upstream my_app_api {
+    server  localhost:8080;
+}
+upstream seacat_public_api {
+    server  localhost:3081;
+}
+upstream seacat_private_api {
+    server  localhost:8900;
+}
+
 server {
     listen 443;
     listen [::]:443;
@@ -32,7 +42,7 @@ server {
         proxy_method          POST;
         proxy_set_body        "$http_authorization";
         proxy_set_header      X-Request-URI "$request_uri";
-        proxy_pass            http://localhost:3081/openidconnect/introspect/nginx?add=credentials&add=tenants&add=roles;
+        proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect;
         proxy_cache           app_token_responses;
         proxy_cache_key       $http_authorization;
         proxy_cache_lock      on;
@@ -75,12 +85,12 @@ server {
     location /auth/api/seacat-auth {
         # SCA webUI uses only the public part of the API, no authentication required
         rewrite ^/auth/api/seacat-auth/(.*) /$1 break;
-        proxy_pass http://localhost:3081;
+        proxy_pass http://seacat_public_api;
     }
 
     location /auth/api/openidconnect {
         rewrite ^/auth/api/(.*) /$1 break;
-        proxy_pass http://localhost:3081;
+        proxy_pass http://seacat_public_api;
     }
 
 
@@ -96,17 +106,30 @@ server {
         auth_request_set   $authorization $upstream_http_authorization;
         proxy_set_header   Authorization $authorization;
         rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
-        proxy_pass http://localhost:8900;
+        proxy_pass http://seacat_private_api;
     }
 
     location /seacat/api/seacat-auth/public {
         rewrite ^/seacat/api/seacat-auth/(.*) /$1 break;
-        proxy_pass http://localhost:3081;
+        proxy_pass http://seacat_public_api;
     }
 
     location /seacat/api/openidconnect {
         rewrite ^/seacat/api/(.*) /$1 break;
-        proxy_pass http://localhost:3081;
+        proxy_pass http://seacat_public_api;
+    }
+
+    location = /_oauth2_introspect {
+        internal;
+        proxy_method          POST;
+        proxy_set_body        "$http_authorization";
+        proxy_set_header      X-Request-URI "$request_uri";
+        proxy_pass            http://seacat_private_api/nginx/openidconnect/introspect;
+        proxy_cache           app_token_responses;
+        proxy_cache_key       $http_authorization;
+        proxy_cache_lock      on;
+        proxy_cache_valid     200 10s;
+        proxy_ignore_headers  Cache-Control Expires Set-Cookie;
     }
 
     error_page 401 403 /auth/api/openidconnect/authorize?response_type=code&scope=openid%20cookie&client_id=signin&prompt=login&redirect_uri=$request_uri;

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -28,6 +28,12 @@ class M2MIntrospectHandler(object):
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/nginx/introspect/m2m", self.nginx)
 
+		# TODO: Insecure, back-compat only - will be removed in next release!
+		# >>>
+		web_app_public = app.PublicWebContainer.WebApp
+		web_app_public.router.add_post("/m2m/nginx", self.nginx)
+		# <<<
+
 
 	async def _authenticate_request(self, request, client_id):
 		# Get credentials from request

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -26,11 +26,7 @@ class M2MIntrospectHandler(object):
 		self.BasicRealm = "asab"  # TODO: Configurable
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_post('/m2m/nginx', self.nginx)
-
-		# Public aliases
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_post('/m2m/nginx', self.nginx)
+		web_app.router.add_post("/nginx/m2m", self.nginx)
 
 
 	async def _authenticate_request(self, request, client_id):

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -26,7 +26,7 @@ class M2MIntrospectHandler(object):
 		self.BasicRealm = "asab"  # TODO: Configurable
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_post("/nginx/m2m", self.nginx)
+		web_app.router.add_post("/nginx/introspect/m2m", self.nginx)
 
 
 	async def _authenticate_request(self, request, client_id):

--- a/seacatauth/batman/handler.py
+++ b/seacatauth/batman/handler.py
@@ -24,6 +24,12 @@ class BatmanHandler(object):
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/nginx/introspect/batman", self.batman_nginx)
 
+		# TODO: Insecure, back-compat only - will be removed in next release!
+		# >>>
+		web_app_public = app.PublicWebContainer.WebApp
+		web_app_public.router.add_post("/batman/nginx", self.batman_nginx)
+		# <<<
+
 
 	async def batman_nginx(self, request):
 		"""

--- a/seacatauth/batman/handler.py
+++ b/seacatauth/batman/handler.py
@@ -22,7 +22,7 @@ class BatmanHandler(object):
 	def __init__(self, app, batman_svc):
 		self.BatmanService = batman_svc
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_post("/nginx/batman", self.batman_nginx)
+		web_app.router.add_post("/nginx/introspect/batman", self.batman_nginx)
 
 
 	async def batman_nginx(self, request):

--- a/seacatauth/batman/handler.py
+++ b/seacatauth/batman/handler.py
@@ -28,6 +28,7 @@ class BatmanHandler(object):
 		# >>>
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_post("/batman/nginx", self.batman_nginx)
+		web_app_public.router.add_put("/batman/nginx", self.batman_nginx)
 		# <<<
 
 

--- a/seacatauth/batman/handler.py
+++ b/seacatauth/batman/handler.py
@@ -22,7 +22,6 @@ class BatmanHandler(object):
 	def __init__(self, app, batman_svc):
 		self.BatmanService = batman_svc
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_put("/nginx/batman", self.batman_nginx)
 		web_app.router.add_post("/nginx/batman", self.batman_nginx)
 
 

--- a/seacatauth/batman/handler.py
+++ b/seacatauth/batman/handler.py
@@ -20,16 +20,10 @@ class BatmanHandler(object):
 	"""
 
 	def __init__(self, app, batman_svc):
-		web_app_public = app.PublicWebContainer.WebApp
 		self.BatmanService = batman_svc
-
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_put("/batman/nginx", self.batman_nginx)
-		web_app.router.add_post("/batman/nginx", self.batman_nginx)
-
-		# Public endpoints
-		web_app_public.router.add_put("/batman/nginx", self.batman_nginx)
-		web_app_public.router.add_post("/batman/nginx", self.batman_nginx)
+		web_app.router.add_put("/nginx/batman", self.batman_nginx)
+		web_app.router.add_post("/nginx/batman", self.batman_nginx)
 
 
 	async def batman_nginx(self, request):

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -60,7 +60,7 @@ class CookieHandler(object):
 			proxy_method          POST;
 			proxy_set_body        "$http_authorization";
 			proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
-			proxy_pass            http://auth_api/nginx/cookie?client_id=my-protected-app;
+			proxy_pass            http://auth_api/nginx/introspect/cookie?client_id=my-protected-app;
 			proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
 			# Successful introspection responses should be cached
@@ -89,8 +89,8 @@ class CookieHandler(object):
 		self.RBACService = app.get_service("seacatauth.RBACService")
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_post("/nginx/cookie", self.nginx)
-		web_app.router.add_post("/nginx/cookie/anonymous", self.nginx_anonymous)
+		web_app.router.add_post("/nginx/introspect/cookie", self.nginx)
+		web_app.router.add_post("/nginx/introspect/cookie/anonymous", self.nginx_anonymous)
 		web_app.router.add_get("/cookie/entry", self.bouncer_get)
 		web_app.router.add_post("/cookie/entry", self.bouncer_post)
 

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -60,7 +60,7 @@ class CookieHandler(object):
 			proxy_method          POST;
 			proxy_set_body        "$http_authorization";
 			proxy_set_header      X-Request-Uri "$scheme://$host$request_uri";
-			proxy_pass            http://auth_api/cookie/nginx?client_id=my-protected-app;
+			proxy_pass            http://auth_api/nginx/cookie?client_id=my-protected-app;
 			proxy_ignore_headers  Cache-Control Expires Set-Cookie;
 
 			# Successful introspection responses should be cached

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -99,6 +99,12 @@ class CookieHandler(object):
 		web_app_public.router.add_get("/cookie/entry", self.bouncer_get)
 		web_app_public.router.add_post("/cookie/entry", self.bouncer_post)
 
+		# TODO: Insecure, back-compat only - will be removed in next release!
+		# >>>
+		web_app_public.router.add_post("/cookie/nginx", self.nginx)
+		web_app_public.router.add_post("/cookie/nginx/anonymous", self.nginx_anonymous)
+		# <<<
+
 
 	async def nginx(self, request):
 		"""

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -89,15 +89,13 @@ class CookieHandler(object):
 		self.RBACService = app.get_service("seacatauth.RBACService")
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_post("/cookie/nginx", self.nginx)
-		web_app.router.add_post("/cookie/nginx/anonymous", self.nginx_anonymous)
+		web_app.router.add_post("/nginx/cookie", self.nginx)
+		web_app.router.add_post("/nginx/cookie/anonymous", self.nginx_anonymous)
 		web_app.router.add_get("/cookie/entry", self.bouncer_get)
 		web_app.router.add_post("/cookie/entry", self.bouncer_post)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_post("/cookie/nginx", self.nginx)
-		web_app_public.router.add_post("/cookie/nginx/anonymous", self.nginx_anonymous)
 		web_app_public.router.add_get("/cookie/entry", self.bouncer_get)
 		web_app_public.router.add_post("/cookie/entry", self.bouncer_post)
 

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -44,6 +44,10 @@ def private_auth_middleware_factory(app):
 		[asab:api:auth]
 		bearer=xtA4J9c6KK3g_Y0VplS_Rz4xmoVoU1QWrwz9CHz2p3aTpHzOkr0yp3xhcbkJK-Z0
 		"""
+		if request.path.startswith("/nginx/") and request.method == "POST":
+			# NGINX introspection endpoints handle authorization on their own
+			return await handler(request)
+
 		request.Session = None
 		token_value = get_bearer_token_value(request)
 		if token_value is not None:

--- a/seacatauth/openidconnect/handler/discovery.py
+++ b/seacatauth/openidconnect/handler/discovery.py
@@ -88,10 +88,6 @@ class DiscoveryHandler(object):
 
 			# PKCE
 			"code_challenge_methods_supported": ["plain", "S256"],
-
-			# NON-STANDARD
-			"nginx_introspection_endpoint": "{}{}".format(
-				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.NginxIntrospectionPath),
 		}
 
 		return asab.web.rest.json_response(request, data)

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -32,7 +32,7 @@ class TokenIntrospectionHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/openidconnect/introspect", self.introspect)
-		web_app.router.add_post("/nginx/openidconnect", self.introspect_nginx)
+		web_app.router.add_post("/nginx/introspect/openidconnect", self.introspect_nginx)
 
 
 	async def introspect(self, request):
@@ -115,7 +115,7 @@ class TokenIntrospectionHandler(object):
 					internal;
 					proxy_method          POST;
 					proxy_set_body        "$http_authorization";
-					proxy_pass            http://localhost:8900/nginx/openidconnect/introspect?client_id=my-app;
+					proxy_pass            http://localhost:8900/nginx/introspect/openidconnect?client_id=my-app;
 
 					proxy_cache           token_responses;     # Enable caching
 					proxy_cache_key       $http_authorization; # Cache for each access token

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -115,7 +115,7 @@ class TokenIntrospectionHandler(object):
 					internal;
 					proxy_method          POST;
 					proxy_set_body        "$http_authorization";
-					proxy_pass            http://localhost:8080/openidconnect/introspect/nginx;
+					proxy_pass            http://localhost:8900/nginx/openidconnect/introspect?client_id=my-app;
 
 					proxy_cache           token_responses;     # Enable caching
 					proxy_cache_key       $http_authorization; # Cache for each access token

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -34,6 +34,12 @@ class TokenIntrospectionHandler(object):
 		web_app.router.add_post("/openidconnect/introspect", self.introspect)
 		web_app.router.add_post("/nginx/introspect/openidconnect", self.introspect_nginx)
 
+		# TODO: Insecure, back-compat only - will be removed in next release!
+		# >>>
+		web_app_public = app.PublicWebContainer.WebApp
+		web_app_public.router.add_post("/openidconnect/introspect/nginx", self.introspect_nginx)
+		# <<<
+
 
 	async def introspect(self, request):
 		"""

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -32,12 +32,7 @@ class TokenIntrospectionHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/openidconnect/introspect", self.introspect)
-		web_app.router.add_post(self.OpenIdConnectService.NginxIntrospectionPath, self.introspect_nginx)
-
-		# Public endpoints
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_post("/openidconnect/introspect", self.introspect)
-		web_app_public.router.add_post(self.OpenIdConnectService.NginxIntrospectionPath, self.introspect_nginx)
+		web_app.router.add_post("/nginx/openidconnect", self.introspect_nginx)
 
 
 	async def introspect(self, request):

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -48,7 +48,6 @@ class OpenIdConnectService(asab.Service):
 	UserInfoPath = "/openidconnect/userinfo"
 	JwksPath = "/openidconnect/public_keys"
 	EndSessionPath = "/openidconnect/logout"
-	NginxIntrospectionPath = "/openidconnect/introspect/nginx"
 
 	def __init__(self, app, service_name="seacatauth.OpenIdConnectService"):
 		super().__init__(app, service_name)


### PR DESCRIPTION
# Breaking changes
- NGINX introspection endpoints moved from **public API (port 3081)** to **private API (port 8900)**. This is a **security fix** - Nginx introspection is for internal use only!
- NGINX introspection endpoint paths changed so that all start with `/nginx/introspect` for easier filtering (see below for updated paths).
- Batman NGINX introspection method changed to POST (unification with all the other introspection endpoints).

## Backwards compatibility
- The old endpoint paths in public API will be **kept until the next release** to allow for smoother transition of existing deployments.
- Recommended upgrade plan (to prevent network downtime):
  - Upgrade Seacat Auth to this version.
  - Update the introspection URLs and methods in you nginx configuration.
  - Upgrade Seacat Auth to newer versions (if available).

# New introspection paths
-  ~~`/openidconnect/introspect/nginx`~~ -> `/nginx/introspect/openidconnect`
- ~~`/coookie/nginx`~~ -> `/nginx/introspect/cookie`
- ~~`/cookie/nginx/anonymous`~~ -> `/nginx/introspect/cookie/anonymous`
- ~~`/m2m/nginx`~~ -> `/nginx/introspect/m2m`
- ~~`/batman/nginx`~~ -> `/nginx/introspect/batman`
