### PR TITLE
Client cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix the initialization of NoTenantsError (#346, `v24.06-alpha2`)
 
 ### Features
+- Client cache (#361, `v24.06-alpha13`)
 - Update OpenAPI specs (#360, `v24.06-alpha12`)
 - Client secret management (#359, `v24.06-alpha11`)
 - External login provider label contains just the display name (#352, `v24.06-alpha10`)

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -47,10 +47,11 @@ asab.Config.add_defaults({
 	},
 
 	"seacatauth:client": {
-		# How long until the secret expires
+		# How long until the secret expires.
+		# Set to "0" to disable the expiration.
 		"client_secret_expiration": "0",
 
-		# Validity period of local client metadata cache
+		# Validity period of local client metadata cache.
 		# Set to "0" to disable cache.
 		"cache_expiration": "30 s",
 	},

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -49,6 +49,10 @@ asab.Config.add_defaults({
 	"seacatauth:client": {
 		# How long until the secret expires
 		"client_secret_expiration": "0",
+
+		# Validity period of local client metadata cache
+		# Set to "0" to disable cache.
+		"cache_expiration": "30 s",
 	},
 
 	"seacatauth:cookie": {

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -226,7 +226,7 @@ class ClientService(asab.Service):
 
 		self.Cache: typing.Optional[typing.Dict[str, typing.Tuple[dict, datetime.datetime]]] = {}
 		self.CacheExpiration = asab.Config.getseconds(
-			"seacatauth:client", "client_cache_expiration", fallback=30)
+			"seacatauth:client", "cache_expiration", fallback=30)
 		if self.CacheExpiration == 0:
 			# Disable cache
 			self.Cache = None

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import re
 import secrets
+import typing
 import urllib.parse
 import passlib.hash
 
@@ -223,6 +224,15 @@ class ClientService(asab.Service):
 		if self.ClientSecretExpiration <= 0:
 			self.ClientSecretExpiration = None
 
+		self.Cache: typing.Optional[typing.Dict[str, typing.Tuple[dict, datetime.datetime]]] = {}
+		self.CacheExpiration = asab.Config.getseconds(
+			"seacatauth:client", "client_cache_expiration", fallback=30)
+		if self.CacheExpiration == 0:
+			# Disable cache
+			self.Cache = None
+		else:
+			self.CacheExpiration = datetime.timedelta(seconds=self.CacheExpiration)
+
 		# DEV OPTIONS
 		# _allow_custom_client_ids
 		#   https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/
@@ -238,6 +248,8 @@ class ClientService(asab.Service):
 
 		if not self._AllowCustomClientID:
 			CLIENT_METADATA_SCHEMA.pop("preferred_client_id")
+
+		app.PubSub.subscribe("Application.tick/600!", self._clear_expired_cache)
 
 
 	async def initialize(self, app):
@@ -281,9 +293,27 @@ class ClientService(asab.Service):
 
 
 	async def get(self, client_id: str):
+		"""
+		Get client metadata
+
+		@param client_id:
+		@return:
+		"""
+		# Try to get client from cache
+		client = self._get_from_cache(client_id)
+		if client:
+			return client
+
+		# Get from the database
 		cookie_svc = self.App.get_service("seacatauth.CookieService")
 		client = await self.StorageService.get(self.ClientCollection, client_id)
 		client["cookie_name"] = cookie_svc.get_cookie_name(client_id)
+
+		# Store in cache
+		self.Cache[client_id] = (
+			client,
+			datetime.datetime.now(datetime.UTC) + self.CacheExpiration
+		)
 		return client
 
 
@@ -383,7 +413,9 @@ class ClientService(asab.Service):
 			upsertor.set("client_secret_expires_at", client_secret_expires_at)
 
 		await upsertor.execute(event_type=EventTypes.CLIENT_SECRET_RESET)
+		self._delete_from_cache(client_id)
 		L.log(asab.LOG_NOTICE, "Client secret updated.", struct_data={"client_id": client_id})
+
 		return client_secret, client_secret_expires_at
 
 
@@ -424,6 +456,7 @@ class ClientService(asab.Service):
 				upsertor.set(k, v)
 
 		await upsertor.execute(event_type=EventTypes.CLIENT_UPDATED)
+		self._delete_from_cache(client_id)
 		L.log(asab.LOG_NOTICE, "Client updated.", struct_data={
 			"client_id": client_id,
 			"fields": " ".join(client_update.keys())
@@ -432,6 +465,7 @@ class ClientService(asab.Service):
 
 	async def delete(self, client_id: str):
 		await self.StorageService.delete(self.ClientCollection, client_id)
+		self._delete_from_cache(client_id)
 		L.log(asab.LOG_NOTICE, "Client deleted.", struct_data={"client_id": client_id})
 
 
@@ -566,6 +600,34 @@ class ClientService(asab.Service):
 		else:
 			client_secret_expires_at = None
 		return client_secret, client_secret_expires_at
+
+
+	def _get_from_cache(self, client_id: str):
+		if self.Cache is None:
+			return None
+		if client_id not in self.Cache:
+			return None
+		client, expires_at = self.Cache[client_id]
+		if datetime.datetime.now(datetime.UTC) > expires_at:
+			del self.Cache[client_id]
+			return None
+		return client
+
+
+	def _delete_from_cache(self, client_id: str):
+		if self.Cache is not None and client_id in self.Cache:
+			del self.Cache[client_id]
+
+
+	def _clear_expired_cache(self, event_name):
+		if not self.Cache:
+			return
+		valid = {}
+		now = datetime.datetime.now(datetime.UTC)
+		for k, (v, exp) in self.Cache.items():
+			if now < exp:
+				valid[k] = v, exp
+		self.Cache = valid
 
 
 def validate_redirect_uri(redirect_uri: str, registered_uris: list, validation_method: str = "full_match"):


### PR DESCRIPTION
closes #306

Client metadata are accessed frequently, but they don't change too often. It makes sense to cache them to lower the number of database requests.

Default cache expiration is 30 seconds, it can be configured using the following option:
```ini
[seacatauth:client]
cache_expiration=5m
```

Expired cache entries are deleted every 10 minutes.

Cache is used only for get-client-detail calls, not for get-client-list.