### PR TITLE
Separate login factors in session object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## v23.47
 
 ### Pre-releases
-- `v23.47-alpha`
+- `v23.47-alpha3`
 - `v23.47-alpha2`
+- `v23.47-alpha`
 
 ### Breaking changes
 - Remove access token from websocket protocol header during introspection (#324, `v23.47-alpha2`)
@@ -14,6 +15,9 @@
 
 ### Features
 - Kibana spaces and roles are now synchronized with Seacat tenants (#281, `v23.47-alpha`)
+
+### Refactoring
+- Separate login factors in session object (#325, `v23.47-alpha3`)
 
 ---
 

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -194,6 +194,7 @@ class CookieService(asab.Service):
 		if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
 			session_builders.append([
 				(SessionAdapter.FN.Authentication.LoginDescriptor, root_session.Authentication.LoginDescriptor),
+				(SessionAdapter.FN.Authentication.LoginFactors, root_session.Authentication.LoginFactors),
 				(SessionAdapter.FN.Authentication.ExternalLoginOptions, root_session.Authentication.ExternalLoginOptions),
 				(SessionAdapter.FN.Authentication.AvailableFactors, root_session.Authentication.AvailableFactors),
 			])

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -73,18 +73,13 @@ async def add_to_header(headers, attributes_to_add, session, requested_tenant=No
 
 	# Obtain login factors from session object
 	if "factors" in attributes_to_add:
-		if session.Authentication.LoginDescriptor is not None:
-			factors = [
-				factor["id"]
-				for factor
-				in session.Authentication.LoginDescriptor["factors"]
-			]
-			headers["X-Login-Factors"] = " ".join(factors)
+		if session.Authentication.LoginFactors is not None:
+			headers["X-Login-Factors"] = " ".join(session.Authentication.LoginFactors)
 
 	# Obtain login descriptor IDs from session object
 	if "ldid" in attributes_to_add:
 		if session.Authentication.LoginDescriptor is not None:
-			headers["X-Login-Descriptor"] = session.Authentication.LoginDescriptor["id"]
+			headers["X-Login-Descriptor"] = session.Authentication.LoginDescriptor
 
 	return headers
 

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -622,9 +622,9 @@ class AuthorizeHandler(object):
 		# Check if all the enforced factors are present in the session
 		if self.AuthenticationService.EnforceFactors is not None:
 			factors_to_setup = list(self.AuthenticationService.EnforceFactors)
-			for factor in session.Authentication.LoginDescriptor["factors"]:
-				if factor["type"] in factors_to_setup:
-					factors_to_setup.remove(factor["type"])
+			for factor in session.Authentication.LoginFactors:
+				if factor in factors_to_setup:
+					factors_to_setup.remove(factor)
 
 		# Check if there are additional factors to be reset
 		credentials = await self.CredentialsService.get(session.Credentials.Id)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -264,6 +264,7 @@ class OpenIdConnectService(asab.Service):
 		if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
 			session_builders.append([
 				(SessionAdapter.FN.Authentication.LoginDescriptor, root_session.Authentication.LoginDescriptor),
+				(SessionAdapter.FN.Authentication.LoginFactors, root_session.Authentication.LoginFactors),
 				(SessionAdapter.FN.Authentication.AvailableFactors, root_session.Authentication.AvailableFactors),
 				(
 					SessionAdapter.FN.Authentication.ExternalLoginOptions,

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -407,12 +407,9 @@ class OpenIdConnectService(asab.Service):
 			userinfo["available_factors"] = session.Authentication.AvailableFactors
 
 		if session.Authentication.LoginDescriptor is not None:
-			userinfo["ldid"] = session.Authentication.LoginDescriptor["id"]
-			userinfo["factors"] = [
-				factor["type"]
-				for factor
-				in session.Authentication.LoginDescriptor["factors"]
-			]
+			userinfo["ldid"] = session.Authentication.LoginDescriptor
+		if session.Authentication.LoginFactors is not None:
+			userinfo["factors"] = session.Authentication.LoginFactors
 
 		# List enabled external login providers
 		if session.Authentication.ExternalLoginOptions is not None:

--- a/seacatauth/session/adapter.py
+++ b/seacatauth/session/adapter.py
@@ -41,6 +41,7 @@ class AuthenticationData:
 	TOTPSet: str
 	ExternalLoginOptions: typing.Optional[list]
 	LoginDescriptor: typing.Optional[dict]
+	LoginFactors: typing.Optional[dict]
 	AvailableFactors: typing.Optional[list]
 	LastLogin: typing.Optional[dict]
 	IsAnonymous: typing.Optional[bool]
@@ -122,6 +123,7 @@ class SessionAdapter:
 			TOTPSet = "an_ts"
 			ExternalLoginOptions = "an_ex"
 			LoginDescriptor = "an_ld"
+			LoginFactors = "an_lf"
 			AvailableFactors = "an_af"
 			LastLogin = "an_ll"
 			IsAnonymous = "an_ano"
@@ -229,6 +231,7 @@ class SessionAdapter:
 			session_dict.update({
 				self.FN.Authentication.LastLogin: self.Authentication.LastLogin,
 				self.FN.Authentication.LoginDescriptor: self.Authentication.LoginDescriptor,
+				self.FN.Authentication.LoginFactors: self.Authentication.LoginFactors,
 				self.FN.Authentication.AvailableFactors: self.Authentication.AvailableFactors,
 				self.FN.Authentication.TOTPSet: self.Authentication.TOTPSet,
 				self.FN.Authentication.IsAnonymous: self.Authentication.IsAnonymous,
@@ -329,13 +332,11 @@ class SessionAdapter:
 	@classmethod
 	def _deserialize_authentication_data(cls, session_dict):
 		return AuthenticationData(
-			TOTPSet=session_dict.pop(cls.FN.Authentication.TOTPSet, None)
-			or session_dict.pop("TS", None),
+			TOTPSet=session_dict.pop(cls.FN.Authentication.TOTPSet, None),
 			ExternalLoginOptions=session_dict.pop(cls.FN.Authentication.ExternalLoginOptions, None),
-			LoginDescriptor=session_dict.pop(cls.FN.Authentication.LoginDescriptor, None)
-			or session_dict.pop("LD", None),
-			AvailableFactors=session_dict.pop(cls.FN.Authentication.AvailableFactors, None)
-			or session_dict.pop("AF", None),
+			LoginDescriptor=session_dict.pop(cls.FN.Authentication.LoginDescriptor, None),
+			LoginFactors=session_dict.pop(cls.FN.Authentication.LoginFactors, None),
+			AvailableFactors=session_dict.pop(cls.FN.Authentication.AvailableFactors, None),
 			LastLogin=session_dict.pop(cls.FN.Authentication.LastLogin, None),
 			IsAnonymous=session_dict.pop(cls.FN.Authentication.IsAnonymous, None),
 			ImpersonatorCredentialsId=session_dict.pop(cls.FN.Authentication.ImpersonatorCredentialsId, None),

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -62,7 +62,9 @@ async def authz_session_builder(
 
 def login_descriptor_session_builder(login_descriptor):
 	if login_descriptor is not None:
-		yield (SessionAdapter.FN.Authentication.LoginDescriptor, login_descriptor)
+		yield (SessionAdapter.FN.Authentication.LoginDescriptor, login_descriptor["id"])
+		yield (SessionAdapter.FN.Authentication.LoginFactors, [
+			factor["type"] for factor in login_descriptor["factors"]])
 
 
 async def available_factors_session_builder(authentication_service, credentials_id):


### PR DESCRIPTION
Instead of storing the entire login descriptor in the session object, store only its ID and its list of used factors.