### PR TITLE
Revise ElasticSearch index and Kibana space authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.06
 
 ### Pre-releases
+- `v24.06-alpha7`
 - `v24.06-beta`
 - `v24.06-alpha6`
 - `v24.06-alpha5`
@@ -20,6 +21,7 @@
 - Fix the initialization of NoTenantsError (#346, `v24.06-alpha2`)
 
 ### Features
+- ElasticSearch index and Kibana space authorization (#353, `v24.06-alpha7`)
 - Disable special characters in tenant ID (#349, `v24.06-alpha6`)
 - New paths for account management endpoints (#343, `v24.06-alpha3`)
 - Deprecate "seacat:access" resource ID (#341, `v24.06-alpha1`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v24.06
 
 ### Pre-releases
-- `v24.06-alpha7`
+- `v24.06-alpha7.2`
 - `v24.06-beta`
 - `v24.06-alpha6`
 - `v24.06-alpha5`
@@ -21,7 +21,7 @@
 - Fix the initialization of NoTenantsError (#346, `v24.06-alpha2`)
 
 ### Features
-- ElasticSearch index and Kibana space authorization (#353, `v24.06-alpha7`)
+- ElasticSearch index and Kibana space authorization (#353, `v24.06-alpha7.2`)
 - Disable special characters in tenant ID (#349, `v24.06-alpha6`)
 - New paths for account management endpoints (#343, `v24.06-alpha3`)
 - Deprecate "seacat:access" resource ID (#341, `v24.06-alpha1`)

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -99,8 +99,9 @@ class ResourceService(asab.Service):
 		await self._ensure_builtin_resources()
 
 
-	def is_builtin_resource(self, resource_id):
-		return resource_id in self._BuiltinResources
+	def is_editable_resource(self, resource_id):
+		# TODO: Check the `managed_by` flag
+		return resource_id not in self._BuiltinResources
 
 
 	def is_global_only_resource(self, resource_id):
@@ -119,7 +120,7 @@ class ResourceService(asab.Service):
 			try:
 				db_resource = await self.get(resource_id)
 			except KeyError:
-				await self.create(resource_id, description)
+				await self.create(resource_id, description, is_managed_by_seacat_auth=True)
 				continue
 
 			# Update resource description
@@ -142,7 +143,7 @@ class ResourceService(asab.Service):
 		resources = []
 		count = await collection.count_documents(query_filter)
 		async for resource_dict in cursor:
-			if self.is_builtin_resource(resource_dict["_id"]):
+			if self.is_editable_resource(resource_dict["_id"]):
 				resource_dict["editable"] = False
 			if self.is_global_only_resource(resource_dict["_id"]):
 				resource_dict["global_only"] = True
@@ -156,14 +157,14 @@ class ResourceService(asab.Service):
 
 	async def get(self, resource_id: str):
 		data = await self.StorageService.get(self.ResourceCollection, resource_id)
-		if self.is_builtin_resource(data["_id"]):
+		if self.is_editable_resource(data["_id"]):
 			data["editable"] = False
 		if self.is_global_only_resource(data["_id"]):
 			data["global_only"] = True
 		return data
 
 
-	async def create(self, resource_id: str, description: str = None):
+	async def create(self, resource_id: str, description: str = None, is_managed_by_seacat_auth=False):
 		if self.ResourceIdRegex.match(resource_id) is None:
 			raise asab.exceptions.ValidationError(
 				"Resource ID must consist only of characters 'a-z0-9.:_-', "
@@ -173,6 +174,9 @@ class ResourceService(asab.Service):
 
 		if description is not None:
 			upsertor.set("description", description)
+
+		if is_managed_by_seacat_auth:
+			upsertor.set("managed_by", "seacat-auth")
 
 		try:
 			await upsertor.execute(event_type=EventTypes.RESOURCE_CREATED)
@@ -204,13 +208,13 @@ class ResourceService(asab.Service):
 
 
 	async def update(self, resource_id: str, description: str):
-		if self.is_builtin_resource(resource_id):
+		if self.is_editable_resource(resource_id):
 			raise asab.exceptions.ValidationError("Built-in resource cannot be modified")
 		await self._update(resource_id, description)
 
 
 	async def delete(self, resource_id: str, hard_delete: bool = False):
-		if self.is_builtin_resource(resource_id):
+		if self.is_editable_resource(resource_id):
 			raise asab.exceptions.ValidationError("Built-in resource cannot be deleted")
 
 		resource = await self.get(resource_id)
@@ -266,7 +270,7 @@ class ResourceService(asab.Service):
 		Shortcut for creating a new resource with the desired name,
 		assigning it to roles that have the original resource and deleting the original resource
 		"""
-		if self.is_builtin_resource(resource_id):
+		if self.is_editable_resource(resource_id):
 			raise asab.exceptions.ValidationError("Built-in resource cannot be renamed")
 
 		role_svc = self.App.get_service("seacatauth.RoleService")

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -294,7 +294,8 @@ class ElasticSearchIntegration(asab.config.Configurable):
 			except KeyError:
 				await self.ResourceService.create(
 					resource_id,
-					description=description
+					description=description,
+					is_managed_by_seacat_auth=True,
 				)
 
 	async def sync_all_credentials(self):

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -55,8 +55,8 @@ class ElasticSearchIntegration(asab.config.Configurable):
 		# There should be a role created in the ElasticSearch that grants no rights
 		"seacat_user_flag": "seacat_managed",
 
-		# What indices can be accessed by tenant members. Space-separated.
-		"tenant_indices": "lmio-{tenant}-*",
+		# What indices can be accessed by tenant members. Space-separated. Can use {tenant} variable.
+		"tenant_indices": "{tenant}-*",
 	}
 
 	EssentialKibanaResources = {
@@ -290,7 +290,6 @@ class ElasticSearchIntegration(asab.config.Configurable):
 			# No changes
 			L.debug("Kibana space metadata up to date", struct_data={
 				"space_id": space_id, "tenant_id": tenant_id})
-			return
 
 		elif existing_space:
 			# Update existing space
@@ -333,14 +332,18 @@ class ElasticSearchIntegration(asab.config.Configurable):
 		role_name = self._elastic_role_from_tenant(tenant_id, privileges)
 		role = {
 			# Add all privileges for the new space
-			"kibana": [{"spaces": [space_id], "base": [privileges]}],
+			"kibana": [
+				{"spaces": [space_id], "base": [privileges]}
+			],
 			# Add access to elasticsearch indices
-			"elasticsearch": {"indices": {
-				"names": [
-					index.format(tenant=tenant_id)
-					for index in self.TenantIndices
-				],
-				"privileges": [privileges]}
+			"elasticsearch": {
+				"indices": [{
+					"names": [
+						index.format(tenant=tenant_id)
+						for index in self.TenantIndices
+					],
+					"privileges": [privileges]
+				}]
 			}
 		}
 

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -110,7 +110,7 @@ class ElasticSearchIntegration(asab.config.Configurable):
 
 		self.Headers = self._prepare_session_headers(username, password, api_key)
 
-		self.TenantIndices = self.Config.get("tenant_indices").split(" ")
+		self.TenantIndices = re.split(r"\s+", self.Config.get("tenant_indices"))
 		self.ResourcePrefix = "kibana:"
 		self.DeprecatedResourcePrefix = "elk:"
 		self.DeprecatedResourceRegex = re.compile("^elk:")

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -333,18 +333,21 @@ class ElasticSearchIntegration(asab.config.Configurable):
 		role = {
 			# Add all privileges for the new space
 			"kibana": [
-				{"spaces": [space_id], "base": [privileges]}
+				{
+					"spaces": [space_id],
+					"base": [privileges]
+				}
 			],
 			# Add access to elasticsearch indices
-			"elasticsearch": {
-				"indices": [{
+			"elasticsearch": {"indices": [
+				{
 					"names": [
 						index.format(tenant=tenant_id)
 						for index in self.TenantIndices
 					],
 					"privileges": [privileges]
-				}]
-			}
+				}
+			]}
 		}
 
 		async with self._elasticsearch_session() as session:

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -741,7 +741,7 @@ def section_has_ssl_option(config_section_name):
 
 def get_index_access_role_name(tenant: str, privileges: str):
 	assert privileges in {"read", "all"}
-	return "tenant_{}_{}".format(tenant, privileges)
+	return "index_{}_{}".format(tenant, privileges)
 
 
 def get_space_access_role_name(tenant: str, privileges: str):

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -68,8 +68,8 @@ class ElasticSearchIntegration(asab.config.Configurable):
 
 		self.Kibana = KibanaUtils(self.App, config_section_name, config)
 
-		self.ElasticSearchUrl = self.Config.get("url")
-		self.ElasticSearchNodesUrls = get_url_list(self.ElasticSearchUrl)
+		elasticsearch_url = self.Config.get("url")
+		self.ElasticSearchNodesUrls = get_url_list(elasticsearch_url)
 		if len(self.ElasticSearchNodesUrls) == 0:
 			raise ValueError("No ElasticSearch URL has been provided")
 
@@ -218,7 +218,7 @@ class ElasticSearchIntegration(asab.config.Configurable):
 		}
 
 		async with self._elasticsearch_session() as session:
-			async with session.get("{}_security/role/{}".format(self.ElasticSearchUrl, role_name)) as resp:
+			async with session.get("{}_security/role/{}".format(random.choice(self.ElasticSearchNodesUrls), role_name)) as resp:
 				if resp.status == 200:
 					role_data = (await resp.json()).get(role_name)
 				elif resp.status == 404:
@@ -249,7 +249,7 @@ class ElasticSearchIntegration(asab.config.Configurable):
 		role_data["indices"].append(required_index_settings)
 		async with self._elasticsearch_session() as session:
 			async with session.put(
-				"{}_security/role/{}".format(self.ElasticSearchUrl, role_name), json=role_data
+				"{}_security/role/{}".format(random.choice(self.ElasticSearchNodesUrls), role_name), json=role_data
 			) as resp:
 				if not (200 <= resp.status < 300):
 					text = await resp.text()

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -413,7 +413,7 @@ class KibanaUtils(asab.config.Configurable):
 	ConfigDefaults = {
 		# Enables automatic synchronization of Kibana spaces with Seacat tenants
 		# Space sync is disabled if kibana_url is empty.
-		"kibana_url": "http://localhost:5601",
+		"kibana_url": "",
 
 		# IDs of Kibana resources
 		"kibana_read_resource_id": "tools:kibana:read",  # Read-only access to tenant space in Kibana

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -3,7 +3,6 @@ import datetime
 import re
 import ssl
 import logging
-import typing
 import aiohttp
 import aiohttp.client_exceptions
 import urllib.parse

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -242,11 +242,7 @@ class ElasticSearchIntegration(asab.config.Configurable):
 					return
 
 		# Add access to elasticsearch indices
-		if not role_data:
-			role_data = {}
-		if not role_data.get("indices"):
-			role_data["indices"] = []
-		role_data["indices"].append(required_index_settings)
+		role_data = {"indices": [required_index_settings]}
 		async with self._elasticsearch_session() as session:
 			async with session.put(
 				"{}_security/role/{}".format(random.choice(self.ElasticSearchNodesUrls), role_name), json=role_data

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -77,14 +77,16 @@ class GrafanaIntegration(asab.config.Configurable):
 		except KeyError:
 			await self.ResourceService.create(
 				_GRAFANA_ADMIN_RESOURCE,
-				description="Grants admin access to Grafana."
+				description="Grants admin access to Grafana.",
+				is_managed_by_seacat_auth=True,
 			)
 		try:
 			await self.ResourceService.get(_GRAFANA_USER_RESOURCE)
 		except KeyError:
 			await self.ResourceService.create(
 				_GRAFANA_USER_RESOURCE,
-				description="Grants user access to Grafana."
+				description="Grants user access to Grafana.",
+				is_managed_by_seacat_auth=True,
 			)
 
 	async def initialize(self):


### PR DESCRIPTION
# Summary
- Tenant membership implicitly grants **read access to tenant indices** that match a pre-configured pattern.
- Separated ElasticSearch and Kibana sync operations - Kibana is optional.

# Changes
- Tenant membership implicitly grants read access to tenant indices that match the pattern `tenant-{tenant}-*`. For this purpose, an ElasticSearch role `index-{tenant}-read` is created for each Seacat tenant.
- The index name pattern can be configured via `tenant_indices` option in `batman:elasticsearch` config section, e.g.:
```ini
[batman:elasticsearch]
tenant_indices=lmio-{tenant}-*
```
- To access a tenant space in Kibana, the user must have access to `tools:kibana:read` resource (or `tools:kibana:all` for read-write access). For this purpose, Kibana roles `space-{tenant}-read` and `space-{tenant}-all` are created for each Seacat tenant.
- Resource `authz:superuser` maps to ElasticSearch role `superuser`.
- Resource `tools:kibana:admin` maps to Kibana role `kibana_admin`.
- Resource IDs can be changed using the following config options:
```ini
[batman:elasticsearch]
elasticsearch_superuser_resource_id=authz:superuser
kibana_read_resource_id=tools:kibana:read
kibana_all_resource_id=tools:kibana:all
kibana_admin_resource_id=tools:kibana:admin
```
- Removed deprecated synchronization of `elk:`-prefixed resources.
