### PR TITLE
Fix flak8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v24.06
 
 ### Pre-releases
-- `v24.06-beta5`
+- `v24.06-beta6`
 - `v24.06-alpha11`
 - `v24.06-alpha10`
 - `v24.06-beta3`
@@ -23,8 +23,8 @@
 - Disable special characters in tenant ID (#349, `v24.06-alpha6`)
 
 ### Fix
-- Fix resource initialization (#365, `v24.06-beta5`)
-- Remove seacat:resource:access authorization (#365, `v24.06-beta5`)
+- Fix resource initialization (#365, `v24.06-beta6`)
+- Remove seacat:resource:access authorization (#365, `v24.06-beta6`)
 - Better TOTP error responses (#352, `v24.06-alpha10`)
 - Fix resource editability (#355, `v24.06-alpha9`)
 - Make FIDO MDS request non-blocking using TaskService (#354, `v24.06-alpha8`)

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -136,8 +136,8 @@ class ResourceService(asab.Service):
 				continue
 
 			if (
-					(db_resource.get("managed_by") != "seacat-auth")
-					or (description is not None and db_resource.get("description") != description)
+				(db_resource.get("managed_by") != "seacat-auth")
+				or (description is not None and db_resource.get("description") != description)
 			):
 				await self._update(db_resource, description, is_managed_by_seacat_auth=True)
 


### PR DESCRIPTION
- fix resource updating on init (#363) - fixes the `AttributeError: 'ResourceService' object has no attribute '_update'` error
- seacat:resource:access authorization is no longer required (included in #362) - this fixes the 403 error "Failed to fetch resources" in role detail 