### PR TITLE
Account web UI migration tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.06
 
 ### Pre-releases
+- `v24.06-alpha10`
 - `v24.06-beta3`
 - `v24.06-alpha9`
 - `v24.06-alpha8`
@@ -20,6 +21,7 @@
 - Disable special characters in tenant ID (#349, `v24.06-alpha6`)
 
 ### Fix
+- Better TOTP error responses (#352, `v24.06-alpha10`)
 - Fix resource editability (#355, `v24.06-alpha9`)
 - Make FIDO MDS request non-blocking using TaskService (#354, `v24.06-alpha8`)
 - Improve error handling in FIDO MDS (#351, `v24.06-alpha5`)
@@ -27,6 +29,7 @@
 - Fix the initialization of NoTenantsError (#346, `v24.06-alpha2`)
 
 ### Features
+- External login provider label contains just the display name (#352, `v24.06-alpha10`)
 - ElasticSearch index and Kibana space authorization (#353, `v24.06-alpha7.2`)
 - Disable special characters in tenant ID (#349, `v24.06-alpha6`)
 - New paths for account management endpoints (#343, `v24.06-alpha3`)

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -279,6 +279,13 @@ class AuthenticationService(asab.Service):
 	def get_login_factor(self, factor_type):
 		return self.LoginFactors[factor_type]
 
+	async def get_eligible_factors(self, credentials_id: str):
+		return [
+			factor.Type
+			for factor in self.LoginFactors.values()
+			if await factor.is_eligible({"credentials_id": credentials_id})
+		]
+
 	def create_login_factor(self, factor_config):
 		self.LoginFactors[factor_config["type"]] = login_factor_builder(self, factor_config)
 		return self.LoginFactors[factor_config["type"]]

--- a/seacatauth/authn/webauthn/handler.py
+++ b/seacatauth/authn/webauthn/handler.py
@@ -140,7 +140,8 @@ class WebAuthnHandler(object):
 		"properties": {
 			"name": {
 				"type": "string",
-				"pattern": "^[a-z][a-z0-9._-]{0,128}[a-z0-9]$"
+				"minLength": 3,
+				"maxLength": 128,
 			},
 		}
 	})

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -191,11 +191,17 @@ class CookieService(asab.Service):
 			])
 
 		if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
+			external_login_service = self.App.get_service("seacatauth.ExternalLoginService")
+			available_factors = await self.AuthenticationService.get_eligible_factors(root_session.Credentials.Id)
+			available_external_logins = {
+				result["t"]: result["s"]
+				for result in await external_login_service.list(root_session.Credentials.Id)
+			}
 			session_builders.append([
 				(SessionAdapter.FN.Authentication.LoginDescriptor, root_session.Authentication.LoginDescriptor),
 				(SessionAdapter.FN.Authentication.LoginFactors, root_session.Authentication.LoginFactors),
-				(SessionAdapter.FN.Authentication.ExternalLoginOptions, root_session.Authentication.ExternalLoginOptions),
-				(SessionAdapter.FN.Authentication.AvailableFactors, root_session.Authentication.AvailableFactors),
+				(SessionAdapter.FN.Authentication.AvailableFactors, available_factors),
+				(SessionAdapter.FN.Authentication.ExternalLoginOptions, available_external_logins),
 			])
 
 		if root_session.TrackId is not None:

--- a/seacatauth/credentials/schemas.py
+++ b/seacatauth/credentials/schemas.py
@@ -13,6 +13,7 @@ _FIELDS = {
 		"description": "Email address",
 		"anyOf": [
 			{"type": "null"},
+			{"type": "string", "const": ""},
 			{"type": "string", "format": "email"},
 		],
 	},
@@ -20,6 +21,7 @@ _FIELDS = {
 		"description": "Mobile number",
 		"anyOf": [
 			{"type": "null"},
+			{"type": "string", "const": ""},
 			{"type": "string", "pattern": r"^\+?[0-9 ]+$"},
 		],
 	},

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -123,9 +123,18 @@ class TenantNotAssignedError(SeacatAuthError, KeyError):
 		super().__init__("Credentials do not have the tenant assigned.", *args)
 
 
-class TOTPError(SeacatAuthError):
+class TOTPActivationError(SeacatAuthError):
 	"""
-	Failed to activate, verify or deactivate TOTP
+	Failed to activate TOTP
+	"""
+	def __init__(self, message: str, credentials_id: str):
+		self.CredentialsID: str = credentials_id
+		super().__init__(message)
+
+
+class TOTPDeactivationError(SeacatAuthError):
+	"""
+	Failed to deactivate TOTP
 	"""
 	def __init__(self, message: str, credentials_id: str):
 		self.CredentialsID: str = credentials_id

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -123,13 +123,13 @@ class TenantNotAssignedError(SeacatAuthError, KeyError):
 		super().__init__("Credentials do not have the tenant assigned.", *args)
 
 
-class TOTPNotActiveError(SeacatAuthError):
+class TOTPError(SeacatAuthError):
 	"""
-	Credentials do not have any registered TOTP secret
+	Failed to activate, verify or deactivate TOTP
 	"""
-	def __init__(self, credential_id: str):
-		self.CredentialID: str = credential_id
-		super().__init__("TOTP not active for credentials.")
+	def __init__(self, message: str, credentials_id: str):
+		self.CredentialsID: str = credentials_id
+		super().__init__(message)
 
 
 class ClientResponseError(SeacatAuthError):

--- a/seacatauth/external_login/providers/appleid.py
+++ b/seacatauth/external_login/providers/appleid.py
@@ -35,7 +35,7 @@ class AppleIDOAuth2Login(GenericOAuth2Login):
 		"token_endpoint": "https://appleid.apple.com/auth/token",
 		"jwks_uri": "https://appleid.apple.com/auth/keys",
 		"scope": "name email",
-		"label": "Sign in with Apple",
+		"label": "AppleID",
 	}
 
 	def __init__(self, external_login_svc, config_section_name, config=None):

--- a/seacatauth/external_login/providers/facebook.py
+++ b/seacatauth/external_login/providers/facebook.py
@@ -33,7 +33,7 @@ class FacebookOAuth2Login(GenericOAuth2Login):
 		"response_type": "code",
 		"scope": "public_profile",
 		"fields": "id,name,email",
-		"label": "Sign in with Facebook",
+		"label": "Facebook",
 	}
 
 	def __init__(self, external_login_svc, config_section_name):

--- a/seacatauth/external_login/providers/github.py
+++ b/seacatauth/external_login/providers/github.py
@@ -27,7 +27,7 @@ class GitHubOAuth2Login(GenericOAuth2Login):
 		"userinfo_endpoint": "https://api.github.com/user",
 		"user_emails_endpoint": "https://api.github.com/user/emails",
 		"scope": "user:email",  # Scope is not used
-		"label": "Sign in with Github",
+		"label": "Github",
 	}
 
 	def __init__(self, external_login_svc, config_section_name):

--- a/seacatauth/external_login/providers/google.py
+++ b/seacatauth/external_login/providers/google.py
@@ -18,5 +18,5 @@ class GoogleOAuth2Login(GenericOAuth2Login):
 		"authorization_endpoint": "https://accounts.google.com/o/oauth2/auth",
 		"token_endpoint": "https://accounts.google.com/o/oauth2/token",
 		"scope": "openid profile email",
-		"label": "Sign in with Google",
+		"label": "Google",
 	}

--- a/seacatauth/external_login/providers/mojeid.py
+++ b/seacatauth/external_login/providers/mojeid.py
@@ -18,7 +18,7 @@ class MojeIDOAuth2Login(GenericOAuth2Login):
 		"authorization_endpoint": "https://mojeid.cz/oidc/authorization/",
 		"token_endpoint": "https://mojeid.cz/oidc/token/",
 		"scope": "openid email phone",
-		"label": "Sign in with MojeID",
+		"label": "MojeID",
 	}
 
 	# TODO: MojeID provides extensive settings for encryption algorithms and other features.

--- a/seacatauth/external_login/providers/office365.py
+++ b/seacatauth/external_login/providers/office365.py
@@ -20,7 +20,7 @@ class Office365OAuth2Login(GenericOAuth2Login):
 		"token_endpoint": "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
 		"tenant_id": "",
 		"scope": "openid",
-		"label": "Sign in with Office365",
+		"label": "Office365",
 	}
 
 	def __init__(self, external_login_svc, config_section_name):

--- a/seacatauth/feature/handler.py
+++ b/seacatauth/feature/handler.py
@@ -23,6 +23,7 @@ class FeatureHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/public/features", self.get_features)
+		web_app.router.add_get("/account/features", self.get_features)
 
 		# Public endpoints
 		web_app_public = app.PublicWebContainer.WebApp

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -256,14 +256,18 @@ class OpenIdConnectService(asab.Service):
 		]
 
 		if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
+			authentication_service = self.App.get_service("seacatauth.AuthenticationService")
+			external_login_service = self.App.get_service("seacatauth.ExternalLoginService")
+			available_factors = await authentication_service.get_eligible_factors(root_session.Credentials.Id)
+			available_external_logins = {
+				result["t"]: result["s"]
+				for result in await external_login_service.list(root_session.Credentials.Id)
+			}
 			session_builders.append([
 				(SessionAdapter.FN.Authentication.LoginDescriptor, root_session.Authentication.LoginDescriptor),
 				(SessionAdapter.FN.Authentication.LoginFactors, root_session.Authentication.LoginFactors),
-				(SessionAdapter.FN.Authentication.AvailableFactors, root_session.Authentication.AvailableFactors),
-				(
-					SessionAdapter.FN.Authentication.ExternalLoginOptions,
-					root_session.Authentication.ExternalLoginOptions
-				),
+				(SessionAdapter.FN.Authentication.AvailableFactors, available_factors),
+				(SessionAdapter.FN.Authentication.ExternalLoginOptions, available_external_logins),
 			])
 
 		if "batman" in scope:

--- a/seacatauth/otp/service.py
+++ b/seacatauth/otp/service.py
@@ -41,21 +41,23 @@ class OTPService(asab.Service):
 		await self._delete_expired_totp_secrets()
 
 
-	async def deactivate_totp(self, credential_id: str):
+	async def deactivate_totp(self, credentials_id: str):
 		"""
 		Delete active TOTP secret for requested credentials.
 		"""
-		if not await self.has_activated_totp(credential_id):
-			raise exceptions.TOTPError(credential_id)
+		if not await self.has_activated_totp(credentials_id):
+			L.log(asab.LOG_NOTICE, "Cannot deactivate TOTP because it is already active.", struct_data={
+				"cid": credentials_id})
+			raise exceptions.TOTPDeactivationError("TOTP is not active.", credentials_id)
 		try:
-			await self.StorageService.delete(collection=self.TOTPCollection, obj_id=credential_id)
+			await self.StorageService.delete(collection=self.TOTPCollection, obj_id=credentials_id)
 		except KeyError:
 			# TOTP are stored in the old self.PreparedTOTPCollection -> only for backward compatibility
 			pass
 
 
-		provider = self.CredentialsService.get_provider(credential_id)
-		await provider.update(credential_id, {
+		provider = self.CredentialsService.get_provider(credentials_id)
+		await provider.update(credentials_id, {
 			"__totp": None
 		})
 
@@ -86,18 +88,23 @@ class OTPService(asab.Service):
 		Requires entering the generated OTP to succeed.
 		"""
 		if await self.has_activated_totp(credentials_id):
-			raise exceptions.TOTPError("TOTP is already active.", credentials_id)
+			L.log(asab.LOG_NOTICE, "Cannot activate TOTP because it is already active.", struct_data={
+				"cid": credentials_id})
+			raise exceptions.TOTPActivationError("TOTP is already active.", credentials_id)
 
 		try:
 			secret = await self._get_prepared_totp_secret_by_session_id(session.SessionId)
 		except KeyError:
-			# TOTP secret has not been initialized or has expired
-			raise exceptions.TOTPError("TOTP secret is not ready, possibly expired.", credentials_id)
+			L.log(asab.LOG_NOTICE, "Cannot activate TOTP because the secret is not ready or has expired.", struct_data={
+				"cid": credentials_id})
+			raise exceptions.TOTPActivationError("TOTP secret is not ready, or possibly has expired.", credentials_id)
 
 		totp = pyotp.TOTP(secret)
 		if totp.verify(request_otp) is False:
 			# TOTP secret does not match
-			raise exceptions.TOTPError("TOTP verification failed.", credentials_id)
+			L.log(asab.LOG_NOTICE, "Cannot activate TOTP because the verification failed.", struct_data={
+				"cid": credentials_id})
+			raise exceptions.TOTPActivationError("TOTP verification failed.", credentials_id)
 
 		# Store secret in its own dedicated collection
 		upsertor = self.StorageService.upsertor(collection=self.TOTPCollection, obj_id=credentials_id)
@@ -124,7 +131,7 @@ class OTPService(asab.Service):
 		expires: datetime.datetime = datetime.datetime.now(datetime.timezone.utc) + self.RegistrationTimeout
 		upsertor.set("exp", expires)
 
-		secret: str = pyotp.random_base32().encode("ascii")
+		secret = pyotp.random_base32().encode("ascii")
 		upsertor.set("__s", secret, encrypt=True)
 
 		await upsertor.execute(event_type=EventTypes.TOTP_CREATED)

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -70,10 +70,7 @@ def authentication_session_builder(login_descriptor):
 
 
 async def available_factors_session_builder(authentication_service, credentials_id):
-	factors = []
-	for factor in authentication_service.LoginFactors.values():
-		if await factor.is_eligible({"credentials_id": credentials_id}):
-			factors.append(factor.Type)
+	factors = await authentication_service.get_eligible_factors(credentials_id)
 	return ((SessionAdapter.FN.Authentication.AvailableFactors, factors),)
 
 


### PR DESCRIPTION
Collection of tweaks and fixes made while migrating Seacat Account Webui (http://gitlab.teskalabs.int/ateska/webui-microfrontends-poc/-/merge_requests/148)
- Move `GET /features` endpoint under `/account` since it won't be used in public API anymore.
- FIDO credential name allows any character (it should be a human-palatable name).
- External login provider `label` contains only the display name of the provider, e.g. "AppleID" instead of "Sign in with AppleID".
- TOTP error responses now have error code 400.