### PR TITLE
Initialize batman service regardless of configuration

### DIFF
--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -128,15 +128,9 @@ class SeaCatAuthApplication(asab.Application):
 		self.CookieService = CookieService(self)
 		self.CookieHandler = CookieHandler(self, self.CookieService, self.SessionService, self.CredentialService)
 
-		# Initialize Batman if requested so in config
-		self.BatmanService = None
-		self.BatmanHandler = None
-		for section in asab.Config.sections():
-			if section.startswith("batman"):
-				from .batman import BatmanService, BatmanHandler
-				self.BatmanService = BatmanService(self)
-				self.BatmanHandler = BatmanHandler(self, self.BatmanService)
-				break
+		from .batman import BatmanService, BatmanHandler
+		self.BatmanService = BatmanService(self)
+		self.BatmanHandler = BatmanHandler(self, self.BatmanService)
 
 		from .authn.webauthn import WebAuthnService, WebAuthnHandler
 		self.WebAuthnService = WebAuthnService(self)

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -37,7 +37,7 @@ class AuthenticationHandler(object):
 		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
 		self.SessionService = app.get_service("seacatauth.SessionService")
 		self.CookieService = app.get_service("seacatauth.CookieService")
-		self.BatmanService = app.BatmanService
+		self.BatmanService = app.get_service("seacatauth.BatmanService")
 		self.CommunicationService = app.get_service("seacatauth.CommunicationService")
 
 		web_app = app.WebContainer.WebApp


### PR DESCRIPTION
Authorization request with `scope=batman...` requires batman service even if neither kibana nor grafana are active. That's why it needs to be initialized in any case.