### PR TITLE
Handle missing webauthn data in login request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,16 @@
 - Dropped support for authorize query params `ldid` and `expiration` (#296, PLUM Sprint 231006)
 
 ### Fix
-- Fix default authorize parameter values when redirecting (#313, PLUM Sprint 231020)
 - Handle missing webauthn data in login request (#314, INDIGO Sprint 231027, `v23.44-alpha4`)
+- Fix default authorize parameter values when redirecting (#313, PLUM Sprint 231020)
 
 ### Features
+- Reduce grafana sync frequency (#317, INDIGO Sprint 231027, `v23.44-alpha3`)
 - Authorization for websocket requests (#300, PLUM Sprint 231006)
 - Silence stable log messages (#312, PLUM Sprint 231006)
 - External login registration webhook (#286, PLUM Sprint 231006)
 - OAuth Authorize ignores all unknown parameters (#296, PLUM Sprint 231006)
 - Log failure reasons in introspection and authorization flow (#315, INDIGO Sprint 231027)
-- Reduce grafana sync frequency (#317, INDIGO Sprint 231027, `v23.44-alpha3`)
 
 ### Refactoring
 - Do not log "unhappy flow" as errors (#315, INDIGO Sprint 231027)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 ## v23.44 (release candidate)
 
 ### Pre-releases
-- v23.44-alpha1
+- `v23.44-alpha4`
+- `v23.44-alpha3`
 
 ### Breaking changes
 - Dropped support for authorize query params `ldid` and `expiration` (#296, PLUM Sprint 231006)
 
 ### Fix
 - Fix default authorize parameter values when redirecting (#313, PLUM Sprint 231020)
+- Handle missing webauthn data in login request (#314, INDIGO Sprint 231027, `v23.44-alpha4`)
 
 ### Features
 - Authorization for websocket requests (#300, PLUM Sprint 231006)
@@ -17,7 +19,7 @@
 - External login registration webhook (#286, PLUM Sprint 231006)
 - OAuth Authorize ignores all unknown parameters (#296, PLUM Sprint 231006)
 - Log failure reasons in introspection and authorization flow (#315, INDIGO Sprint 231027)
-- Reduce grafana sync frequency (#317, INDIGO Sprint 231027, `v23.44-alpha1`)
+- Reduce grafana sync frequency (#317, INDIGO Sprint 231027, `v23.44-alpha3`)
 
 ### Refactoring
 - Do not log "unhappy flow" as errors (#315, INDIGO Sprint 231027)

--- a/seacatauth/authn/login_factors/webauthn.py
+++ b/seacatauth/authn/login_factors/webauthn.py
@@ -1,5 +1,7 @@
 import logging
 
+import asab.exceptions
+
 from .abc import LoginFactorABC
 
 #
@@ -27,7 +29,12 @@ class WebAuthnFactor(LoginFactorABC):
 		return False
 
 	async def authenticate(self, login_session, request_data) -> bool:
-		public_key_credential = request_data.get("webauthn")
+		if "webauthn" not in request_data:
+			L.info("No webauthn data in login request.", struct_data={
+				"lsid": login_session.Id, "cid": login_session.CredentialsId})
+			return False
+		public_key_credential = request_data["webauthn"]
+
 		webauthn_svc = self.AuthenticationService.App.get_service("seacatauth.WebAuthnService")
 		return await webauthn_svc.authenticate_credential(
 			login_session.CredentialsId,

--- a/seacatauth/authn/login_factors/webauthn.py
+++ b/seacatauth/authn/login_factors/webauthn.py
@@ -1,7 +1,5 @@
 import logging
 
-import asab.exceptions
-
 from .abc import LoginFactorABC
 
 #

--- a/seacatauth/authn/login_factors/webauthn.py
+++ b/seacatauth/authn/login_factors/webauthn.py
@@ -1,5 +1,7 @@
 import logging
 
+import asab
+
 from .abc import LoginFactorABC
 
 #
@@ -28,7 +30,7 @@ class WebAuthnFactor(LoginFactorABC):
 
 	async def authenticate(self, login_session, request_data) -> bool:
 		if "webauthn" not in request_data:
-			L.info("No webauthn data in login request.", struct_data={
+			L.log(asab.LOG_NOTICE, "No webauthn data in login request", struct_data={
 				"lsid": login_session.Id, "cid": login_session.CredentialsId})
 			return False
 		public_key_credential = request_data["webauthn"]


### PR DESCRIPTION
Sometimes the login request has no webauthn data although it is expected to have it. This is now handled and evaluated as authentication failure.