### PR TITLE
Move NGINX introspection endpoints to private API (post-fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## Release candidate
 
 ### Breaking changes
-- NGINX introspection endpoints paths changed and moved to private API (#301, PLUM Sprint 231006)
+- NGINX introspection endpoints paths changed and moved to private API (#301, #311, PLUM Sprint 231006)
 
 ### Fix
 - Preserve nonce when redirecting to login (#294, PLUM Sprint 230908, @elpablos)
 - Allow username for WebAuthn credentials username (#297, PLUM Sprint 230908)
-- NGINX introspection endpoints moved to private API (#301, PLUM Sprint 231006)
+- NGINX introspection endpoints moved to private API (#301, #311, PLUM Sprint 231006)
 
 ### Features
 - Login with AppleID (#293, PLUM Sprint 230908, @filipmelik)

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -28,11 +28,10 @@ class M2MIntrospectHandler(object):
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/nginx/introspect/m2m", self.nginx)
 
-		# TODO: Insecure, back-compat only - will be removed in next release!
-		# >>>
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_post("/m2m/nginx", self.nginx)
-		# <<<
+		# TODO: Insecure, back-compat only - remove after 2024-03-31
+		if asab.Config.getboolean("seacatauth:introspection", "_enable_insecure_legacy_endpoints", fallback=False):
+			web_app_public = app.PublicWebContainer.WebApp
+			web_app_public.router.add_post("/m2m/nginx", self.nginx)
 
 
 	async def _authenticate_request(self, request, client_id):

--- a/seacatauth/batman/handler.py
+++ b/seacatauth/batman/handler.py
@@ -1,4 +1,5 @@
 import logging
+import asab
 
 import aiohttp.web
 
@@ -24,12 +25,11 @@ class BatmanHandler(object):
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/nginx/introspect/batman", self.batman_nginx)
 
-		# TODO: Insecure, back-compat only - will be removed in next release!
-		# >>>
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_post("/batman/nginx", self.batman_nginx)
-		web_app_public.router.add_put("/batman/nginx", self.batman_nginx)
-		# <<<
+		# TODO: Insecure, back-compat only - remove after 2024-03-31
+		if asab.Config.getboolean("seacatauth:introspection", "_enable_insecure_legacy_endpoints", fallback=False):
+			web_app_public = app.PublicWebContainer.WebApp
+			web_app_public.router.add_post("/batman/nginx", self.batman_nginx)
+			web_app_public.router.add_put("/batman/nginx", self.batman_nginx)
 
 
 	async def batman_nginx(self, request):

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -99,11 +99,10 @@ class CookieHandler(object):
 		web_app_public.router.add_get("/cookie/entry", self.bouncer_get)
 		web_app_public.router.add_post("/cookie/entry", self.bouncer_post)
 
-		# TODO: Insecure, back-compat only - will be removed in next release!
-		# >>>
-		web_app_public.router.add_post("/cookie/nginx", self.nginx)
-		web_app_public.router.add_post("/cookie/nginx/anonymous", self.nginx_anonymous)
-		# <<<
+		# TODO: Insecure, back-compat only - remove after 2024-03-31
+		if asab.Config.getboolean("seacatauth:introspection", "_enable_insecure_legacy_endpoints", fallback=False):
+			web_app_public.router.add_post("/cookie/nginx", self.nginx)
+			web_app_public.router.add_post("/cookie/nginx/anonymous", self.nginx_anonymous)
 
 
 	async def nginx(self, request):

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -34,11 +34,16 @@ class TokenIntrospectionHandler(object):
 		web_app.router.add_post("/openidconnect/introspect", self.introspect)
 		web_app.router.add_post("/nginx/introspect/openidconnect", self.introspect_nginx)
 
-		# TODO: Insecure, back-compat only - will be removed in next release!
-		# >>>
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_post("/openidconnect/introspect/nginx", self.introspect_nginx)
-		# <<<
+		# TODO: Insecure, back-compat only - remove after 2024-03-31
+		if asab.Config.getboolean("seacatauth:introspection", "_enable_legacy_endpoints", fallback=False):
+			asab.LogObsolete.warning(
+				"Insecure legacy introspection endpoints are enabled. Please migrate your Nginx configuration to the "
+				"new recommended endpoints and then turn off the '_enable_legacy_endpoints' option. "
+				"See https://github.com/TeskaLabs/seacat-auth/pull/301 for migration details.",
+				struct_data={"eol": "2024-03-31"}
+			)
+			web_app_public = app.PublicWebContainer.WebApp
+			web_app_public.router.add_post("/openidconnect/introspect/nginx", self.introspect_nginx)
 
 
 	async def introspect(self, request):


### PR DESCRIPTION
this is a post-fix to #301

# Breaking changes
- NGINX introspection endpoints moved from **public API (port 3081)** to **private API (port 8900)**. This is a **security fix** - Nginx introspection is for internal use only!
- NGINX introspection endpoint paths changed so that all start with `/nginx/introspect` for easier filtering (see below for updated paths).
- Batman NGINX introspection method changed to POST (unification with all the other introspection endpoints).

# Migration

In your NGINX configuration, simply replace the old paths with the new ones:

OLD endpoint | NEW endpoint |
--- | --- |
POST {PUBLIC_API}/openidconnect/introspect/nginx | POST {PRIVATE_API}/nginx/introspect/openidconnect |
POST {PUBLIC_API}/coookie/nginx | POST {PRIVATE_API}/nginx/introspect/cookie |
POST {PUBLIC_API}/cookie/nginx/anonymous | POST {PRIVATE_API}/nginx/introspect/cookie/anonymous |
POST {PUBLIC_API}/m2m/nginx | POST {PRIVATE_API}/nginx/introspect/m2m |
**PUT** {PUBLIC_API}/batman/nginx | **POST** {PRIVATE_API}/nginx/introspect/batman |

# Backwards compatibility

To keep the old endpoints on public API, use the following config option:

```ini
[seacatauth:introspection]
_enable_legacy_endpoints=yes
```

Note that this setting should be used only temporarily for the period of migration, to minimize the impact to network traffic. This functionality will be removed soon.
