### PR TITLE
Unify public URL config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v23.47
 
 ### Pre-releases
+- `v23.47-alpha4`
 - `v23.47-alpha3`
 - `v23.47-alpha2`
 - `v23.47-alpha`
@@ -15,11 +16,12 @@
 
 ### Features
 - Kibana spaces and roles are now synchronized with Seacat tenants (#281, `v23.47-alpha`)
-- Batman configuration for Kibana can be also loaded from the `[elasticsearch]` section, in addition to the `[batman:kibana]` section (#326).
+- Batman configuration for Kibana can be also loaded from the `[elasticsearch]` section, in addition to the `[batman:kibana]` section (#326, `v23.47-alpha4`)
+- Public URL config now requires only one option in canonical deployments (#328, `v23.47-alpha4`)
 
 ### Refactoring
 - Separate login factors in session object (#325, `v23.47-alpha3`)
-- Multiple ElasticSearch node URLs are supported (#326).
+- Multiple ElasticSearch node URLs are supported (#326, `v23.47-alpha4`)
 
 ---
 

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -8,20 +8,20 @@ asab.Config.add_defaults({
 		# Used for deriving callback URLs, issuer IDs (OAuth, WebAuthn, ...).
 		# For full feature availability, the use of HTTPS and a proper domain name is recommended.
 		# Defaults to "http://localhost", which can be overwritten by PUBLIC_SERVER_URL environment variable.
-		"public_server_url": "",
+		"public_url": "",
 
 		# URL prefix of public Seacat Auth API
-		# The URL can be either absolute, or relative to the "public_server_url" above.
+		# The URL can be either absolute, or relative to the "public_url" above.
 		"public_seacat_auth_api_prefix": "api/seacat-auth/",
 
 		# URL prefix of public OpenID Connect API
-		# The URL can be either absolute, or relative to the "public_server_url" above.
+		# The URL can be either absolute, or relative to the "public_url" above.
 		"public_openidconnect_api_prefix": "api/",
 
 		# Auth web UI base URL lets the app know where the auth web UI is served to the public.
 		# It is used for building login and password reset URIs.
 		# The domain name is extracted for cookie and authentication purposes.
-		# The URL can be either absolute, or relative to the "public_server_url" above.
+		# The URL can be either absolute, or relative to the "public_url" above.
 		"auth_webui_base_url": "auth/",
 	},
 

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -4,16 +4,25 @@ import asab
 
 asab.Config.add_defaults({
 	"general": {
-		# Public API base URL lets the app know from what URL is its public API served.
-		# It is used by the OpenIDConnect authorize handler for generating loopback redirect URIs.
+		# Absolute URL of the server where Seacat Auth API is available.
+		# Used for deriving callback URLs, issuer IDs (OAuth, WebAuthn, ...).
 		# For full feature availability, the use of HTTPS and a proper domain name is recommended.
-		"public_api_base_url": "http://localhost/auth/api",
+		# Defaults to "http://localhost", which can be overwritten by PUBLIC_SERVER_URL environment variable.
+		"public_server_url": "",
+
+		# URL prefix of public Seacat Auth API
+		# The URL can be either absolute, or relative to the "public_server_url" above.
+		"public_seacat_auth_api_prefix": "api/seacat-auth/",
+
+		# URL prefix of public OpenID Connect API
+		# The URL can be either absolute, or relative to the "public_server_url" above.
+		"public_openidconnect_api_prefix": "api/",
 
 		# Auth web UI base URL lets the app know where the auth web UI is served to the public.
 		# It is used for building login and password reset URIs.
 		# The domain name is extracted for cookie and authentication purposes.
-		# For full feature availability, the use of HTTPS and a proper domain name is recommended.
-		"auth_webui_base_url": "http://localhost/auth",
+		# The URL can be either absolute, or relative to the "public_server_url" above.
+		"auth_webui_base_url": "auth/",
 	},
 
 	# Admin API (non-public)

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -364,7 +364,7 @@ class SeaCatAuthApplication(asab.Application):
 			self.PublicSeacatAuthApiUrl.startswith("https://")
 			or self.PublicSeacatAuthApiUrl.startswith("http://")
 		):
-			# Relative URL: Append to PublicBaseUrl
+			# Relative URL: Append to PublicUrl
 			self.PublicSeacatAuthApiUrl = urllib.parse.urljoin(self.PublicUrl, self.PublicSeacatAuthApiUrl)
 
 		# Public base URL of OpenID Connect API
@@ -376,7 +376,7 @@ class SeaCatAuthApplication(asab.Application):
 			self.PublicOpenIdConnectApiUrl.startswith("https://")
 			or self.PublicOpenIdConnectApiUrl.startswith("http://")
 		):
-			# Relative URL: Append to PublicBaseUrl
+			# Relative URL: Append to PublicUrl
 			self.PublicOpenIdConnectApiUrl = urllib.parse.urljoin(self.PublicUrl, self.PublicOpenIdConnectApiUrl)
 
 		# Seacat Auth WebUI URL
@@ -388,5 +388,5 @@ class SeaCatAuthApplication(asab.Application):
 			self.AuthWebUiUrl.startswith("https://")
 			or self.AuthWebUiUrl.startswith("http://")
 		):
-			# Relative URL: Append to PublicBaseUrl
+			# Relative URL: Append to PublicUrl
 			self.AuthWebUiUrl = urllib.parse.urljoin(self.PublicUrl, self.AuthWebUiUrl)

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -2,6 +2,7 @@ import os
 import logging
 import secrets
 import jwcrypto.jwk
+import urllib.parse
 
 import asab
 import asab.web
@@ -27,6 +28,12 @@ class SeaCatAuthApplication(asab.Application):
 		self.Provisioning = self._should_activate_provisioning()
 		self._check_encryption_config()
 		self.PrivateKey = self._load_private_key()
+
+		self.PublicServerUrl = None
+		self.PublicSeacatAuthApiUrl = None
+		self.PublicOpenIdConnectApiUrl = None
+		self.AuthWebUiUrl = None
+		self._prepare_public_urls()
 
 		# Load modules
 		self.add_module(asab.web.Module)
@@ -313,3 +320,73 @@ class SeaCatAuthApplication(asab.Application):
 		)
 		parser.add_argument("--provisioning", help="run SeaCat Auth in provisioning mode", action="store_true")
 		return parser
+
+
+	def _prepare_public_urls(self):
+		self.PublicServerUrl = asab.Config.get("general", "public_server_url")
+		if not self.PublicServerUrl:
+			# Check deprecated option (backward compatibility)
+			public_api_base_url = asab.Config.get("general", "public_api_base_url", fallback=None)
+			if public_api_base_url:
+				asab.LogObsolete.warning(
+					"Config option 'public_api_base_url' in the 'general' section is deprecated. "
+					"Please use the 'PUBLIC_SERVER_URL' environment variable "
+					"or the 'public_server_url' option in the 'general' config section.",
+					struct_data={"eol": "2024-05-31"}
+				)
+				self.PublicServerUrl = public_api_base_url
+		if not self.PublicServerUrl:
+			# Try to load config from env variable
+			env_public_server_url = os.getenv("PUBLIC_SERVER_URL")
+			if env_public_server_url:
+				self.PublicServerUrl = env_public_server_url
+			else:
+				self.PublicServerUrl = "http://localhost"
+				L.log(asab.LOG_NOTICE, "No public server URL configured. Falling back to {!r}.".format(self.PublicServerUrl))
+
+		# Ensure that the URL ends with a slash
+		self.PublicServerUrl = self.PublicServerUrl.rstrip("/") + "/"
+		if not (self.PublicServerUrl.startswith("https://") or self.PublicServerUrl.startswith("http://")):
+			raise ValueError(
+				"The value of 'public_base_url' in 'general' config section does not start "
+				"with 'https://' or 'http://' ({!r}). Please supply a full absolute URL.".format(self.PublicServerUrl))
+		if self.PublicServerUrl.startswith("http://"):
+			L.warning(
+				"Seacat Auth public interface is running on plain (insecure) HTTP. "
+				"This may limit the functionality of certain components.")
+
+		# Public base URL of Seacat Auth API
+		#   Canonically, this is "https://${SERVER_NAME}/api/seacat-auth",
+		#   yielding for example "https://example.com/api/seacat-auth/public/features"
+		self.PublicSeacatAuthApiUrl = asab.Config.get(
+			"general", "public_seacat_auth_api_prefix").rstrip("/") + "/"
+		if not (
+			self.PublicSeacatAuthApiUrl.startswith("https://")
+			or self.PublicSeacatAuthApiUrl.startswith("http://")
+		):
+			# Relative URL: Append to PublicBaseUrl
+			self.PublicSeacatAuthApiUrl = urllib.parse.urljoin(self.PublicServerUrl, self.PublicSeacatAuthApiUrl)
+
+		# Public base URL of OpenID Connect API
+		#   Canonically, this is "https://${SERVER_NAME}/api/openidconnect",
+		#   yielding for example "https://example.com/api/openidconnect/authorize"
+		self.PublicOpenIdConnectApiUrl = asab.Config.get(
+			"general", "public_openidconnect_api_prefix").rstrip("/") + "/"
+		if not (
+			self.PublicOpenIdConnectApiUrl.startswith("https://")
+			or self.PublicOpenIdConnectApiUrl.startswith("http://")
+		):
+			# Relative URL: Append to PublicBaseUrl
+			self.PublicOpenIdConnectApiUrl = urllib.parse.urljoin(self.PublicServerUrl, self.PublicOpenIdConnectApiUrl)
+
+		# Seacat Auth WebUI URL
+		#   Canonically, this is "https://${SERVER_NAME}/auth",
+		#   yielding for example "https://example.com/auth/#/login"
+		self.AuthWebUiUrl = asab.Config.get(
+			"general", "auth_webui_base_url").rstrip("/") + "/"
+		if not (
+			self.AuthWebUiUrl.startswith("https://")
+			or self.AuthWebUiUrl.startswith("http://")
+		):
+			# Relative URL: Append to PublicBaseUrl
+			self.AuthWebUiUrl = urllib.parse.urljoin(self.PublicServerUrl, self.AuthWebUiUrl)

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -352,8 +352,8 @@ class SeaCatAuthApplication(asab.Application):
 				"with 'https://' or 'http://' ({!r}). Please supply a full absolute URL.".format(self.PublicServerUrl))
 		if self.PublicServerUrl.startswith("http://"):
 			L.warning(
-				"Seacat Auth public interface is running on plain (insecure) HTTP. "
-				"This may limit the functionality of certain components.")
+				"Seacat Auth public interface is running on plain insecure HTTP ({!r}). "
+				"This may limit the functionality of certain components.".format(self.PublicServerUrl))
 
 		# Public base URL of Seacat Auth API
 		#   Canonically, this is "https://${SERVER_NAME}/api/seacat-auth",

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -356,7 +356,7 @@ class SeaCatAuthApplication(asab.Application):
 				"This may limit the functionality of certain components.".format(self.PublicServerUrl))
 
 		# Public base URL of Seacat Auth API
-		#   Canonically, this is "https://${SERVER_NAME}/api/seacat-auth",
+		#   Canonically, this is "${PUBLIC_SERVER_URL}/api/seacat-auth/",
 		#   yielding for example "https://example.com/api/seacat-auth/public/features"
 		self.PublicSeacatAuthApiUrl = asab.Config.get(
 			"general", "public_seacat_auth_api_prefix").rstrip("/") + "/"
@@ -368,7 +368,7 @@ class SeaCatAuthApplication(asab.Application):
 			self.PublicSeacatAuthApiUrl = urllib.parse.urljoin(self.PublicServerUrl, self.PublicSeacatAuthApiUrl)
 
 		# Public base URL of OpenID Connect API
-		#   Canonically, this is "https://${SERVER_NAME}/api/openidconnect",
+		#   Canonically, this is "${PUBLIC_SERVER_URL}/api/openidconnect/",
 		#   yielding for example "https://example.com/api/openidconnect/authorize"
 		self.PublicOpenIdConnectApiUrl = asab.Config.get(
 			"general", "public_openidconnect_api_prefix").rstrip("/") + "/"
@@ -380,7 +380,7 @@ class SeaCatAuthApplication(asab.Application):
 			self.PublicOpenIdConnectApiUrl = urllib.parse.urljoin(self.PublicServerUrl, self.PublicOpenIdConnectApiUrl)
 
 		# Seacat Auth WebUI URL
-		#   Canonically, this is "https://${SERVER_NAME}/auth",
+		#   Canonically, this is "${PUBLIC_SERVER_URL}/auth/",
 		#   yielding for example "https://example.com/auth/#/login"
 		self.AuthWebUiUrl = asab.Config.get(
 			"general", "auth_webui_base_url").rstrip("/") + "/"

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -29,7 +29,7 @@ class SeaCatAuthApplication(asab.Application):
 		self._check_encryption_config()
 		self.PrivateKey = self._load_private_key()
 
-		self.PublicServerUrl = None
+		self.PublicUrl = None
 		self.PublicSeacatAuthApiUrl = None
 		self.PublicOpenIdConnectApiUrl = None
 		self.AuthWebUiUrl = None
@@ -323,37 +323,37 @@ class SeaCatAuthApplication(asab.Application):
 
 
 	def _prepare_public_urls(self):
-		self.PublicServerUrl = asab.Config.get("general", "public_server_url")
-		if not self.PublicServerUrl:
+		self.PublicUrl = asab.Config.get("general", "public_url")
+		if not self.PublicUrl:
 			# Check deprecated option (backward compatibility)
 			public_api_base_url = asab.Config.get("general", "public_api_base_url", fallback=None)
 			if public_api_base_url:
 				asab.LogObsolete.warning(
 					"Config option 'public_api_base_url' in the 'general' section is deprecated. "
-					"Please use the 'PUBLIC_SERVER_URL' environment variable "
-					"or the 'public_server_url' option in the 'general' config section.",
+					"Please use the 'PUBLIC_URL' environment variable "
+					"or the 'public_url' option in the 'general' config section.",
 					struct_data={"eol": "2024-05-31"}
 				)
-				self.PublicServerUrl = public_api_base_url
-		if not self.PublicServerUrl:
+				self.PublicUrl = public_api_base_url
+		if not self.PublicUrl:
 			# Try to load config from env variable
-			env_public_server_url = os.getenv("PUBLIC_SERVER_URL")
-			if env_public_server_url:
-				self.PublicServerUrl = env_public_server_url
+			env_public_url = os.getenv("PUBLIC_URL")
+			if env_public_url:
+				self.PublicUrl = env_public_url
 			else:
-				self.PublicServerUrl = "http://localhost"
-				L.log(asab.LOG_NOTICE, "No public server URL configured. Falling back to {!r}.".format(self.PublicServerUrl))
+				self.PublicUrl = "http://localhost"
+				L.log(asab.LOG_NOTICE, "No public server URL configured. Falling back to {!r}.".format(self.PublicUrl))
 
 		# Ensure that the URL ends with a slash
-		self.PublicServerUrl = self.PublicServerUrl.rstrip("/") + "/"
-		if not (self.PublicServerUrl.startswith("https://") or self.PublicServerUrl.startswith("http://")):
+		self.PublicUrl = self.PublicUrl.rstrip("/") + "/"
+		if not (self.PublicUrl.startswith("https://") or self.PublicUrl.startswith("http://")):
 			raise ValueError(
 				"The value of 'public_base_url' in 'general' config section does not start "
-				"with 'https://' or 'http://' ({!r}). Please supply a full absolute URL.".format(self.PublicServerUrl))
-		if self.PublicServerUrl.startswith("http://"):
+				"with 'https://' or 'http://' ({!r}). Please supply a full absolute URL.".format(self.PublicUrl))
+		if self.PublicUrl.startswith("http://"):
 			L.warning(
 				"Seacat Auth public interface is running on plain insecure HTTP ({!r}). "
-				"This may limit the functionality of certain components.".format(self.PublicServerUrl))
+				"This may limit the functionality of certain components.".format(self.PublicUrl))
 
 		# Public base URL of Seacat Auth API
 		#   Canonically, this is "${PUBLIC_SERVER_URL}/api/seacat-auth/",
@@ -365,7 +365,7 @@ class SeaCatAuthApplication(asab.Application):
 			or self.PublicSeacatAuthApiUrl.startswith("http://")
 		):
 			# Relative URL: Append to PublicBaseUrl
-			self.PublicSeacatAuthApiUrl = urllib.parse.urljoin(self.PublicServerUrl, self.PublicSeacatAuthApiUrl)
+			self.PublicSeacatAuthApiUrl = urllib.parse.urljoin(self.PublicUrl, self.PublicSeacatAuthApiUrl)
 
 		# Public base URL of OpenID Connect API
 		#   Canonically, this is "${PUBLIC_SERVER_URL}/api/openidconnect/",
@@ -377,7 +377,7 @@ class SeaCatAuthApplication(asab.Application):
 			or self.PublicOpenIdConnectApiUrl.startswith("http://")
 		):
 			# Relative URL: Append to PublicBaseUrl
-			self.PublicOpenIdConnectApiUrl = urllib.parse.urljoin(self.PublicServerUrl, self.PublicOpenIdConnectApiUrl)
+			self.PublicOpenIdConnectApiUrl = urllib.parse.urljoin(self.PublicUrl, self.PublicOpenIdConnectApiUrl)
 
 		# Seacat Auth WebUI URL
 		#   Canonically, this is "${PUBLIC_SERVER_URL}/auth/",
@@ -389,4 +389,4 @@ class SeaCatAuthApplication(asab.Application):
 			or self.AuthWebUiUrl.startswith("http://")
 		):
 			# Relative URL: Append to PublicBaseUrl
-			self.AuthWebUiUrl = urllib.parse.urljoin(self.PublicServerUrl, self.AuthWebUiUrl)
+			self.AuthWebUiUrl = urllib.parse.urljoin(self.PublicUrl, self.AuthWebUiUrl)

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -48,7 +48,7 @@ class WebAuthnService(asab.Service):
 
 		self.Origin = asab.Config.get("seacatauth:webauthn", "origin", fallback=None)
 		if self.Origin is None:
-			auth_webui_base_url = asab.Config.get("general", "auth_webui_base_url")
+			auth_webui_base_url = app.AuthWebUiUrl.rstrip("/")
 			parsed = urllib.parse.urlparse(auth_webui_base_url)
 			self.Origin = "{}://{}".format(parsed.scheme, parsed.netloc)
 

--- a/seacatauth/communication/service.py
+++ b/seacatauth/communication/service.py
@@ -55,7 +55,7 @@ class CommunicationService(asab.Service):
 		self.DefaultLocale = asab.Config.get("seacatauth:communication", "default_locale")
 		self.AppName = asab.Config.get("seacatauth:communication", "app_name", fallback=None)
 		if self.AppName is None:
-			auth_webui_base_url = asab.Config.get("general", "auth_webui_base_url")
+			auth_webui_base_url = app.AuthWebUiUrl
 			parsed = urllib.parse.urlparse(auth_webui_base_url)
 			self.AppName = parsed.netloc
 		self.CommunicationProviders: typing.Dict[str, CommunicationProviderABC] = {}

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -384,7 +384,7 @@ class CookieHandler(object):
 			redirect_uri = parameters["redirect_uri"]
 		else:
 			# Fallback to client URI or Auth UI
-			redirect_uri = client.get("client_uri") or self.CookieService.AuthWebUiBaseUrl
+			redirect_uri = client.get("client_uri") or self.CookieService.AuthWebUiBaseUrl.rstrip("/")
 
 		# Set track ID if not set yet
 		if session.TrackId is None:

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -55,7 +55,7 @@ class CookieService(asab.Service):
 		if self.RootCookieDomain is not None:
 			self.RootCookieDomain = self._validate_cookie_domain(self.RootCookieDomain)
 
-		self.AuthWebUiBaseUrl = asab.Config.get("general", "auth_webui_base_url")
+		self.AuthWebUiBaseUrl = app.AuthWebUiUrl.rstrip("/")
 
 
 	async def initialize(self, app):

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -29,7 +29,7 @@ class ChangePasswordService(asab.Service):
 		self.AuditService = app.get_service("seacatauth.AuditService")
 		self.StorageService = app.get_service("asab.StorageService")
 
-		self.AuthWebUIBaseUrl = asab.Config.get("general", "auth_webui_base_url").rstrip("/")
+		self.AuthWebUIBaseUrl = app.AuthWebUiUrl.rstrip("/")
 		self.Expiration = asab.Config.getseconds("seacatauth:password", "password_reset_expiration")
 
 		self.ResetPwdPath = "/#/reset-password"

--- a/seacatauth/credentials/registration/service.py
+++ b/seacatauth/credentials/registration/service.py
@@ -29,7 +29,7 @@ class RegistrationService(asab.Service):
 		self.AuditService = app.get_service("seacatauth.AuditService")
 		self.StorageService = app.get_service("asab.StorageService")
 
-		self.AuthWebUIBaseUrl = asab.Config.get("general", "auth_webui_base_url").rstrip("/")
+		self.AuthWebUIBaseUrl = app.AuthWebUiUrl.rstrip("/")
 
 		self.RegistrationExpiration = asab.Config.getseconds("seacatauth:registration", "expiration")
 

--- a/seacatauth/external_login/providers/generic.py
+++ b/seacatauth/external_login/providers/generic.py
@@ -104,7 +104,7 @@ class GenericOAuth2Login(asab.Configurable):
 		public_api_base_url = self.Config.get("public_api_base_url")
 		if public_api_base_url is None:
 			# Fallback to general public_api_base_url
-			public_api_base_url = asab.Config.get("general", "public_api_base_url")
+			public_api_base_url = external_login_svc.App.PublicSeacatAuthApiUrl
 
 		self.JwkSet = None
 

--- a/seacatauth/external_login/service.py
+++ b/seacatauth/external_login/service.py
@@ -37,7 +37,7 @@ class ExternalLoginService(asab.Service):
 
 		self.RegistrationWebhookUri = asab.Config.get(
 			"seacatauth:external_login", "registration_webhook_uri").rstrip("/")
-		self.AuthUiBaseUrl = asab.Config.get("general", "auth_webui_base_url").rstrip("/")
+		self.AuthUiBaseUrl = app.AuthWebUiUrl
 		self.HomeUiFragmentPath = "/"
 		self.LoginUiFragmentPath = "/login"
 		self.ExternalLoginPath = "/public/ext-login/{ext_login_provider}"

--- a/seacatauth/openidconnect/__init__.py
+++ b/seacatauth/openidconnect/__init__.py
@@ -19,8 +19,8 @@ class OpenIdConnectModule(asab.Module):
 	def __init__(self, app):
 		super().__init__(app)
 
-		public_api_base_url = asab.Config.get("general", "public_api_base_url")
-		auth_webui_base_url = asab.Config.get("general", "auth_webui_base_url")
+		public_api_base_url = app.PublicOpenIdConnectApiUrl
+		auth_webui_base_url = app.AuthWebUiUrl
 
 		self.OpenIdConnectService = OpenIdConnectService(app)
 		self.CredentialsService = app.get_service("seacatauth.CredentialsService")

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -79,18 +79,11 @@ class AuthorizeHandler(object):
 		self.OpenIdConnectService = oidc_svc
 		self.CredentialsService = credentials_svc
 
-		if public_api_base_url.endswith("/"):
-			self.PublicApiBaseUrl = public_api_base_url[:-1]
-		else:
-			self.PublicApiBaseUrl = public_api_base_url
+		self.PublicApiBaseUrl = public_api_base_url
+		self.AuthWebuiBaseUrl = auth_webui_base_url
 
-		if auth_webui_base_url.endswith("/"):
-			self.AuthWebuiBaseUrl = auth_webui_base_url[:-1]
-		else:
-			self.AuthWebuiBaseUrl = auth_webui_base_url
-
-		self.LoginPath = "/#/login"
-		self.HomePath = "/#/"
+		self.LoginPath = "#/login"
+		self.HomePath = "#/"
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get(self.AuthorizePath, self.authorize_get)

--- a/seacatauth/openidconnect/handler/discovery.py
+++ b/seacatauth/openidconnect/handler/discovery.py
@@ -50,20 +50,20 @@ class DiscoveryHandler(object):
 			# REQUIRED
 			"issuer": self.OpenIdConnectService.Issuer,
 			"authorization_endpoint": "{}{}".format(
-				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.AuthorizePath),
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.AuthorizePath.lstrip("/")),
 			"token_endpoint": "{}{}".format(
-				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.TokenPath),
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.TokenPath.lstrip("/")),
 			# TODO: The algorithm RS256 MUST be included.
 			#  (https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata)
 			"id_token_signing_alg_values_supported": ["ES256"],
 			"jwks_uri": "{}{}".format(
-				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.JwksPath),
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.JwksPath.lstrip("/")),
 			"response_types_supported": ["code"],
 			"subject_types_supported": ["public"],
 
 			# RECOMMENDED
 			"userinfo_endpoint": "{}{}".format(
-				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.UserInfoPath),
+				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.UserInfoPath.lstrip("/")),
 			# "registration_endpoint": "{}/public/client/register",  # TODO: Implement a PUBLIC client registration API
 			"scopes_supported": [
 				"openid", "profile", "email", "phone",

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -61,11 +61,7 @@ class OpenIdConnectService(asab.Service):
 		self.AuditService = app.get_service("seacatauth.AuditService")
 		self.PKCE = pkce.PKCE()  # TODO: Restructure. This is OAuth, but not OpenID Connect!
 
-		public_api_base_url = asab.Config.get("general", "public_api_base_url")
-		if public_api_base_url.endswith("/"):
-			self.PublicApiBaseUrl = public_api_base_url[:-1]
-		else:
-			self.PublicApiBaseUrl = public_api_base_url
+		self.PublicApiBaseUrl = app.PublicOpenIdConnectApiUrl
 
 		self.BearerRealm = asab.Config.get("openidconnect", "bearer_realm")
 
@@ -81,7 +77,7 @@ class OpenIdConnectService(asab.Service):
 					"and has no query or fragment components.")
 		else:
 			# Default fallback option
-			self.Issuer = self.PublicApiBaseUrl
+			self.Issuer = self.PublicApiBaseUrl.rstrip("/")
 
 		self.AuthorizationCodeTimeout = datetime.timedelta(
 			seconds=asab.Config.getseconds("openidconnect", "auth_code_timeout")
@@ -516,7 +512,7 @@ class OpenIdConnectService(asab.Service):
 		# TODO: This should be removed. There must be only one authorize endpoint.
 		authorize_uri = client_dict.get("authorize_uri")
 		if authorize_uri is None:
-			authorize_uri = "{}{}".format(self.PublicApiBaseUrl, self.AuthorizePath)
+			authorize_uri = "{}{}".format(self.PublicApiBaseUrl, self.AuthorizePath.lstrip("/"))
 		return add_params_to_url_query(authorize_uri, **{k: v for k, v in query_params.items() if v is not None})
 
 

--- a/seacatauth/otp/service.py
+++ b/seacatauth/otp/service.py
@@ -28,7 +28,7 @@ class OTPService(asab.Service):
 		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
 		self.Issuer = asab.Config.get("seacatauth:otp", "issuer")
 		if len(self.Issuer) == 0:
-			auth_webui_base_url = asab.Config.get("general", "auth_webui_base_url")
+			auth_webui_base_url = app.AuthWebUiUrl.rstrip("/")
 			self.Issuer = str(urllib.parse.urlparse(auth_webui_base_url).hostname)
 		self.RegistrationTimeout = datetime.timedelta(
 			seconds=asab.Config.getseconds("seacatauth:otp", "registration_timeout")

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -139,7 +139,7 @@ class ProvisioningService(asab.Service):
 		admin_ui_client_id = self.Config["admin_ui_client_id"]
 		admin_ui_url = self.Config["admin_ui_url"].rstrip("/") or None
 		if admin_ui_url is None:
-			auth_webui_base_url = asab.Config.get("general", "auth_webui_base_url")
+			auth_webui_base_url = self.App.AuthWebUiUrl
 			url = urllib.parse.urlparse(auth_webui_base_url)
 			# Use the base URL without path by default, to fit all common deployments
 			admin_ui_url = url._replace(path="", fragment="", query="", params="").geturl()


### PR DESCRIPTION
# Summary
- Simplify public URL configuration to just one option: `public_server_url` in the `general` section.
- Public server URL can be also supplied via `PUBLIC_URL` environment variable.
- All necessary public URLs (login page, public API, OpenID Connect API, WebAuthn issuer name ...) are derived from `public_url` in canonical deployments.

# Canonical locations
- `public_url` defaults to `http://localhost` (but produces a warning on app initialization).

## Seacat Auth API
- prefix `${PUBLIC_URL}/api/seacat-auth/`
- endpoint URL example `https://example.com/api/seacat-auth/public/login`

## OpenID Connect API
- prefix `${PUBLIC_URL}/api/`
- endpoint URL example `https://example.com/api/openidconnect/authorize`

## Seacat Auth WebUI
- URL `${PUBLIC_URL}/auth/`
- Page URL example `https://example.com/auth/#/login`
