### PR TITLE
Do not log HTTP 4xx responses as errors

### DIFF
--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -100,8 +100,7 @@ class AuthenticationHandler(object):
 			for k, v in query_dict.items():
 				if k in self.AuthenticationService.CustomLoginParameters:
 					if len(v) > 1:
-						L.error("Repeated query parameters are not supported", struct_data={"qs": query_string})
-						raise asab.exceptions.ValidationError("Invalid request")
+						raise asab.exceptions.ValidationError("Repeated query parameters are not supported")
 					login_dict[k] = v[0]
 
 			# Get preferred login descriptor IDs

--- a/seacatauth/authn/login_descriptor.py
+++ b/seacatauth/authn/login_descriptor.py
@@ -23,9 +23,7 @@ class LoginDescriptor:
 		data = descriptor_config
 
 		if len(factors_config) == 0:
-			message = "No login factors specified in descriptor"
-			L.error(message, struct_data={"ldid": ldid})
-			raise ValueError(message)
+			raise ValueError("No login factors specified in descriptor {!r}".format(ldid))
 
 		if not isinstance(factors_config[0], list):
 			# There is only one OR-group. Nest it to preserve schema.

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -425,7 +425,7 @@ class AuthenticationService(asab.Service):
 		try:
 			await self.CredentialsService.get(target_cid)
 		except KeyError:
-			L.warning("Impersonation target does not exist.", struct_data={
+			L.log(asab.LOG_NOTICE, "Impersonation target does not exist.", struct_data={
 				"impersonator_cid": impersonator_cid, "target_cid": target_cid})
 			raise exceptions.CredentialsNotFoundError(target_cid)
 
@@ -433,9 +433,10 @@ class AuthenticationService(asab.Service):
 		target_authz = await build_credentials_authz(
 			self.TenantService, self.RoleService, target_cid, tenants=None)
 		if self.RBACService.is_superuser(target_authz):
-			L.warning(
+			L.log(
+				asab.LOG_NOTICE,
 				"Impersonation target is a superuser. Resource 'authz:superuser' will be excluded "
-				"from the impersonated session.",
+				"from the impersonated session's authorization scope.",
 				struct_data={"impersonator_cid": impersonator_cid, "target_cid": target_cid})
 
 		scope = frozenset(["profile", "email", "phone"])

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -169,7 +169,7 @@ class ResourceHandler(object):
 
 
 	@access_control("seacat:resource:edit")
-	async def delete(self, request):
+	async def delete(self, request, *, credentials_id):
 		"""
 		Delete resource
 
@@ -191,6 +191,8 @@ class ResourceHandler(object):
 		resource_id = request.match_info["resource_id"]
 		hard_delete = request.query.get("hard_delete") == "true"
 		if hard_delete and not request.is_superuser:
-			raise aiohttp.web.HTTPForbidden()
+			L.log(asab.LOG_NOTICE, "Cannot hard-delete resources without superuser rights", struct_data={
+				"cid": credentials_id, "resource": resource_id})
+			return aiohttp.web.HTTPForbidden()
 		await self.ResourceService.delete(resource_id, hard_delete=hard_delete)
 		return asab.web.rest.json_response(request, {"result": "OK"})

--- a/seacatauth/authz/role/handler/roles.py
+++ b/seacatauth/authz/role/handler/roles.py
@@ -40,17 +40,8 @@ class RolesHandler(object):
 		Get credentials' roles
 		"""
 		creds_id = request.match_info["credentials_id"]
-		try:
-			result = await self.RoleService.get_roles_by_credentials(creds_id, [tenant])
-		except ValueError as e:
-			L.log(asab.LOG_NOTICE, str(e))
-			raise aiohttp.web.HTTPBadRequest()
-		except KeyError as e:
-			L.log(asab.LOG_NOTICE, str(e))
-			raise aiohttp.web.HTTPNotFound()
-		return asab.web.rest.json_response(
-			request, result
-		)
+		result = await self.RoleService.get_roles_by_credentials(creds_id, [tenant])
+		return asab.web.rest.json_response(request, result)
 
 
 	@asab.web.rest.json_schema_handler({

--- a/seacatauth/authz/role/handler/roles.py
+++ b/seacatauth/authz/role/handler/roles.py
@@ -89,10 +89,9 @@ class RolesHandler(object):
 		if "authz:superuser" in resources:
 			include_global = True
 		elif tenant == "*":
-			L.warning("Not authorized to manage global roles.", struct_data={
-				"cid": request.CredentialsId
-			})
-			raise aiohttp.web.HTTPForbidden()
+			L.log(asab.LOG_NOTICE, "Not authorized to manage global roles.", struct_data={
+				"cid": request.CredentialsId})
+			return aiohttp.web.HTTPForbidden()
 		else:
 			include_global = False
 

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -240,17 +240,10 @@ class CookieHandler(object):
 			if forwarded_for is not None:
 				from_info.extend(forwarded_for.split(", "))
 			track_id = uuid.uuid4().bytes
-			try:
-				session = await self.CookieService.create_anonymous_cookie_client_session(
-					anonymous_cid, client, scope,
-					track_id=track_id,
-					from_info=from_info)
-			except exceptions.AccessDeniedError as e:
-				L.error(
-					"Failed to initialize anonymous session because of unauthorized access. "
-					"Please revise your introspection setup.",
-					struct_data={"reason": str(e)})
-				raise aiohttp.web.HTTPForbidden() from e
+			session = await self.CookieService.create_anonymous_cookie_client_session(
+				anonymous_cid, client, scope,
+				track_id=track_id,
+				from_info=from_info)
 			anonymous_session_created = True
 
 		if session is None:

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -208,8 +208,8 @@ class CredentialsHandler(object):
 		# Filtering based on IDs obtained form another collection
 		if mode in frozenset(["role", "tenant"]):
 			if filtr is None:
-				L.error("No filter string specified.", struct_data={"mode": mode})
-				raise aiohttp.web.HTTPBadRequest()
+				raise asab.exceptions.ValidationError(
+					"Filter mode {!r} requires that a filter string is specified".format(mode))
 
 			# These filters require access dedicated resource
 			rbac_svc = self.CredentialsService.App.get_service("seacatauth.RBACService")
@@ -310,8 +310,7 @@ class CredentialsHandler(object):
 					continue
 
 		else:
-			L.error("Unsupported filter mode", struct_data={"mode": mode})
-			raise aiohttp.web.HTTPBadRequest()
+			raise asab.exceptions.ValidationError("Unsupported filter mode {!r}".format(mode))
 
 		return asab.web.rest.json_response(request, {
 			"result": "OK",

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -211,7 +211,8 @@ class RegistrationHandler(object):
 		"""
 		# Disable this endpoint if self-registration is not enabled
 		if not self.RegistrationService.SelfRegistrationEnabled:
-			raise aiohttp.web.HTTPNotFound()
+			L.log(asab.LOG_NOTICE, "Self-registration is not enabled")
+			return aiohttp.web.HTTPNotFound()
 
 		# Log IPs from which the request was made
 		access_ips = [request.remote]

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -1,11 +1,15 @@
 import typing
 
 
-class TenantNotSpecifiedError(Exception):
+class SeacatAuthError(Exception):
 	pass
 
 
-class AccessDeniedError(Exception):
+class TenantNotSpecifiedError(SeacatAuthError):
+	pass
+
+
+class AccessDeniedError(SeacatAuthError):
 	"""
 	Subject is not authorized to access requested resource (or tenant, operation...).
 
@@ -44,19 +48,19 @@ class NoTenantsError(AccessDeniedError):
 		super().__init__("Subject has access to no tenant.", *args)
 
 
-class TenantNotFoundError(KeyError):
+class TenantNotFoundError(SeacatAuthError, KeyError):
 	def __init__(self, tenant, *args):
 		self.Tenant = tenant
 		super().__init__("Tenant not found.", *args)
 
 
-class RoleNotFoundError(KeyError):
+class RoleNotFoundError(SeacatAuthError, KeyError):
 	def __init__(self, role, *args):
 		self.Role = role
 		super().__init__("Role not found.", *args)
 
 
-class CredentialsNotFoundError(KeyError):
+class CredentialsNotFoundError(SeacatAuthError, KeyError):
 	def __init__(self, credentials_id, *args):
 		self.CredentialsId = credentials_id
 		super().__init__("Credentials not found.", *args)
@@ -73,7 +77,7 @@ class UnauthorizedTenantAccessError(AccessDeniedError):
 		super().__init__("Credentials are not authorized under tenant.", *args)
 
 
-class TenantNotAssignedError(KeyError):
+class TenantNotAssignedError(SeacatAuthError, KeyError):
 	"""
 	Credentials do not have the tenant assigned.
 	"""
@@ -83,27 +87,27 @@ class TenantNotAssignedError(KeyError):
 		super().__init__("Credentials do not have the tenant assigned.", *args)
 
 
-class TOTPNotActiveError(Exception):
+class TOTPNotActiveError(SeacatAuthError):
 	def __init__(self, credential_id: str):
 		self.CredentialID: str = credential_id
 		super().__init__("TOTP not active for credentials.")
 
 
-class ClientResponseError(Exception):
+class ClientResponseError(SeacatAuthError):
 	def __init__(self, status: int, data: typing.Union[str, dict]):
 		self.Status = status
 		self.Data = data
 		super().__init__("Client responded with error {}: {}".format(status, data))
 
 
-class SessionNotFoundError(KeyError):
+class SessionNotFoundError(SeacatAuthError, KeyError):
 	def __init__(self, message, session_id=None, query=None, *args):
 		self.SessionId = session_id
 		self.Query = query
 		super().__init__(message, *args)
 
 
-class CommunicationError(Exception):
+class CommunicationError(SeacatAuthError):
 	def __init__(self, message, credentials_id=None, *args):
 		self.CredentialsId = credentials_id
 		super().__init__(message, *args)

--- a/seacatauth/external_login/handler.py
+++ b/seacatauth/external_login/handler.py
@@ -259,11 +259,7 @@ class ExternalLoginHandler(object):
 		Unregister an external login provider account
 		"""
 		provider_type = request.match_info["ext_login_provider"]
-
-		try:
-			el_credentials = await self.ExternalLoginService.get_sub(credentials_id, provider_type)
-		except KeyError as e:
-			raise aiohttp.web.HTTPNotFound(text=str(e))
+		el_credentials = await self.ExternalLoginService.get_sub(credentials_id, provider_type)
 		await self.ExternalLoginService.delete(provider_type, sub=el_credentials["s"])
 
 		L.log(asab.LOG_NOTICE, "External login successfully removed", struct_data={

--- a/seacatauth/external_login/service.py
+++ b/seacatauth/external_login/service.py
@@ -119,7 +119,7 @@ class ExternalLoginService(asab.Service):
 		query_filter = {"cid": credentials_id, "t": provider_type}
 		result = await collection.find_one(query_filter)
 		if result is None:
-			raise KeyError("External login for type '{}' not registered for credentials".format(provider_type))
+			raise KeyError("External login for type {!r} not registered for credentials".format(provider_type))
 		return result
 
 

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -29,6 +29,7 @@ def private_auth_middleware_factory(app):
 	require_authentication = asab.Config.getboolean("seacat:api", "require_authentication")
 	authorization_resource = asab.Config.get("seacat:api", "authorization_resource")
 	_allow_access_token_auth = asab.Config.getboolean("seacat:api", "_allow_access_token_auth")
+	asab_api_required_bearer_token = asab.Config.get("asab:api:auth", "bearer", fallback=None)
 
 	rbac_svc = app.get_service("seacatauth.RBACService")
 
@@ -92,18 +93,19 @@ def private_auth_middleware_factory(app):
 			if authorization_resource in resources:
 				return await handler(request)
 
-		# TODO authorization should be demanded on the handler level based on @accesscontrol
+		# ASAB API can be protected with a pre-configured bearer token
 		if (request.path.startswith("/asab/v1") or request.path in ("/doc", "/oauth2-redirect.html")) \
 			and request.method == "GET":
-			if "asab:api:auth" in asab.Config.sections():
-				if request.headers.get("Authorization") == "Bearer " + asab.Config.get("asab:api:auth", "bearer"):
+			if asab_api_required_bearer_token:
+				if request.headers.get("Authorization") == "Bearer {}".format(asab_api_required_bearer_token):
 					return await handler(request)
 				else:
-					raise aiohttp.web.HTTPUnauthorized()
+					L.log(asab.LOG_NOTICE, "Invalid bearer token for ASAB API access")
+					return aiohttp.web.HTTPUnauthorized()
 			else:
 				return await handler(request)
 
-		raise aiohttp.web.HTTPUnauthorized()
+		return aiohttp.web.HTTPUnauthorized()
 
 	return private_auth_middleware
 
@@ -134,8 +136,8 @@ def public_auth_middleware_factory(app):
 				elif _allow_access_token_auth:
 					request.Session = await oidc_service.get_session_by_access_token(token_value)
 				else:
-					L.info("Invalid Bearer token")
-					raise aiohttp.web.HTTPUnauthorized()
+					L.log(asab.LOG_NOTICE, "Invalid bearer token")
+					return aiohttp.web.HTTPUnauthorized()
 		else:
 			# No Bearer token exists, authorize using cookie
 			request.Session = await cookie_service.get_session_by_request_cookie(request)

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -300,10 +300,10 @@ class AuthorizeHandler(object):
 			e.RedirectUri = redirect_uri
 			raise e
 		except client.exceptions.ClientNotFoundError as e:
-			L.error("Client not found.", struct_data={"client_id": client_id, "redirect_uri": redirect_uri})
+			L.log(asab.LOG_NOTICE, "Client not found.", struct_data={"client_id": client_id, "redirect_uri": redirect_uri})
 			raise ClientIdError(client_id) from e
 		except client.exceptions.InvalidRedirectURI as e:
-			L.error("Invalid redirect URI.", struct_data={"client_id": client_id, "redirect_uri": redirect_uri})
+			L.log(asab.LOG_NOTICE, "Invalid redirect URI.", struct_data={"client_id": client_id, "redirect_uri": redirect_uri})
 			raise RedirectUriError(redirect_uri, client_id) from e
 
 		# Extract request source

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -202,8 +202,10 @@ class TokenHandler(object):
 
 		2.1.  Revocation Request
 		"""
+		# TODO: Confidential clients must authenticate (query params or Authorization header)
+		# TODO: Public clients are not allowed to revoke other clients' tokens
 		if request.Session is None:
-			raise aiohttp.web.HTTPUnauthorized()
+			return aiohttp.web.HTTPUnauthorized()
 
 		token_type_hint = json_data.get("token_type_hint")  # Optional `access_token` or `refresh_token`
 		await self.OpenIdConnectService.revoke_token(json_data["token"], token_type_hint)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -228,13 +228,13 @@ class OpenIdConnectService(asab.Service):
 	def refresh_token(self, refresh_token, client_id, client_secret, scope):
 		# TODO: this is not implemented
 		L.error("refresh_token is not implemented", struct_data=[refresh_token, client_id, client_secret, scope])
-		raise aiohttp.web.HTTPNotImplemented()
+		return aiohttp.web.HTTPNotImplemented()
 
 
 	def check_access_token(self, bearer_token):
 		# TODO: this is not implemented
 		L.error("check_access_token is not implemented", struct_data={"bearer": bearer_token})
-		raise aiohttp.web.HTTPNotImplemented()
+		return aiohttp.web.HTTPNotImplemented()
 
 
 	async def create_oidc_session(


### PR DESCRIPTION
Client should not cause `L.error`, `L.warning` or surface unhandled.