### PR TITLE
Fix searching credentials with multiple filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Disable special characters in tenant ID (#349, `v24.06-alpha6`)
 
 ### Fix
+- Fix searching credentials with multiple filters (#362, `v24.06-alpha14`)
 - Better TOTP error responses (#352, `v24.06-alpha10`)
 - Fix resource editability (#355, `v24.06-alpha9`)
 - Make FIDO MDS request non-blocking using TaskService (#354, `v24.06-alpha8`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.06
 
 ### Pre-releases
+- `v24.06-alpha14`
 - `v24.06-alpha13`
 - `v24.06-alpha12`
 - `v24.06-alpha11`

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -217,6 +217,7 @@ class CredentialsHandler(object):
 		return asab.web.rest.json_response(request, {
 			"data": result["data"],
 			"count": result["count"],
+			"result": "OK",
 		})
 
 

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -195,8 +195,10 @@ class CredentialsHandler(object):
 		mode = request.query.get("m", "default")
 		if mode == "role":
 			search.AdvancedFilter["role"] = request.query.get("f")
+			search.SimpleFilter = None
 		elif mode == "tenant":
 			search.AdvancedFilter["tenant"] = request.query.get("f")
+			search.SimpleFilter = None
 		elif mode == "default":
 			search.SimpleFilter = request.query.get("f")
 

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -284,7 +284,6 @@ class CredentialsService(asab.Service):
 				return {"count": 0, "data": []}
 
 			credentials = []
-			total_count = estimated_count
 			filtered_cids = sorted(filtered_cids)
 
 			offset = search_params.Page * search_params.ItemsPerPage
@@ -312,7 +311,7 @@ class CredentialsService(asab.Service):
 
 			return {
 				"data": credentials,
-				"count": total_count,
+				"count": estimated_count,
 			}
 
 		# Search without external filters

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -317,7 +317,7 @@ class CredentialsService(asab.Service):
 					try:
 						provider = self.CredentialProviders[provider_id]
 						credentials.append(await provider.get(cid))
-					except None:
+					except KeyError:
 						L.info("Found an assignment of nonexisting credentials", struct_data={
 							"cid": cid, "role_ids": searched_roles, "tenant_ids": searched_tenants})
 

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -300,8 +300,8 @@ class CredentialsService(asab.Service):
 							"cid": cid, "role_ids": searched_roles, "tenant_ids": searched_tenants})
 						continue
 					if (
-							cred_data.get("username", "").startswith(search_params.SimpleFilter)
-							or cred_data.get("email", "").startswith(search_params.SimpleFilter)
+						cred_data.get("username", "").startswith(search_params.SimpleFilter)
+						or cred_data.get("email", "").startswith(search_params.SimpleFilter)
 					):
 						if offset > 0:
 							# Skip until offset is reached

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -206,6 +206,7 @@ class CredentialsService(asab.Service):
 		List credentials that are members of currently authorized tenants.
 		Global_search lists all credentials, regardless of tenants, but this requires superuser authorization.
 		"""
+		# TODO: Searching with filters is very inefficient and needs serious optimization
 		if len(search_params.AdvancedFilter) > 1:
 			raise asab.exceptions.ValidationError("No more than one advanced filter at a time is supported.")
 
@@ -260,8 +261,7 @@ class CredentialsService(asab.Service):
 		estimated_count = None
 		if searched_roles:
 			role_svc = self.App.get_service("seacatauth.RoleService")
-			assignments = await role_svc.list_role_assignments(
-				role_id=searched_roles, page=search_params.Page, limit=search_params.ItemsPerPage)
+			assignments = await role_svc.list_role_assignments(role_id=searched_roles)
 			if filtered_cids is None:
 				filtered_cids = set(a["c"] for a in assignments["data"])
 				estimated_count = assignments["count"]
@@ -271,8 +271,7 @@ class CredentialsService(asab.Service):
 		if searched_tenants:
 			tenant_svc = self.App.get_service("seacatauth.TenantService")
 			provider = tenant_svc.get_provider()
-			assignments = await provider.list_tenant_assignments(
-				searched_tenants, page=search_params.Page, limit=search_params.ItemsPerPage)
+			assignments = await provider.list_tenant_assignments(searched_tenants)
 			if filtered_cids is None:
 				filtered_cids = set(a["c"] for a in assignments["data"])
 				estimated_count = assignments["count"]
@@ -286,15 +285,41 @@ class CredentialsService(asab.Service):
 
 			credentials = []
 			total_count = estimated_count
+			filtered_cids = sorted(filtered_cids)
 
-			for cid in filtered_cids:
-				_, provider_id, _ = cid.split(":", 2)
-				try:
-					provider = self.CredentialProviders[provider_id]
-					credentials.append(await provider.get(cid))
-				except KeyError:
-					L.info("Found an assignment of nonexisting credentials", struct_data={
-						"cid": cid, "role_ids": searched_roles, "tenant_ids": searched_tenants})
+			offset = search_params.Page * search_params.ItemsPerPage
+			if search_params.SimpleFilter:
+				# String filter is specified
+				for cid in filtered_cids:
+					_, provider_id, _ = cid.split(":", 2)
+					try:
+						provider = self.CredentialProviders[provider_id]
+						cred_data = await provider.get(cid)
+					except KeyError:
+						L.info("Found an assignment of nonexisting credentials", struct_data={
+							"cid": cid, "role_ids": searched_roles, "tenant_ids": searched_tenants})
+						continue
+					if (
+							cred_data.get("username", "").startswith(search_params.SimpleFilter)
+							or cred_data.get("email", "").startswith(search_params.SimpleFilter)
+					):
+						if offset > 0:
+							# Skip until offset is reached
+							offset -= 1
+							continue
+						credentials.append(cred_data)
+						if len(credentials) >= search_params.ItemsPerPage:
+							# Page is full
+							break
+			else:
+				for cid in filtered_cids[offset:offset + search_params.ItemsPerPage]:
+					_, provider_id, _ = cid.split(":", 2)
+					try:
+						provider = self.CredentialProviders[provider_id]
+						credentials.append(await provider.get(cid))
+					except None:
+						L.info("Found an assignment of nonexisting credentials", struct_data={
+							"cid": cid, "role_ids": searched_roles, "tenant_ids": searched_tenants})
 
 			return {
 				"data": credentials,


### PR DESCRIPTION
#348 broke credentials searching with multiple filters. It is not possible to search by username when the credentials are already being filtered by tenant or role.

This provides a fix. 

# Issues

- **The fix is inefficient and will not scale.** Performance optimization will be required.
- The total credentials count is overestimated, which may break pagination. **UI needs to support listing data without known count.**