### PR TITLE
Grafana OAuth documentation

### DIFF
--- a/docs/integrations/grafana.md
+++ b/docs/integrations/grafana.md
@@ -7,32 +7,55 @@ title: Grafana
 Grafana has native support for OAuth authorization flow, so connecting it to Seacat Auth is quite straightforward. 
 
 - In Seacat Admin UI, register a new client for grafana. Note down the client ID.
-- Configure generic OAuth in the Grafana section in your `docker-compose.yaml` file through environment variables
+- Configure Grafana to use your Seacat Auth instance as a Generic OAuth provider. This can be either done in Grafana config file, or perhaps more conveniently using environment variables in your `docker-compose.yaml` file:
 
 ```yaml
 services:
   grafana:
-    user: "0"
-    restart: on-failure:3
     image: grafana/grafana:10.3.1
     network_mode: host
-    volumes:
-      - ./grafana/data:/var/lib/grafana
+    (...)
     environment:
+      # URL where Grafana is accessible in the browser
       GF_SERVER_ROOT_URL: ${PUBLIC_URL}/grafana/
+      # Where the user is redirected after pressing the "Sign out" button
       GF_AUTH_SIGNOUT_REDIRECT_URL: ${PUBLIC_URL}
+      # Enable OAuth login
       GF_AUTH_GENERIC_OAUTH_ENABLED: true
-      GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE: true
-      GF_AUTH_GENERIC_OAUTH_AUTO_LOGIN: true
-      GF_AUTH_GENERIC_OAUTH_USE_PKCE: false
-      GF_AUTH_GENERIC_OAUTH_USE_REFRESH_TOKEN: false
-      GF_AUTH_GENERIC_OAUTH_NAME: Seacat Auth
+      # Client ID issued by Seacat Auth
       GF_AUTH_GENERIC_OAUTH_CLIENT_ID: ${GRAFANA_CLIENT_ID}
+      # Client secret issued by Seacat Auth (not supported yet)
       GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ""
+      # OAuth scopes that Grafana will request from Seacat Auth
       GF_AUTH_GENERIC_OAUTH_SCOPES: openid email profile
+      # Public URL of Seacat Auth OAuth Authorization endpoint
       GF_AUTH_GENERIC_OAUTH_AUTH_URL: ${PUBLIC_URL}/api/openidconnect/authorize
-      GF_AUTH_GENERIC_OAUTH_TOKEN_URL: http://${PUBLIC_SEACAT_AUTH_NETLOC}/openidconnect/token
-      GF_AUTH_GENERIC_OAUTH_API_URL: http://${PUBLIC_SEACAT_AUTH_NETLOC}/openidconnect/userinfo
-      GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT: true
+      # Internal URL of Seacat Auth OAuth Token endpoint
+      GF_AUTH_GENERIC_OAUTH_TOKEN_URL: ${INTERNAL_SEACAT_AUTH_URL}/openidconnect/token
+      # Internal URL of Seacat Auth OAuth Userinfo endpoint
+      GF_AUTH_GENERIC_OAUTH_API_URL: ${INTERNAL_SEACAT_AUTH_URL}/openidconnect/userinfo
+      # Try to skip the Grafana login screen and sign the user in automatically
+      GF_AUTH_GENERIC_OAUTH_AUTO_LOGIN: true
+      # Disable PKCE
+      GF_AUTH_GENERIC_OAUTH_USE_PKCE: false
+      # Disable refresh tokens (not supported yet)
+      GF_AUTH_GENERIC_OAUTH_USE_REFRESH_TOKEN: false
+      # OAuth provider name displayed on the "Sign in with ..." button on the Grafana login screen
+      GF_AUTH_GENERIC_OAUTH_NAME: Seacat Auth
+      # JMESPath expression that assigns the user a role depending on the authorized resources in their Userinfo or ID token
       GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: contains(resources."*"[*], 'authz:superuser') && 'Admin' || contains(resources."*"[*], 'grafana:edit') && 'Editor' || contains(resources."*"[*], 'grafana:access') && 'Viewer'
+      # Deny login if the user is not authorized for any of the resources in the expression above
+      GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT: true
+```
+
+- `PUBLIC_URL` is the base URL from which Seacat Auth is accessed from the browser, for example `https://example.com`.
+- `INTERNAL_SEACAT_AUTH_URL` is the internal URL of Seacat Auth's private web container, typically `http://localhost:8900`.
+- `GRAFANA_CLIENT_ID` is the client ID issued by Seacat Auth.
+
+**NOTE:** The above configuration assumes that Grafana backend communicates with Seacat Auth server via secure internal network (usually a VPN). 
+If this is not the case and the two services have no shared internal network, configure `GF_AUTH_GENERIC_OAUTH_TOKEN_URL` and `GF_AUTH_GENERIC_OAUTH_API_URL` using public URLs.
+
+If this is your testing environment and you are using a self-signed SSL certificate, you will need to add the following switch as well.
+```yaml
+GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE: true
 ```

--- a/docs/integrations/grafana.md
+++ b/docs/integrations/grafana.md
@@ -4,16 +4,16 @@ title: Grafana
 
 # Using Seacat authorization in Grafana
 
-This guide will show you how to set up [Grafana](https://grafana.com/) to use Seacat Auth login and access control.
-Grafana has native support for OAuth authorization flow, so connecting it to Seacat Auth is quite straightforward. 
+This guide will show you how to set up [Grafana](https://grafana.com/) so you can use Seacat Auth for logging in and access control.
+Grafana has native support for OAuth authorization flow, so connecting it to Seacat Auth is quite straightforward.
 
-- Register a new client for your Grafana application in the Clients section of Seacat Admin UI. Note down the client ID.
-- Create the following resource IDs in the Resources section of Seacat Admin UI (or choose different names, but remember to change them in Grafana `role_attribute_path` configuration below):
-  - `grafana:access` - will be mapped to [Grafana's _Viewer_ role](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles), 
+1. Register a new client for your Grafana application in the **Clients** section of Seacat Admin UI. Note down the client ID.
+2. Create the following resource IDs in the **Resources** section of the Seacat Admin UI (or choose different names, but remember to change them in Grafana `role_attribute_path` configuration below):
+    - `grafana:access`: Will be mapped to [Grafana's _Viewer_ role](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles), 
     which allows the user to browse dashboards and other data, but not to create or change anything.
-  - `grafana:edit` - will be mapped to [Grafana's _Editor_ role](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles), 
+    - `grafana:edit`: Will be mapped to [Grafana's _Editor_ role](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles), 
     which allows the user to browse and edit dashboards and other data.
-- Configure Grafana to use your Seacat Auth instance as a [Generic OAuth provider](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/).
+3. Configure Grafana to use your Seacat Auth instance as a [Generic OAuth provider](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/).
   This can be either done in Grafana config file, or perhaps more conveniently using environment variables in your `docker-compose.yaml` file as following:
 
 ```yaml

--- a/docs/integrations/grafana.md
+++ b/docs/integrations/grafana.md
@@ -4,10 +4,17 @@ title: Grafana
 
 # Using Seacat authorization in Grafana
 
+This guide will show you how to set up [Grafana](https://grafana.com/) to use Seacat Auth login and access control.
 Grafana has native support for OAuth authorization flow, so connecting it to Seacat Auth is quite straightforward. 
 
-- In Seacat Admin UI, register a new client for grafana. Note down the client ID.
-- Configure Grafana to use your Seacat Auth instance as a Generic OAuth provider. This can be either done in Grafana config file, or perhaps more conveniently using environment variables in your `docker-compose.yaml` file:
+- Register a new client for your Grafana application in the Clients section of Seacat Admin UI. Note down the client ID.
+- Create the following resource IDs in the Resources section of Seacat Admin UI (or choose different names, but remember to change them in Grafana `role_attribute_path` configuration below):
+  - `grafana:access` - will be mapped to [Grafana's _Viewer_ role](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles), 
+    which allows the user to browse dashboards and other data, but not to create or change anything.
+  - `grafana:edit` - will be mapped to [Grafana's _Editor_ role](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/#organization-roles), 
+    which allows the user to browse and edit dashboards and other data.
+- Configure Grafana to use your Seacat Auth instance as a [Generic OAuth provider](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/).
+  This can be either done in Grafana config file, or perhaps more conveniently using environment variables in your `docker-compose.yaml` file as following:
 
 ```yaml
 services:
@@ -16,10 +23,9 @@ services:
     network_mode: host
     (...)
     environment:
+      ## Required configuration options
       # URL where Grafana is accessible in the browser
       GF_SERVER_ROOT_URL: ${PUBLIC_URL}/grafana/
-      # Where the user is redirected after pressing the "Sign out" button
-      GF_AUTH_SIGNOUT_REDIRECT_URL: ${PUBLIC_URL}
       # Enable OAuth login
       GF_AUTH_GENERIC_OAUTH_ENABLED: true
       # Client ID issued by Seacat Auth
@@ -34,7 +40,11 @@ services:
       GF_AUTH_GENERIC_OAUTH_TOKEN_URL: ${INTERNAL_SEACAT_AUTH_URL}/openidconnect/token
       # Internal URL of Seacat Auth OAuth Userinfo endpoint
       GF_AUTH_GENERIC_OAUTH_API_URL: ${INTERNAL_SEACAT_AUTH_URL}/openidconnect/userinfo
-      # Try to skip the Grafana login screen and sign the user in automatically
+      
+      ## Additional useful configuration options
+      # Where the user is redirected after pressing the "Sign out" button
+      GF_AUTH_SIGNOUT_REDIRECT_URL: ${PUBLIC_URL}
+      # Skip Grafana login screen and sign the user in automatically
       GF_AUTH_GENERIC_OAUTH_AUTO_LOGIN: true
       # Disable PKCE
       GF_AUTH_GENERIC_OAUTH_USE_PKCE: false
@@ -42,8 +52,15 @@ services:
       GF_AUTH_GENERIC_OAUTH_USE_REFRESH_TOKEN: false
       # OAuth provider name displayed on the "Sign in with ..." button on the Grafana login screen
       GF_AUTH_GENERIC_OAUTH_NAME: Seacat Auth
-      # JMESPath expression that assigns the user a role depending on the authorized resources in their Userinfo or ID token
-      GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: contains(resources."*"[*], 'authz:superuser') && 'Admin' || contains(resources."*"[*], 'grafana:edit') && 'Editor' || contains(resources."*"[*], 'grafana:access') && 'Viewer'
+      # Get the user login name and screen name primarily from OpenID Connect standard field "preferred_username", with fallback to "username" and "sub" fields
+      GF_AUTH_GENERIC_OAUTH_LOGIN_ATTRIBUTE_PATH: preferred_username || username || sub
+      GF_AUTH_GENERIC_OAUTH_NAME_ATTRIBUTE_PATH: preferred_username || username || sub
+      # Control user permissions using Seacat Auth authorized resources:
+      #   The following JMESPath expression assigns the user a Grafana role depending on the authorized resources in their ID token or Userinfo
+      GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: >
+        contains(resources."*"[*], 'authz:superuser') && 'Admin' 
+        || contains(resources."*"[*], 'grafana:edit') && 'Editor' 
+        || contains(resources."*"[*], 'grafana:access') && 'Viewer'
       # Deny login if the user is not authorized for any of the resources in the expression above
       GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT: true
 ```
@@ -55,7 +72,9 @@ services:
 **NOTE:** The above configuration assumes that Grafana backend communicates with Seacat Auth server via secure internal network (usually a VPN). 
 If this is not the case and the two services have no shared internal network, configure `GF_AUTH_GENERIC_OAUTH_TOKEN_URL` and `GF_AUTH_GENERIC_OAUTH_API_URL` using public URLs.
 
-If this is your testing environment and you are using a self-signed SSL certificate, you will need to add the following switch as well.
+If this is your testing environment and you are using a self-signed SSL certificate, you will need to add the following switch as well:
 ```yaml
 GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE: true
 ```
+
+For more details about Grafana OAuth configuration, [refer to its documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/generic-oauth/).

--- a/docs/integrations/grafana.md
+++ b/docs/integrations/grafana.md
@@ -2,4 +2,37 @@
 title: Grafana
 ---
 
-# Connecting to Grafana
+# Using Seacat authorization in Grafana
+
+Grafana has native support for OAuth authorization flow, so connecting it to Seacat Auth is quite straightforward. 
+
+- In Seacat Admin UI, register a new client for grafana. Note down the client ID.
+- Configure generic OAuth in the Grafana section in your `docker-compose.yaml` file through environment variables
+
+```yaml
+services:
+  grafana:
+    user: "0"
+    restart: on-failure:3
+    image: grafana/grafana:10.3.1
+    network_mode: host
+    volumes:
+      - ./grafana/data:/var/lib/grafana
+    environment:
+      GF_SERVER_ROOT_URL: ${PUBLIC_URL}/grafana/
+      GF_AUTH_SIGNOUT_REDIRECT_URL: ${PUBLIC_URL}
+      GF_AUTH_GENERIC_OAUTH_ENABLED: true
+      GF_AUTH_GENERIC_OAUTH_TLS_SKIP_VERIFY_INSECURE: true
+      GF_AUTH_GENERIC_OAUTH_AUTO_LOGIN: true
+      GF_AUTH_GENERIC_OAUTH_USE_PKCE: false
+      GF_AUTH_GENERIC_OAUTH_USE_REFRESH_TOKEN: false
+      GF_AUTH_GENERIC_OAUTH_NAME: Seacat Auth
+      GF_AUTH_GENERIC_OAUTH_CLIENT_ID: ${GRAFANA_CLIENT_ID}
+      GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: ""
+      GF_AUTH_GENERIC_OAUTH_SCOPES: openid email profile
+      GF_AUTH_GENERIC_OAUTH_AUTH_URL: ${PUBLIC_URL}/api/openidconnect/authorize
+      GF_AUTH_GENERIC_OAUTH_TOKEN_URL: http://${PUBLIC_SEACAT_AUTH_NETLOC}/openidconnect/token
+      GF_AUTH_GENERIC_OAUTH_API_URL: http://${PUBLIC_SEACAT_AUTH_NETLOC}/openidconnect/userinfo
+      GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_STRICT: true
+      GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: contains(resources."*"[*], 'authz:superuser') && 'Admin' || contains(resources."*"[*], 'grafana:edit') && 'Editor' || contains(resources."*"[*], 'grafana:access') && 'Viewer'
+```

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -9,7 +9,7 @@ Thanks to such integration, you may use your Active Directory, LDAP or social lo
 
  * [TheHive](the-hive)
  * [ElasticSearch/Kibana](elk)
- * Grafana
+ * [Grafana](grafana)
 
 ## NGINX
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,8 @@ nav:
       - integrations/oauth2-introspect.md
       - Connecting other apps:
         - integrations/cookies.md
-        - integrations/elk.md     
+        - integrations/elk.md
+        - integrations/grafana.md
         - integrations/the-hive.md
   
     - Development:

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -2,6 +2,7 @@ import re
 import logging
 import aiohttp
 import aiohttp.client_exceptions
+import asab
 import asab.config
 
 from seacatauth.authz import build_credentials_authz
@@ -33,6 +34,9 @@ class GrafanaIntegration(asab.config.Configurable):
 
 	def __init__(self, batman_svc, config_section_name="batman:grafana", config=None):
 		super().__init__(config_section_name=config_section_name, config=config)
+		asab.LogObsolete.warning(
+			"Batman for Grafana is deprecated. Please use Grafana generic OAuth instead.",
+			struct_data={"eol": "2024-12-31"})
 		self.BatmanService = batman_svc
 		self.TenantService = self.BatmanService.App.get_service("seacatauth.TenantService")
 		self.RoleService = self.BatmanService.App.get_service("seacatauth.RoleService")


### PR DESCRIPTION
- Document setting up Grafana with Seacat Auth OAuth.
- Add deprecation warning for Batman for Grafana.