### PR TITLE
Reduce grafana sync frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
-## Release candidate
+## v23.44 (release candidate)
+
+### Pre-releases
+- v23.44-alpha1
 
 ### Breaking changes
 - Dropped support for authorize query params `ldid` and `expiration` (#296, PLUM Sprint 231006)
@@ -14,6 +17,7 @@
 - External login registration webhook (#286, PLUM Sprint 231006)
 - OAuth Authorize ignores all unknown parameters (#296, PLUM Sprint 231006)
 - Log failure reasons in introspection and authorization flow (#315, INDIGO Sprint 231027)
+- Reduce grafana sync frequency (#317, INDIGO Sprint 231027, `v23.44-alpha1`)
 
 ### Refactoring
 - Do not log "unhappy flow" as errors (#315, INDIGO Sprint 231027)

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -61,9 +61,9 @@ class GrafanaIntegration(asab.config.Configurable):
 	async def _on_housekeeping(self, event_name):
 		await self.sync_all()
 
-	async def _on_authz_change(self, event_name, credential_id=None, **kwargs):
-		if credential_id:
-			await self.sync_credentials(credential_id)
+	async def _on_authz_change(self, event_name, credentials_id=None, **kwargs):
+		if credentials_id:
+			await self.sync_credentials(credentials_id)
 		else:
 			await self.sync_all()
 

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -12,10 +12,6 @@ L = logging.getLogger(__name__)
 
 #
 
-
-# TODO: When credentials are added/updated/deleted, the sync should happen
-#       That's to be done using PubSub mechanism
-
 # TODO: Remove users that are managed by us but are removed (use `managed_role` to find these)
 
 _GRAFANA_ADMIN_RESOURCE = "grafana:admin"
@@ -23,15 +19,15 @@ _GRAFANA_USER_RESOURCE = "grafana:user"
 
 
 class GrafanaIntegration(asab.config.Configurable):
-	'''
+	"""
 	Grafana user push compomnent
-	'''
+	"""
 
 	ConfigDefaults = {
-		'url': 'http://localhost:3000/',
-		'username': 'admin',
-		'password': 'admin',
-		'local_users': 'admin',
+		"url": "http://localhost:3000/",
+		"username": "admin",
+		"password": "admin",
+		"local_users": "admin",
 	}
 
 
@@ -50,18 +46,26 @@ class GrafanaIntegration(asab.config.Configurable):
 		else:
 			self.Authorization = None
 
-		self.URL = self.Config.get('url').rstrip('/')
+		self.URL = self.Config.get("url").rstrip("/")
 
-		lu = re.split(r'\s+', self.Config.get('local_users'), flags=re.MULTILINE)
+		lu = re.split(r"\s+", self.Config.get("local_users"), flags=re.MULTILINE)
 		lu.append(username)
 
 		self.LocalUsers = frozenset(lu)
 
-		batman_svc.App.PubSub.subscribe("Application.tick/60!", self._on_tick)
+		batman_svc.App.PubSub.subscribe("Application.housekeeping!", self._on_housekeeping)
+		batman_svc.App.PubSub.subscribe("Role.assigned!", self._on_authz_change)
+		batman_svc.App.PubSub.subscribe("Role.unassigned!", self._on_authz_change)
+		batman_svc.App.PubSub.subscribe("Role.updated!", self._on_authz_change)
 
-	async def _on_tick(self, event_name):
-		# TODO: Sync on housekeeping + on credential update + on permissions update
+	async def _on_housekeeping(self, event_name):
 		await self.sync_all()
+
+	async def _on_authz_change(self, event_name, credential_id=None, **kwargs):
+		if credential_id:
+			await self.sync_credentials(credential_id)
+		else:
+			await self.sync_all()
 
 	async def _initialize_resources(self):
 		try:
@@ -81,25 +85,53 @@ class GrafanaIntegration(asab.config.Configurable):
 
 	async def initialize(self):
 		await self._initialize_resources()
-		await self.sync_all()
 
 
 	async def sync_all(self):
-		cred_svc = self.BatmanService.App.get_service('seacatauth.CredentialsService')
+		"""
+		Synchronize Seacat credential metadata and relevant access rights to Grafana user
+
+		Args:
+			credential_id: Seacat Auth credential ID
+		"""
+		cred_svc = self.BatmanService.App.get_service("seacatauth.CredentialsService")
 		try:
 			async with aiohttp.ClientSession(auth=self.Authorization) as session:
 				async for cred in cred_svc.iterate():
-					await self._sync_credential(session, cred)
+					await self._sync_credentials(session, cred)
 		except aiohttp.client_exceptions.ClientConnectionError as e:
 			L.error("Cannot connect to Grafana: {}".format(str(e)))
 
 
-	async def _sync_credential(self, session: aiohttp.ClientSession, cred: dict):
-		username = cred.get('username')
+	async def sync_credentials(self, credential_id: str):
+		"""
+		Synchronize Seacat credential metadata and relevant access rights to Grafana user
+
+		Args:
+			credential_id: Seacat Auth credential ID
+		"""
+		cred_svc = self.BatmanService.App.get_service("seacatauth.CredentialsService")
+		credentials = await cred_svc.get(credential_id)
+		try:
+			async with aiohttp.ClientSession(auth=self.Authorization) as session:
+				await self._sync_credentials(session, credentials)
+		except aiohttp.client_exceptions.ClientConnectionError as e:
+			L.error("Cannot connect to Grafana: {}".format(str(e)))
+
+
+	async def _sync_credentials(self, session: aiohttp.ClientSession, credentials: dict):
+		"""
+		Propagate Seacat credential metadata and relevant access rights to Grafana
+
+		Args:
+			session: Grafana connection session
+			credentials: Seacat credentials dictionary
+		"""
+		username = credentials.get("username")
 		if username is None:
 			# Be defensive
 			L.info("Cannot create Grafana user: No username", struct_data={
-				"cid": cred["_id"]
+				"cid": credentials["_id"]
 			})
 			return
 
@@ -108,7 +140,7 @@ class GrafanaIntegration(asab.config.Configurable):
 			return
 
 		# Get authz dict
-		authz = await build_credentials_authz(self.TenantService, self.RoleService, cred["_id"])
+		authz = await build_credentials_authz(self.TenantService, self.RoleService, credentials["_id"])
 
 		# Grafana roles from SCA resources
 		# Use only global "*" roles for now
@@ -117,40 +149,40 @@ class GrafanaIntegration(asab.config.Configurable):
 			return
 
 		grafana_user = {
-			'login': username,
+			"login": username,
 
 			# Generate technical password
-			'password': self.BatmanService.generate_password(cred['_id']),
+			"password": self.BatmanService.generate_password(credentials["_id"]),
 
-			'metadata': {
+			"metadata": {
 				# We are managed by SeaCat Auth
-				'seacatauth': True
+				"seacatauth": True
 			},
 		}
 
-		v = cred.get('email')
+		v = credentials.get("email")
 		if v is not None:
-			grafana_user['email'] = v
+			grafana_user["email"] = v
 
-		v = cred.get('full_name')
+		v = credentials.get("full_name")
 		if v is not None:
-			grafana_user['name'] = v
+			grafana_user["name"] = v
 
 		# TODO: Check if user exists
-		async with session.post('{}/api/admin/users'.format(self.URL), json=grafana_user) as resp:
+		async with session.post("{}/api/admin/users".format(self.URL), json=grafana_user) as resp:
 			if resp.status == 200:
 				pass
 			elif resp.status == 412:
 				# User already exists
 				L.debug(
 					"Grafana user already exists",
-					struct_data={"cid": cred["_id"], "status": resp.status})
+					struct_data={"cid": credentials["_id"], "status": resp.status})
 				return
 			else:
 				text = await resp.text()
 				L.warning(
 					"Failed to create user in Grafana:\n{}".format(text[:1000]),
-					struct_data={"cid": cred["_id"], "status": resp.status}
+					struct_data={"cid": credentials["_id"], "status": resp.status}
 				)
 				return
 
@@ -167,7 +199,7 @@ class GrafanaIntegration(asab.config.Configurable):
 						text = await resp_role.text()
 						L.warning(
 							"Failed to update user permissions in Grafana:\n{}".format(text[:1000]),
-							struct_data={"cid": cred["_id"], "status": resp.status}
+							struct_data={"cid": credentials["_id"], "status": resp.status}
 						)
 
 				# Update role
@@ -180,5 +212,5 @@ class GrafanaIntegration(asab.config.Configurable):
 						text = await resp_role.text()
 						L.warning(
 							"Failed to update user roles in Grafana:\n{}".format(text[:1000]),
-							struct_data={"cid": cred["_id"], "status": resp.status}
+							struct_data={"cid": credentials["_id"], "status": resp.status}
 						)

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -89,7 +89,7 @@ class GrafanaIntegration(asab.config.Configurable):
 
 	async def sync_all(self):
 		"""
-		Synchronize Seacat credential metadata and relevant access rights to Grafana user
+		Synchronize all Seacat credentials' metadata and relevant access rights to Grafana user
 
 		Args:
 			credential_id: Seacat Auth credential ID
@@ -100,23 +100,24 @@ class GrafanaIntegration(asab.config.Configurable):
 				async for cred in cred_svc.iterate():
 					await self._sync_credentials(session, cred)
 		except aiohttp.client_exceptions.ClientConnectionError as e:
-			L.error("Cannot connect to Grafana: {}".format(str(e)))
+			L.error("Failed to sync Grafana users (Connection error): {}".format(str(e)))
 
 
-	async def sync_credentials(self, credential_id: str):
+	async def sync_credentials(self, credentials_id: str):
 		"""
-		Synchronize Seacat credential metadata and relevant access rights to Grafana user
+		Synchronize a single Seacat credential metadata and relevant access rights to Grafana user
 
 		Args:
-			credential_id: Seacat Auth credential ID
+			credentials_id: Seacat Auth credential ID
 		"""
 		cred_svc = self.BatmanService.App.get_service("seacatauth.CredentialsService")
-		credentials = await cred_svc.get(credential_id)
+		credentials = await cred_svc.get(credentials_id)
 		try:
 			async with aiohttp.ClientSession(auth=self.Authorization) as session:
 				await self._sync_credentials(session, credentials)
 		except aiohttp.client_exceptions.ClientConnectionError as e:
-			L.error("Cannot connect to Grafana: {}".format(str(e)))
+			L.error("Failed to sync Grafana user (Connection error): {}".format(str(e)), struct_data={
+				"cid": credentials_id})
 
 
 	async def _sync_credentials(self, session: aiohttp.ClientSession, credentials: dict):


### PR DESCRIPTION
# Issue

Batman syncs with Grafana every minute and logs failed connection for every user. This results in tens of thousands of error messages daily when Grafana is down.

# Changes

- Use a single grafana connection session when synchronizing all credentials.
- Synchronize all credentials on housekeeping.
- Synchronize individual users on authorization change (role assigned, role unassigned, role auth updated).