### PR TITLE
Add new "/account"- prefixed paths for account management endpoints

### DIFF
--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -51,13 +51,13 @@ class AuthenticationHandler(object):
 		self.CommunicationService = app.get_service("seacatauth.CommunicationService")
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_put(r"/public/login.prologue", self.login_prologue)
-		web_app.router.add_put(r"/public/login/{lsid}", self.login)
-		web_app.router.add_put(r"/public/login/{lsid}/smslogin", self.prepare_smslogin_challenge)
-		web_app.router.add_put(r"/public/login/{lsid}/webauthn", self.prepare_webauthn_login_challenge)
-		web_app.router.add_put(r"/public/logout", self.logout)
-		web_app.router.add_put("/impersonate", self.impersonate)
-		web_app.router.add_post("/impersonate", self.impersonate_and_redirect)
+		web_app.router.add_put("/public/login.prologue", self.login_prologue)
+		web_app.router.add_put("/public/login/{lsid}", self.login)
+		web_app.router.add_put("/public/login/{lsid}/smslogin", self.prepare_smslogin_challenge)
+		web_app.router.add_put("/public/login/{lsid}/webauthn", self.prepare_webauthn_login_challenge)
+		web_app.router.add_put("/public/logout", self.logout)
+		web_app.router.add_put("/account/impersonate", self.impersonate)
+		web_app.router.add_post("/account/impersonate", self.impersonate_and_redirect)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
@@ -66,8 +66,14 @@ class AuthenticationHandler(object):
 		web_app_public.router.add_put(r"/public/login/{lsid}/smslogin", self.prepare_smslogin_challenge)
 		web_app_public.router.add_put(r"/public/login/{lsid}/webauthn", self.prepare_webauthn_login_challenge)
 		web_app_public.router.add_put(r"/public/logout", self.logout)
+
+		# Back-compat; To be removed in next major version
+		# >>>
+		web_app.router.add_put("/impersonate", self.impersonate)
+		web_app.router.add_post("/impersonate", self.impersonate_and_redirect)
 		web_app_public.router.add_put("/impersonate", self.impersonate)
 		web_app_public.router.add_post("/impersonate", self.impersonate_and_redirect)
+		# <<<
 
 
 	@asab.web.rest.json_schema_handler({

--- a/seacatauth/authn/webauthn/handler.py
+++ b/seacatauth/authn/webauthn/handler.py
@@ -28,19 +28,27 @@ class WebAuthnHandler(object):
 		self.WebAuthnService = webauthn_svc
 
 		web_app = app.WebContainer.WebApp
+		web_app.router.add_get("/account/webauthn/register-options", self.get_registration_options)
+		web_app.router.add_put("/account/webauthn/register", self.register_credential)
+		web_app.router.add_delete("/account/webauthn/{wacid}", self.remove_credential)
+		web_app.router.add_put("/account/webauthn/{wacid}", self.update_credential)
+		web_app.router.add_get("/account/webauthn", self.list_credentials)
+
+		# Back-compat; To be removed in next major version
+		# >>>
 		web_app.router.add_get('/public/webauthn/register-options', self.get_registration_options)
 		web_app.router.add_put('/public/webauthn/register', self.register_credential)
 		web_app.router.add_delete('/public/webauthn/{wacid}', self.remove_credential)
 		web_app.router.add_put('/public/webauthn/{wacid}', self.update_credential)
 		web_app.router.add_get('/public/webauthn', self.list_credentials)
 
-		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_get('/public/webauthn/register-options', self.get_registration_options)
 		web_app_public.router.add_put('/public/webauthn/register', self.register_credential)
 		web_app_public.router.add_delete('/public/webauthn/{wacid}', self.remove_credential)
 		web_app_public.router.add_put('/public/webauthn/{wacid}', self.update_credential)
 		web_app_public.router.add_get('/public/webauthn', self.list_credentials)
+		# <<<
 
 
 	@access_control()

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -31,14 +31,19 @@ class ChangePasswordHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_put("/password", self.admin_request_password_change)
-		web_app.router.add_put("/public/password-change", self.change_password)
+		web_app.router.add_put("/account/password-change", self.change_password)
 		web_app.router.add_put("/public/password-reset", self.reset_password)
 		web_app.router.add_put("/public/lost-password", self.lost_password)
 
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_put("/public/password-change", self.change_password)
 		web_app_public.router.add_put("/public/password-reset", self.reset_password)
 		web_app_public.router.add_put("/public/lost-password", self.lost_password)
+
+		# Back-compat; To be removed in next major version
+		# >>>
+		web_app.router.add_put("/public/password-change", self.change_password)
+		web_app_public.router.add_put("/public/password-change", self.change_password)
+		# <<<
 
 
 	@asab.web.rest.json_schema_handler({

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -48,20 +48,25 @@ class CredentialsHandler(object):
 		web_app.router.add_put("/credentials/{credentials_id}", self.update_credentials)
 		web_app.router.add_delete("/credentials/{credentials_id}", self.delete_credentials)
 
+		web_app.router.add_get("/provider/{provider_id}", self.get_provider_info)
+		web_app.router.add_get("/providers", self.list_providers)
+		web_app.router.add_put("/enforce-factors/{credentials_id}", self.enforce_factors)
+
+		web_app.router.add_get("/account/provider", self.get_my_provider_info)
+		web_app.router.add_put("/account/credentials", self.update_my_credentials)
+		web_app.router.add_get("/account/last_login", self.get_my_last_login_data)
+
+		# Back-compat; To be removed in next major version
+		# >>>
+		web_app.router.add_get("/public/provider", self.get_my_provider_info)
 		web_app.router.add_put("/public/credentials", self.update_my_credentials)
 		web_app.router.add_get("/public/last_login", self.get_my_last_login_data)
 
-		# Providers
-		web_app.router.add_get("/provider/{provider_id}", self.get_provider_info)
-		web_app.router.add_get("/providers", self.list_providers)
-		web_app.router.add_get("/public/provider", self.get_my_provider_info)
-		web_app.router.add_put("/enforce-factors/{credentials_id}", self.enforce_factors)
-
-		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp
 		web_app_public.router.add_put("/public/credentials", self.update_my_credentials)
 		web_app_public.router.add_get("/public/provider", self.get_my_provider_info)
 		web_app_public.router.add_get("/public/last_login", self.get_my_last_login_data)
+		# <<<
 
 
 	@access_control("seacat:credentials:access")

--- a/seacatauth/otp/handler.py
+++ b/seacatauth/otp/handler.py
@@ -27,14 +27,20 @@ class OTPHandler(object):
 		web_app_public = app.PublicWebContainer.WebApp
 
 		web_app = app.WebContainer.WebApp
+		web_app.router.add_get("/account/totp", self.prepare_totp_if_not_active)
+		web_app.router.add_put("/account/set-totp", self.set_totp)
+		web_app.router.add_put("/account/unset-totp", self.unset_totp)
+
+		# Back-compat; To be removed in next major version
+		# >>>
 		web_app.router.add_get("/public/totp", self.prepare_totp_if_not_active)
 		web_app.router.add_put("/public/set-totp", self.set_totp)
 		web_app.router.add_put("/public/unset-totp", self.unset_totp)
 
-		# Public endpoints
 		web_app_public.router.add_get("/public/totp", self.prepare_totp_if_not_active)
 		web_app_public.router.add_put("/public/set-totp", self.set_totp)
 		web_app_public.router.add_put("/public/unset-totp", self.unset_totp)
+		# <<<
 
 	@access_control()
 	async def prepare_totp_if_not_active(self, request, *, credentials_id):

--- a/seacatauth/session/handler.py
+++ b/seacatauth/session/handler.py
@@ -26,18 +26,22 @@ class SessionHandler(object):
 		self.SessionService = session_svc
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_get(r"/session", self.session_list)
-		web_app.router.add_get(r"/session/{session_id}", self.session_detail)
-		web_app.router.add_delete(r"/session/{session_id}", self.session_delete)
-		web_app.router.add_delete(r"/sessions", self.delete_all)
-		web_app.router.add_get(r"/sessions/{credentials_id}", self.search_by_credentials_id)
-		web_app.router.add_delete(r"/sessions/{credentials_id}", self.delete_by_credentials_id)
+		web_app.router.add_get("/session", self.session_list)
+		web_app.router.add_get("/session/{session_id}", self.session_detail)
+		web_app.router.add_delete("/session/{session_id}", self.session_delete)
+		web_app.router.add_delete("/sessions", self.delete_all)
+		web_app.router.add_get("/sessions/{credentials_id}", self.search_by_credentials_id)
+		web_app.router.add_delete("/sessions/{credentials_id}", self.delete_by_credentials_id)
 
-		web_app.router.add_delete(r"/public/sessions", self.delete_own_sessions)
+		web_app.router.add_delete("/account/sessions", self.delete_own_sessions)
 
-		# Public aliases
+		# Back-compat; To be removed in next major version
+		# >>>
+		web_app.router.add_delete("/public/sessions", self.delete_own_sessions)
+
 		web_app_public = app.PublicWebContainer.WebApp
-		web_app_public.router.add_delete(r"/public/sessions", self.delete_own_sessions)
+		web_app_public.router.add_delete("/public/sessions", self.delete_own_sessions)
+		# <<<
 
 
 	@access_control("seacat:session:access")


### PR DESCRIPTION
- All user account management endpoint paths are now prefixed with `/account/`
- The original paths are temporarily preserved for backward compatibility