### PR TITLE
Disable auditing anonymous sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Features
 - Login with AppleID (#293, PLUM Sprint 230908, @filipmelik)
 - Webauthn authenticator metadata (#256, PLUM Sprint 230908)
+- Configurably disable auditing of anonymous sessions (#304, PLUM Sprint 231006)
 
 ---
 

--- a/seacatauth/audit/service.py
+++ b/seacatauth/audit/service.py
@@ -50,7 +50,7 @@ class AuditService(asab.Service):
 		"""
 		assert (isinstance(code, AuditCode))
 
-		# Only audit anonymous sessions if desired (performance reasons)
+		# Do not audit anonymous sessions if desired (performance reasons)
 		if code == AuditCode.ANONYMOUS_SESSION_CREATED and not self.IsAnonymousLoggingEnabled:
 			return
 

--- a/seacatauth/audit/service.py
+++ b/seacatauth/audit/service.py
@@ -11,6 +11,14 @@ L = logging.getLogger(__name__)
 
 #
 
+asab.Config.add_defaults({
+	"seacatauth:audit": {
+		# Enable or disable the auditing of anonymous sessions.
+		# Disabling may be desirable for database performance reasons.
+		"log_anonymous_sessions": True,
+	},
+})
+
 
 class AuditService(asab.Service):
 
@@ -26,7 +34,7 @@ class AuditService(asab.Service):
 	def __init__(self, app, service_name="seacatauth.AuditService"):
 		super().__init__(app, service_name)
 		self.StorageService = app.get_service("asab.StorageService")
-		self.IsAnonymousLoggingEnabled = False
+		self.IsAnonymousLoggingEnabled = asab.Config.getboolean("seacatauth:audit", "log_anonymous_sessions")
 
 
 	async def append(
@@ -42,9 +50,9 @@ class AuditService(asab.Service):
 		"""
 		assert (isinstance(code, AuditCode))
 
-		# skip anon audit if is necessary
-		if self.IsAnonymousLoggingEnabled is False and AuditCode.ANONYMOUS_SESSION_CREATED == code:
-			return None
+		# Only audit anonymous sessions if desired (performance reasons)
+		if code == AuditCode.ANONYMOUS_SESSION_CREATED and not self.IsAnonymousLoggingEnabled:
+			return
 
 		# Do not use upsertor because it can trigger webhook
 		now = datetime.datetime.now(datetime.timezone.utc)

--- a/seacatauth/audit/service.py
+++ b/seacatauth/audit/service.py
@@ -51,7 +51,7 @@ class AuditService(asab.Service):
 		assert (isinstance(code, AuditCode))
 
 		# Do not audit anonymous sessions if desired (performance reasons)
-		if code == AuditCode.ANONYMOUS_SESSION_CREATED and not self.IsAnonymousLoggingEnabled:
+		if not self.IsAnonymousLoggingEnabled and code == AuditCode.ANONYMOUS_SESSION_CREATED:
 			return
 
 		# Do not use upsertor because it can trigger webhook

--- a/seacatauth/audit/service.py
+++ b/seacatauth/audit/service.py
@@ -26,6 +26,7 @@ class AuditService(asab.Service):
 	def __init__(self, app, service_name="seacatauth.AuditService"):
 		super().__init__(app, service_name)
 		self.StorageService = app.get_service("asab.StorageService")
+		self.IsAnonymousLoggingEnabled = False
 
 
 	async def append(
@@ -40,6 +41,10 @@ class AuditService(asab.Service):
 		Records a new audit entry.
 		"""
 		assert (isinstance(code, AuditCode))
+
+		# skip anon audit if is necessary
+		if self.IsAnonymousLoggingEnabled is False and AuditCode.ANONYMOUS_SESSION_CREATED == code:
+			return None
 
 		# Do not use upsertor because it can trigger webhook
 		now = datetime.datetime.now(datetime.timezone.utc)

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -87,7 +87,6 @@ class CookieHandler(object):
 		self.SessionService = session_svc
 		self.CredentialsService = credentials_svc
 		self.RBACService = app.get_service("seacatauth.RBACService")
-		self.IsAnonymousWebhookEnabled = False
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/cookie/nginx", self.nginx)
@@ -475,9 +474,6 @@ class CookieHandler(object):
 		"""
 		cookie_webhook_uri = client.get("cookie_webhook_uri")
 		if cookie_webhook_uri is None:
-			return None
-		# skip webhook for alg webhook
-		if self.IsAnonymousWebhookEnabled is False and session is not None and session.is_algorithmic():
 			return None
 		async with aiohttp.ClientSession() as http_session:
 			# TODO: Better serialization

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -87,6 +87,7 @@ class CookieHandler(object):
 		self.SessionService = session_svc
 		self.CredentialsService = credentials_svc
 		self.RBACService = app.get_service("seacatauth.RBACService")
+		self.IsAnonymousWebhookEnabled = False
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/cookie/nginx", self.nginx)
@@ -474,6 +475,9 @@ class CookieHandler(object):
 		"""
 		cookie_webhook_uri = client.get("cookie_webhook_uri")
 		if cookie_webhook_uri is None:
+			return None
+		# skip webhook for alg webhook
+		if self.IsAnonymousWebhookEnabled is False and session is not None and session.is_algorithmic():
 			return None
 		async with aiohttp.ClientSession() as http_session:
 			# TODO: Better serialization


### PR DESCRIPTION
see #303 

To disable auditing the creation of anonymous sessions, use the following config:
```ini
[seacatauth:audit]
log_anonymous_sessions=no
```

Auditing the creation of anonymous sessions is still enabled by default.