### PR TITLE
Check suspended credentials before login and password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v23.47
 
 ### Pre-releases
+- `v23.47-alpha6`
+- `v23.47-beta`
 - `v23.47-alpha5`
 - `v23.47-alpha4`
 - `v23.47-alpha3`
@@ -18,6 +20,7 @@
 - ~~Config section 'batman:elk' renamed to 'batman:kibana' (#281, `v23.47-alpha`)~~
 
 ### Fix
+- Check suspended credentials before login and password reset (#334, `v23.47-alpha6`)
 - Fixed Batman Kibana component initialization (#333, `v23.47-alpha5`)
 
 ### Features

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -113,12 +113,18 @@ class AuthenticationHandler(object):
 			# Empty credentials is used for creating a fake login session
 			credentials_id = ""
 
-		# Deny login to m2m credentials
 		if credentials_id != "":
+			# M2M credentials produce a fake login session
 			cred_provider = self.CredentialsService.get_provider(credentials_id)
 			if cred_provider.Type == "m2m":
 				L.warning("Cannot login with machine credentials.", struct_data={"cid": credentials_id})
 				# Empty credentials is used for creating a fake login session
+				credentials_id = ""
+
+			# Suspended credentials produce a fake login session
+			credentials = await self.CredentialsService.get(credentials_id)
+			if credentials.get("suspended") is True:
+				L.warning("Login denied to suspended credentials", struct_data={"cid": credentials_id})
 				credentials_id = ""
 
 		# Prepare login descriptors

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -74,12 +74,6 @@ class ChangePasswordHandler(object):
 		# Change the password
 		try:
 			await self.ChangePasswordService.change_password(credentials_id, new_password)
-		except exceptions.CredentialsSuspendedError:
-			AuditLogger.log(asab.LOG_NOTICE, "Password change denied: Credentials suspended", struct_data={
-				"cid": credentials_id})
-			await self.LastActivityService.update_last_activity(
-				EventCode.PASSWORD_CHANGE_FAILED, credentials_id=credentials_id, from_ip=from_ip)
-			return asab.web.rest.json_response(request, status=401, data={"result": "FAILED"})
 		except Exception as e:
 			L.exception("Password change failed: {}".format(e))
 			AuditLogger.log(asab.LOG_NOTICE, "Password change failed: {}".format(e.__class__.__name__), struct_data={

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -126,8 +126,13 @@ class ChangePasswordService(asab.Service):
 	async def change_password(self, credentials_id: str, new_password: str):
 		provider = self.CredentialsService.get_provider(credentials_id)
 
-		# Remove "password" from enforced factors
 		credentials = await self.CredentialsService.get(credentials_id)
+
+		# Verify that the credentials are not suspended
+		if credentials.get("suspended") is True:
+			raise exceptions.CredentialsSuspendedError(credentials_id)
+
+		# Remove "password" from enforced factors
 		enforce_factors = set(credentials.get("enforce_factors", []))
 		if "password" in enforce_factors:
 			enforce_factors.remove("password")

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -4,7 +4,7 @@ import datetime
 
 import asab
 
-from ... import exceptions, AuditLogger
+from ... import exceptions
 from ...generic import generate_ergonomic_token
 from ...events import EventTypes
 

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -4,7 +4,7 @@ import datetime
 
 import asab
 
-from ... import exceptions
+from ... import exceptions, AuditLogger
 from ...generic import generate_ergonomic_token
 from ...events import EventTypes
 
@@ -92,16 +92,17 @@ class ChangePasswordService(asab.Service):
 
 
 	async def init_password_change(self, credentials_id: str, is_new_user: bool = False, expiration: float = None):
-		'''
-		Parameter `new` states, if the user has been just created, so maybe a different email will be sent to him/her
-		Parameter `expires_in` is in seconds.
-		'''
-
-		# Verify if credentials exists
+		"""
+		Create a password reset link and send it to the user via email or other way
+		"""
+		# Verify that credentials exists
 		creds = await self.CredentialsService.get(credentials_id)
 		if creds is None:
-			L.error("Cannot find credentials", struct_data={"cid": credentials_id})
-			return False
+			raise exceptions.CredentialsNotFoundError(credentials_id)
+
+		# Deny password reset to suspended credentials
+		if creds.get("suspended") is True:
+			raise exceptions.CredentialsSuspendedError(credentials_id)
 
 		pwdreset_token = await self.create_password_reset_token(credentials_id=credentials_id, expiration=expiration)
 
@@ -115,12 +116,11 @@ class ChangePasswordService(asab.Service):
 		)
 
 		if successful:
-			L.log(asab.LOG_NOTICE, "Password change initiated", struct_data={"cid": credentials_id})
-			return True
+			L.log(asab.LOG_NOTICE, "Password reset initiated", struct_data={"cid": credentials_id})
 		else:
 			await self.delete_password_reset_token(pwdreset_token)
 			raise exceptions.CommunicationError(
-				"Failed to send password reset link.", credentials_id=credentials_id)
+				"Failed to send password reset link", credentials_id=credentials_id)
 
 
 	async def change_password(self, credentials_id: str, new_password: str):

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -5,6 +5,7 @@ import asab.web.rest
 import asab.web.webcrypto
 import asab.exceptions
 
+from .. import exceptions
 from ..decorators import access_control
 from .schemas import (
 	CREATE_CREDENTIALS,
@@ -399,7 +400,11 @@ class CredentialsHandler(object):
 		if password_link:
 			# TODO: Separate password creation from password reset
 			crd_svc = self.SessionService.App.get_service("seacatauth.ChangePasswordService")
-			await crd_svc.init_password_change(credentials_id, is_new_user=True)
+			try:
+				await crd_svc.init_password_change(credentials_id, is_new_user=True)
+			except exceptions.CommunicationError:
+				L.error("Password reset failed: Failed to send password change link", struct_data={
+					"cid": credentials_id})
 
 		return asab.web.rest.json_response(request, {
 			"status": "OK",

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -50,8 +50,8 @@ class NoTenantsError(AccessDeniedError):
 	Subject has access to no tenants.
 	"""
 	def __init__(self, subject=None, *args):
-		self.Subject = subject
-		super().__init__("Subject has access to no tenant.", *args)
+		super().__init__(
+			"Subject {!r} does not have access to any tenant".format(self.Subject), subject=subject, *args)
 
 
 class TenantNotFoundError(SeacatAuthError, KeyError):
@@ -60,7 +60,7 @@ class TenantNotFoundError(SeacatAuthError, KeyError):
 	"""
 	def __init__(self, tenant, *args):
 		self.Tenant = tenant
-		super().__init__("Tenant not found.", *args)
+		super().__init__("Tenant {!r} not found".format(self.Tenant), *args)
 
 
 class RoleNotFoundError(SeacatAuthError, KeyError):
@@ -69,7 +69,7 @@ class RoleNotFoundError(SeacatAuthError, KeyError):
 	"""
 	def __init__(self, role, *args):
 		self.Role = role
-		super().__init__("Role not found.", *args)
+		super().__init__("Role {!r} not found".format(self.Role), *args)
 
 
 class CredentialsNotFoundError(SeacatAuthError, KeyError):
@@ -78,18 +78,31 @@ class CredentialsNotFoundError(SeacatAuthError, KeyError):
 	"""
 	def __init__(self, credentials_id, *args):
 		self.CredentialsId = credentials_id
-		super().__init__("Credentials not found.", *args)
+		super().__init__("Credentials {!r} not found".format(self.CredentialsId), *args)
+
+
+class CredentialsSuspendedError(SeacatAuthError):
+	"""
+	Credentials not active
+	"""
+	def __init__(self, credentials_id, *args):
+		self.CredentialsId = credentials_id
+		super().__init__("Credentials {!r} suspended".format(self.CredentialsId), *args)
 
 
 class UnauthorizedTenantAccessError(AccessDeniedError):
 	"""
 	Session not authorized for the tenant.
 	"""
-	def __init__(self, session_id, tenant, credentials_id=None, *args):
-		self.SessionId = session_id
+	def __init__(self, session, tenant, credentials_id=None, *args):
+		self.Session = session
 		self.CredentialsId = credentials_id
 		self.Tenant = tenant
-		super().__init__("Credentials are not authorized under tenant.", *args)
+		super().__init__(
+			"{!r} is not authorized to access tenant {!r}".format(self.Session, self.Tenant),
+			subject=self.CredentialsId,
+			*args
+		)
 
 
 class TenantNotAssignedError(SeacatAuthError, KeyError):


### PR DESCRIPTION
- The suspended status is checked at the beginning of the login process, at login prologue time.
- **`CRITICAL`** Password reset is now disabled for suspended credentials. The check is performed both before the reset token is created and before the password is changed.