### PR TITLE
Make FIDO MDS request non-blocking using TaskService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.06
 
 ### Pre-releases
+- `v24.06-alpha8`
 - `v24.06-beta2`
 - `v24.06-alpha7.2`
 - `v24.06-beta`
@@ -17,6 +18,7 @@
 - Disable special characters in tenant ID (#349, `v24.06-alpha6`)
 
 ### Fix
+- Make FIDO MDS request non-blocking using TaskService (#354, `v24.06-alpha8`)
 - Improve error handling in FIDO MDS (#351, `v24.06-alpha5`)
 - Fix typo in last login endpoint path (#346, `v24.06-alpha4`)
 - Fix the initialization of NoTenantsError (#346, `v24.06-alpha2`)

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -3,7 +3,6 @@ import datetime
 import json
 import logging
 import secrets
-import typing
 import urllib.parse
 
 import aiohttp

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -109,11 +109,14 @@ class WebAuthnService(asab.Service):
 					async with session.get(self.FidoMetadataServiceUrl) as resp:
 						if resp.status != 200:
 							text = await resp.text()
-							L.error("Failed to fetch FIDO metadata:\n{}".format(text[:1000]))
+							L.info(
+								"FIDO Metadata Service responded with error:\n{!r}.".format(text[:1000]),
+								struct_data={"status": resp.status}
+							)
 							return
 						jwt = await resp.text()
 			except (TimeoutError, ConnectionError) as e:
-				L.info("FIDO metadata service is unreachable ({}).".format(e.__class__.__name__))
+				L.info("FIDO Metadata Service is unreachable ({}: {}).".format(e.__class__.__name__, e))
 				return
 
 		else:

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -107,14 +107,15 @@ class WebAuthnService(asab.Service):
 			try:
 				async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
 					async with session.get(self.FidoMetadataServiceUrl) as resp:
-						if resp.status != 200:
+						if resp.status == 200:
+							jwt = await resp.text()
+						else:
 							text = await resp.text()
 							L.info(
 								"FIDO Metadata Service responded with error:\n{!r}.".format(text[:1000]),
 								struct_data={"status": resp.status}
 							)
 							return
-						jwt = await resp.text()
 			except (TimeoutError, ConnectionError) as e:
 				L.info("FIDO Metadata Service is unreachable ({}: {}).".format(e.__class__.__name__, e))
 				return

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -113,7 +113,7 @@ class WebAuthnService(asab.Service):
 							return
 						jwt = await resp.text()
 			except (TimeoutError, ConnectionError) as e:
-				L.log(asab.LOG_NOTICE, "FIDO metadata service is unreachable ({}).".format(e.__class__.__name__))
+				L.info("FIDO metadata service is unreachable ({}).".format(e.__class__.__name__))
 				return
 
 		else:


### PR DESCRIPTION
- FIDO metadata request is made by Task Service to prevent blocking the application.
- Request timeout is lowered to 30 seconds.