### PR TITLE
Major API restructuring

### DIFF
--- a/seacatauth/audit/handler.py
+++ b/seacatauth/audit/handler.py
@@ -26,7 +26,7 @@ class AuditHandler(object):
 		self.AuditService = audit_service
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_put("/audit/prune", self.prune_old_audit_entries)
+		web_app.router.add_put("/admin/audit/prune", self.prune_old_audit_entries)
 
 	@asab.web.rest.json_schema_handler({
 		"type": "object",

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -58,8 +58,6 @@ class AuthenticationHandler(object):
 		web_app_public.router.add_put(r"/public/login/{lsid}/smslogin", self.smslogin)
 		web_app_public.router.add_put(r"/public/login/{lsid}/webauthn", self.webauthn_login)
 		web_app_public.router.add_put(r"/public/logout", self.logout)
-		web_app_public.router.add_put("/impersonate", self.impersonate)
-		web_app_public.router.add_post("/impersonate", self.impersonate_and_redirect)
 
 	@asab.web.rest.json_schema_handler({
 		"type": "object",

--- a/seacatauth/authn/webauthn/handler.py
+++ b/seacatauth/authn/webauthn/handler.py
@@ -28,19 +28,11 @@ class WebAuthnHandler(object):
 		self.WebAuthnService = webauthn_svc
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_get('/public/webauthn/register-options', self.get_registration_options)
-		web_app.router.add_put('/public/webauthn/register', self.register_credential)
-		web_app.router.add_delete('/public/webauthn/{wacid}', self.remove_credential)
-		web_app.router.add_put('/public/webauthn/{wacid}', self.update_credential)
-		web_app.router.add_get('/public/webauthn', self.list_credentials)
-
-		# Public endpoints
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_get('/public/webauthn/register-options', self.get_registration_options)
-		web_app_public.router.add_put('/public/webauthn/register', self.register_credential)
-		web_app_public.router.add_delete('/public/webauthn/{wacid}', self.remove_credential)
-		web_app_public.router.add_put('/public/webauthn/{wacid}', self.update_credential)
-		web_app_public.router.add_get('/public/webauthn', self.list_credentials)
+		web_app.router.add_get("/account/webauthn/register-options", self.get_registration_options)
+		web_app.router.add_put("/account/webauthn/register", self.register_credential)
+		web_app.router.add_delete("/account/webauthn/{wacid}", self.remove_credential)
+		web_app.router.add_put("/account/webauthn/{wacid}", self.update_credential)
+		web_app.router.add_get("/account/webauthn", self.list_credentials)
 
 
 	@access_control()

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -28,12 +28,11 @@ class ChangePasswordHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_put("/password", self.admin_request_password_change)
-		web_app.router.add_put("/public/password-change", self.change_password)
+		web_app.router.add_put("/account/password-change", self.change_password)
 		web_app.router.add_put("/public/password-reset", self.reset_password)
 		web_app.router.add_put("/public/lost-password", self.lost_password)
 
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_put("/public/password-change", self.change_password)
 		web_app_public.router.add_put("/public/password-reset", self.reset_password)
 		web_app_public.router.add_put("/public/lost-password", self.lost_password)
 

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -47,20 +47,13 @@ class CredentialsHandler(object):
 		web_app.router.add_put("/credentials/{credentials_id}", self.update_credentials)
 		web_app.router.add_delete("/credentials/{credentials_id}", self.delete_credentials)
 
-		web_app.router.add_put("/public/credentials", self.update_my_credentials)
-		web_app.router.add_get("/public/last_login", self.get_my_last_login_data)
-
-		# Providers
 		web_app.router.add_get("/provider/{provider_id}", self.get_provider_info)
 		web_app.router.add_get("/providers", self.list_providers)
-		web_app.router.add_get("/public/provider", self.get_my_provider_info)
 		web_app.router.add_put("/enforce-factors/{credentials_id}", self.enforce_factors)
 
-		# Public endpoints
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_put("/public/credentials", self.update_my_credentials)
-		web_app_public.router.add_get("/public/provider", self.get_my_provider_info)
-		web_app_public.router.add_get("/public/last_login", self.get_my_last_login_data)
+		web_app.router.add_get("/account/provider", self.get_my_provider_info)
+		web_app.router.add_put("/account/credentials", self.update_my_credentials)
+		web_app.router.add_get("/account/last_login", self.get_my_last_login_data)
 
 
 	@access_control("seacat:credentials:access")

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -36,7 +36,7 @@ class RegistrationHandler(object):
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_post("/{tenant}/invite", self.admin_create_invitation)
 		web_app.router.add_post("/invite/{credentials_id}", self.resend_invitation)
-		web_app.router.add_post("/public/{tenant}/invite", self.public_create_invitation)
+		web_app.router.add_post("/account/{tenant}/invite", self.public_create_invitation)
 		web_app.router.add_post("/public/register", self.request_self_invitation)
 		web_app.router.add_get("/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.get_registration)
 		web_app.router.add_put("/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.update_registration)
@@ -45,7 +45,6 @@ class RegistrationHandler(object):
 
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_post("/public/register", self.request_self_invitation)
-		web_app_public.router.add_post("/public/{tenant}/invite", self.public_create_invitation)
 		web_app_public.router.add_get("/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.get_registration)
 		web_app_public.router.add_put("/public/register/{registration_code:[-_=a-zA-Z0-9]{16,}}", self.update_registration)
 		web_app_public.router.add_post(

--- a/seacatauth/otp/handler.py
+++ b/seacatauth/otp/handler.py
@@ -27,14 +27,9 @@ class OTPHandler(object):
 		web_app_public = app.PublicWebContainer.WebApp
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_get("/public/totp", self.prepare_totp_if_not_active)
-		web_app.router.add_put("/public/set-totp", self.set_totp)
-		web_app.router.add_put("/public/unset-totp", self.unset_totp)
-
-		# Public endpoints
-		web_app_public.router.add_get("/public/totp", self.prepare_totp_if_not_active)
-		web_app_public.router.add_put("/public/set-totp", self.set_totp)
-		web_app_public.router.add_put("/public/unset-totp", self.unset_totp)
+		web_app.router.add_get("/account/totp", self.prepare_totp_if_not_active)
+		web_app.router.add_put("/account/set-totp", self.set_totp)
+		web_app.router.add_put("/account/unset-totp", self.unset_totp)
 
 	@access_control()
 	async def prepare_totp_if_not_active(self, request, *, credentials_id):

--- a/seacatauth/session/handler.py
+++ b/seacatauth/session/handler.py
@@ -33,11 +33,7 @@ class SessionHandler(object):
 		web_app.router.add_get(r"/sessions/{credentials_id}", self.search_by_credentials_id)
 		web_app.router.add_delete(r"/sessions/{credentials_id}", self.delete_by_credentials_id)
 
-		web_app.router.add_delete(r"/public/sessions", self.delete_own_sessions)
-
-		# Public aliases
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_delete(r"/public/sessions", self.delete_own_sessions)
+		web_app.router.add_delete("/account/sessions", self.delete_own_sessions)
 
 
 	@access_control("seacat:session:access")

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -46,10 +46,6 @@ class TenantHandler(object):
 
 		web_app.router.add_get("/tenant_propose", self.propose_tenant_name)
 
-		# Public endpoints
-		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_get("/tenant", self.list)
-
 
 	# IMPORTANT: This endpoint needs to be compatible with `/tenant` handler in Asab Tenant Service
 	async def list(self, request):


### PR DESCRIPTION
# Endpoint categories (path prefixes)

* `/.well-known/` - standardní dle specifikace (PUBLIC)
* `/openidconnect/` - oidc api (PUBLIC)
* `/public/` - login a registrace (PUBLIC)
* `/nginx/` - introspekce (private)
* `/account/` - správa vlastního účtu (private)
* `/admin/` - administrace tenantů, rolí, kredenšlů etc. (private)
* `/asab/` - asab api (private)

# Issues

- [ ] Verify that no ASAB service relies on the public `GET /tenant` endpoint anymore
- [ ] Invite user to tenant - `/account/`?