### PR TITLE
Invitation URL in response, resending invitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # CHANGELOG
 
+## v24.17
+
+### Pre-releases
+- `v24.17-alpha1`
+
+### Fix
+- Fix the initialization and updating of built-in resources (#363, `v24.06-alpha15`)
+- Fix searching credentials with multiple filters (#362, `v24.06-alpha14`)
+
+### Features
+- When invitation cannot be created because the user already exists, the invitation is re-sent (#364, `v24.17-alpha1`)
+- When no communication channel is configured, invitation and password reset URLs are returned in admin responses (#364, `v24.17-alpha1`)
+- Listing assigned tenants and roles no longer requires resource authorization (#348, `v24.06-alpha13`)
+- List credentials from authorized tenant only (#348, `v24.06-alpha13`)
+
+---
+
+
 ## v24.06
 
 ### Pre-releases
@@ -27,8 +45,6 @@
 - Disable special characters in tenant ID (#349, `v24.06-alpha6`)
 
 ### Fix
-- Fix the initialization and updating of built-in resources (#363, `v24.06-alpha15`)
-- Fix searching credentials with multiple filters (#362, `v24.06-alpha14`)
 - Better TOTP error responses (#352, `v24.06-alpha10`)
 - Fix resource editability (#355, `v24.06-alpha9`)
 - Make FIDO MDS request non-blocking using TaskService (#354, `v24.06-alpha8`)
@@ -37,8 +53,6 @@
 - Fix the initialization of NoTenantsError (#346, `v24.06-alpha2`)
 
 ### Features
-- Listing assigned tenants and roles no longer requires resource authorization (#348, `v24.06-alpha13`)
-- List credentials from authorized tenant only (#348, `v24.06-alpha13`)
 - Client cache (#361, `v24.06-alpha13`)
 - Update OpenAPI specs (#360, `v24.06-alpha12`)
 - Client secret management (#359, `v24.06-alpha11`)

--- a/seacatauth/communication/email_smtp.py
+++ b/seacatauth/communication/email_smtp.py
@@ -113,4 +113,4 @@ class SMTPProvider(CommunicationProviderABC):
 			)
 			L.log(asab.LOG_NOTICE, "Email sent", struct_data={'result': result[1]})
 
-		return True
+		return

--- a/seacatauth/communication/service.py
+++ b/seacatauth/communication/service.py
@@ -118,7 +118,6 @@ class CommunicationService(asab.Service):
 				await self.build_and_send_message(
 					template_id=template_id,
 					channel=channel,
-					app_name=self.AppName,
 					email=credentials.get("email"),
 					phone=credentials.get("phone"),
 					username=credentials.get("username"),
@@ -142,7 +141,6 @@ class CommunicationService(asab.Service):
 		await self.build_and_send_message(
 			template_id="invitation",
 			channel="email",
-			app_name=self.AppName,
 			email=credentials.get("email"),
 			username=credentials.get("username"),
 			tenants=tenants,

--- a/seacatauth/communication/service.py
+++ b/seacatauth/communication/service.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import typing
 
 import asab

--- a/seacatauth/communication/service.py
+++ b/seacatauth/communication/service.py
@@ -87,9 +87,6 @@ class CommunicationService(asab.Service):
 			else:
 				L.error("Unsupported communication provider: '{}'".format(provider_id))
 
-		if len(self.CommunicationProviders) == 0:
-			L.error("No communication provider configured.")
-
 
 	def is_enabled(self, channel=None):
 		if not channel:

--- a/seacatauth/communication/service.py
+++ b/seacatauth/communication/service.py
@@ -91,8 +91,11 @@ class CommunicationService(asab.Service):
 			L.error("No communication provider configured.")
 
 
-	def is_enabled(self):
-		return len(self.CommunicationProviders) > 0
+	def is_enabled(self, channel=None):
+		if not channel:
+			return len(self.CommunicationProviders) > 0
+		else:
+			return channel in self.CommunicationProviders
 
 	def get_communication_provider(self, channel):
 		provider = self.CommunicationProviders.get(channel)

--- a/seacatauth/communication/service.py
+++ b/seacatauth/communication/service.py
@@ -91,6 +91,9 @@ class CommunicationService(asab.Service):
 			L.error("No communication provider configured.")
 
 
+	def is_enabled(self):
+		return len(self.CommunicationProviders) > 0
+
 	def get_communication_provider(self, channel):
 		provider = self.CommunicationProviders.get(channel)
 		if provider is None:
@@ -106,7 +109,7 @@ class CommunicationService(asab.Service):
 
 
 	async def password_reset(self, *, credentials, reset_url, welcome=False):
-		if not self.CommunicationProviders:
+		if not self.is_enabled():
 			raise exceptions.CommunicationNotConfiguredError()
 		channels = ["email", "sms"]
 		template_id = "password_reset_welcome" if welcome else "password_reset"
@@ -135,6 +138,8 @@ class CommunicationService(asab.Service):
 
 
 	async def invitation(self, *, credentials, tenants, registration_uri, expires_at=None):
+		if not self.is_enabled():
+			raise exceptions.CommunicationNotConfiguredError()
 		await self.build_and_send_message(
 			template_id="invitation",
 			channel="email",
@@ -148,6 +153,8 @@ class CommunicationService(asab.Service):
 
 
 	async def sms_login(self, *, credentials: dict, otp: str):
+		if not self.is_enabled():
+			raise exceptions.CommunicationNotConfiguredError()
 		await self.build_and_send_message(
 			template_id="login_otp",
 			channel="sms",
@@ -157,6 +164,8 @@ class CommunicationService(asab.Service):
 
 
 	async def build_and_send_message(self, template_id, channel, **kwargs):
+		if not self.is_enabled():
+			raise exceptions.CommunicationNotConfiguredError()
 		try:
 			provider = self.get_communication_provider(channel)
 			message_builder = self.get_message_builder(channel)

--- a/seacatauth/communication/sms_smsbranacz.py
+++ b/seacatauth/communication/sms_smsbranacz.py
@@ -91,7 +91,7 @@ class SMSBranaCZProvider(CommunicationProviderABC):
 					asab.LOG_NOTICE, "SMSBrana.cz provider is in mock mode. Message will not be sent.",
 					struct_data=url_params
 				)
-				return True
+				return
 
 			async with aiohttp.ClientSession() as session:
 				async with session.get(self.URL, params=url_params) as resp:
@@ -105,4 +105,3 @@ class SMSBranaCZProvider(CommunicationProviderABC):
 				raise RuntimeError("SMS delivery failed.")
 			else:
 				L.log(asab.LOG_NOTICE, "SMS sent")
-		return True

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -30,7 +30,7 @@ class ChangePasswordHandler(object):
 		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_put("/password", self.admin_request_password_change)
+		web_app.router.add_put("/password", self.admin_request_password_reset)
 		web_app.router.add_put("/account/password-change", self.change_password)
 		web_app.router.add_put("/public/password-reset", self.reset_password)
 		web_app.router.add_put("/public/lost-password", self.lost_password)
@@ -177,7 +177,7 @@ class ChangePasswordHandler(object):
 		}
 	})
 	@access_control("seacat:credentials:edit")
-	async def admin_request_password_change(self, request, *, json_data):
+	async def admin_request_password_reset(self, request, *, json_data):
 		"""
 		Send a password reset link to specified user
 		"""

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -191,7 +191,6 @@ class RegistrationHandler(object):
 			)
 
 		except asab.exceptions.Conflict as e:
-			assert e.Value is not None
 			# Credentials already exist
 			# Locate the credentials by the conflicting value and use them
 			credentials_id = await self.CredentialsService.locate(credential_data["email"], stop_at_first=True)

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -190,7 +190,7 @@ class RegistrationHandler(object):
 				invited_from_ips=access_ips,
 			)
 
-		except asab.exceptions.Conflict as e:
+		except asab.exceptions.Conflict:
 			# Credentials already exist
 			# Locate the credentials by the conflicting value and use them
 			credentials_id = await self.CredentialsService.locate(credential_data["email"], stop_at_first=True)

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -235,7 +235,7 @@ class RegistrationHandler(object):
 		return credentials_id, None
 
 
-	@access_control("seacat:tenant:invite")
+	@access_control("seacat:tenant:assign")
 	async def resend_invitation(self, request):
 		"""
 		Resend invitation to an already invited user and extend the expiration of the invitation.

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -259,10 +259,9 @@ class RegistrationHandler(object):
 		tenants = await self.RegistrationService.TenantService.get_tenants(credentials_id)
 
 		await self.RegistrationService.CommunicationService.invitation(
-			email=credentials["email"],
-			registration_uri=self.RegistrationService.format_registration_uri(credentials["__registration"]["code"]),
-			username=credentials.get("username"),
+			credentials=credentials,
 			tenants=tenants,
+			registration_uri=self.RegistrationService.format_registration_uri(credentials["__registration"]["code"]),
 			expires_at=expiration,
 		)
 

--- a/seacatauth/credentials/registration/service.py
+++ b/seacatauth/credentials/registration/service.py
@@ -255,9 +255,15 @@ class RegistrationService(asab.Service):
 		reg_roles = await self.RoleService.get_roles_by_credentials(
 			reg_credential_id, reg_tenants)
 		for tenant in reg_tenants:
-			await self.TenantService.assign_tenant(credentials_id, tenant)
+			try:
+				await self.TenantService.assign_tenant(credentials_id, tenant)
+			except asab.exceptions.Conflict:
+				L.log(asab.LOG_NOTICE, "Tenant already assigned.", struct_data={"cid": credentials_id, "t": tenant})
 		for role in reg_roles:
-			await self.RoleService.assign_role(credentials_id, role)
+			try:
+				await self.RoleService.assign_role(credentials_id, role)
+			except asab.exceptions.Conflict:
+				L.log(asab.LOG_NOTICE, "Role already assigned.", struct_data={"cid": credentials_id, "r": role})
 		await self.CredentialsService.delete_credentials(reg_credential_id)
 
 		AuditLogger.log(asab.LOG_NOTICE, "Invitation accepted by an existing user", struct_data={

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -381,8 +381,11 @@ class CredentialsService(asab.Service):
 		'''
 		Find detail of credentials for a credentials_id.
 		'''
-		provider = self.get_provider(credentials_id)
-		return await provider.get(credentials_id, include=include)
+		try:
+			provider = self.get_provider(credentials_id)
+			return await provider.get(credentials_id, include=include)
+		except KeyError:
+			raise exceptions.CredentialsNotFoundError(credentials_id=credentials_id)
 
 
 	async def authenticate(self, credentials_id: str, credentials: dict) -> bool:

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -175,7 +175,7 @@ class CommunicationNotConfiguredError(SeacatAuthError):
 	"""
 	No communication channels are configured
 	"""
-	def __init__(self,  *args):
+	def __init__(self, *args):
 		super().__init__("No communication channels are configured.", *args)
 
 

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -161,13 +161,22 @@ class SessionNotFoundError(SeacatAuthError, KeyError):
 		super().__init__(message, *args)
 
 
-class CommunicationError(SeacatAuthError):
+class MessageDeliveryError(SeacatAuthError):
 	"""
-	Failed to send notification or message
+	Failed to send message
 	"""
-	def __init__(self, message, credentials_id=None, *args):
-		self.CredentialsId = credentials_id
+	def __init__(self, message, channel, template_id=None, *args):
+		self.TemplateId = template_id
+		self.Channel = channel
 		super().__init__(message, *args)
+
+
+class CommunicationNotConfiguredError(SeacatAuthError):
+	"""
+	No communication channels are configured
+	"""
+	def __init__(self,  *args):
+		super().__init__("No communication channels are configured.", *args)
 
 
 class NoCookieError(SeacatAuthError):


### PR DESCRIPTION
# Summary
- When no communication channel is configured, invitation and password reset URLs are returned in **admin** responses.
- When an invitation request is created for an email that already exists, the invitation message is resent.
- When an invitation request is created for an email of a user that is already registered, that user is simply added to the tenant.
- CommunicationService raises exceptions instead of returning `None`.
- Resending an invitation is now part of `seacat:tenant:assign` resource to keep consistency. It was ~`seacat:tenant:invite`~.