### PR TITLE
Well-known endpoints in the private container are available without auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - ~~Config section 'batman:elk' renamed to 'batman:kibana' (#281, `v23.47-alpha`)~~
 
 ### Fix
+- Well-known endpoints in the private container are available without auth (#335, `v23.47-alpha6`)
 - Check suspended credentials before login and password reset (#334, `v23.47-alpha6`)
 - Fixed Batman Kibana component initialization (#333, `v23.47-alpha5`)
 

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -46,11 +46,20 @@ def private_auth_middleware_factory(app):
 		[asab:api:auth]
 		bearer=xtA4J9c6KK3g_Y0VplS_Rz4xmoVoU1QWrwz9CHz2p3aTpHzOkr0yp3xhcbkJK-Z0
 		"""
-		if request.path.startswith("/nginx/") and request.method == "POST":
-			# NGINX introspection endpoints handle authorization on their own
+		request.Session = None
+
+		if request.path.startswith("/nginx/"):
+			# NGINX introspection endpoints handle authentication on their own
 			return await handler(request)
 
-		request.Session = None
+		elif request.path.startswith("/.well-known/"):
+			# Well-known endpoints use no authentication
+			return await handler(request)
+
+		elif request.path.startswith("/openidconnect/"):
+			# OpenID Connect endpoints use custom authentication
+			return await handler(request)
+
 		token_value = get_bearer_token_value(request)
 		if token_value is not None:
 			try:

--- a/seacatauth/middleware.py
+++ b/seacatauth/middleware.py
@@ -56,10 +56,6 @@ def private_auth_middleware_factory(app):
 			# Well-known endpoints use no authentication
 			return await handler(request)
 
-		elif request.path.startswith("/openidconnect/"):
-			# OpenID Connect endpoints use custom authentication
-			return await handler(request)
-
 		token_value = get_bearer_token_value(request)
 		if token_value is not None:
 			try:


### PR DESCRIPTION
- Well-known endpoints must be accessible without any authentication, even in the private container
- `/.well-known/jwks.json` - JSON Web Key Set (the server's public keys)
- `/.well-known/openid-configuration` - OpenID Connect provider metadata