### PR TITLE
Fix typo in last login path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## v24.06
 
 ### Pre-releases
-- `v24.06-alpha1`
+- `v24.06-alpha4`
+- `v24.06-alpha3`
 - `v24.06-alpha2`
+- `v24.06-alpha1`
 
 ### Fix
+- Fix typo in last login endpoint path (#346, `v24.06-alpha4`)
 - Fix the initialization of NoTenantsError (#346, `v24.06-alpha2`)
 
 ### Features

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -54,7 +54,7 @@ class CredentialsHandler(object):
 
 		web_app.router.add_get("/account/provider", self.get_my_provider_info)
 		web_app.router.add_put("/account/credentials", self.update_my_credentials)
-		web_app.router.add_get("/account/last_login", self.get_my_last_login_data)
+		web_app.router.add_get("/account/last-login", self.get_my_last_login_data)
 
 		# Back-compat; To be removed in next major version
 		# >>>


### PR DESCRIPTION
Replace `_` with `-` in last login endpoint path for uniformity.