### PR TITLE
Improve error handling in FIDO MDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## v24.06
 
 ### Pre-releases
+- `v24.06-alpha5`
 - `v24.06-alpha4`
 - `v24.06-alpha3`
 - `v24.06-alpha2`
 - `v24.06-alpha1`
 
 ### Fix
+- Improve error handling in FIDO MDS (#351, `v24.06-alpha5`)
 - Fix typo in last login endpoint path (#346, `v24.06-alpha4`)
 - Fix the initialization of NoTenantsError (#346, `v24.06-alpha2`)
 


### PR DESCRIPTION
- Handle connection errors gracefully.
- Supply your own MDS JWT file URL (or local file path) using the `metadata_service_url` option in `seacatauth:webauthn` config section.
- Disable the metadata service by configuring `metadata_service_url` in `seacatauth:webauthn` to `DISABLED`.