### PR TITLE
Deprecate "seacat:access" resource ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 # CHANGELOG
 
+## v24.06
+
+### Pre-releases
+- `v24.06-alpha1`
+
+### Features
+- Deprecate "seacat:access" resource ID (#341, `v24.06-alpha1`)
+
+---
+
+
 ## v23.47
 
 ### Pre-releases
+- `v23.47-beta2`
 - `v23.47-alpha7`
 - `v23.47-alpha6`
 - `v23.47-beta`

--- a/docs/access/resources.md
+++ b/docs/access/resources.md
@@ -49,4 +49,3 @@ The following resources are automatically available in an installation of SeaCat
 * `seacat:session:access`: List sessions and view session details.
 * `seacat:credentials:edit`: Edit and suspend credentials.
 * `seacat:credentials:access`: List credentials and view credentials details.
-* `seacat:access`: Access to Seacat Admin API and UI.

--- a/docs/installation/provisioning.md
+++ b/docs/installation/provisioning.md
@@ -51,10 +51,8 @@ In the WebUI you will see that a provisioning tenant and a provisioning role hav
 ## Setting up the environment
 
 - **Create a tenant.** Any user must have at least one tenant assigned to them to be allowed into SeaCat WebUI.
-- **Create a superuser role.** To be able to execute some administrative commands it is necessary to have a superuser role assigned. This role must be created as **global**. After creating it, open the role detail and add the `authz:superuser` resource into the role. It is advisable to have at least one user with superuser rights.
-- `OPTIONAL` **Create a seacat-user role.** If you are using resource-based authorization in SeaCat WebUI or API, it is useful to have a role that allows its bearer to access the SeaCat WebUI but doesn't grant them superuser administrative rights. Create a role and assign the `seacat:access` resource to it.
 - **Create a user account.** The password will be sent via email or SMS, depending on what contact info you fill in. **Make sure that your SMTP or SMS provider is set up properly in SeaCat Auth config.**
-- Open the user detail and **assign the tenant and the role** that you created earlier.
+- Open the user detail and **assign the tenant** that you created earlier and the **`*/superuser` role**.
 - You can now log out of the provisioning superuser session.
 - Check if you have received the reset password link for your new credentials. Proceed to reset the password and then log in!
 

--- a/docs/reference/resources.md
+++ b/docs/reference/resources.md
@@ -33,8 +33,6 @@ title: Resources
 
 ## SeaCat Auth admin resources
 
-### `seacat:access`
-
 ### `authz:superuser`
 
 ### `authz:tenant:access`

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -71,10 +71,6 @@ asab.Config.add_defaults({
 		# Specifies if non-public endpoints require authentication
 		"require_authentication": "yes",
 
-		# Specifies resource required for API access
-		# If set to "DISABLED", no authorization is required
-		"authorization_resource": "seacat:access",
-
 		# DEV ONLY!
 		# Allow authentication via access token
 		# This imposes the risk of the access token being misused by 3rd party app (user impersonation)

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -22,9 +22,6 @@ class ResourceService(asab.Service):
 
 	# TODO: gather these system resources automatically
 	_BuiltinResources = {
-		"seacat:access": {
-			"description": "Access to Seacat Admin API and UI.",
-		},
 		"authz:superuser": {
 			"description": "Grants superuser access, including the access to all tenants.",
 		},


### PR DESCRIPTION
- Users no longer need to have `seacat:access` assigned to be able to access Seacat Admin API. All admin endpoints already have their own specific resource identifiers (sucha as `seacat:credentials:edit`, `seacat:client:access` etc.); there is no need for double protection.