### PR TITLE
Deprecate passlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         pip install bson
         pip install pymongo
         pip install bcrypt
+        pip install argon2
         pip install jwcrypto
         pip install git+https://github.com/TeskaLabs/asab.git#egg=asab[encryption]
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
         pip install bson
         pip install pymongo
         pip install jwcrypto
-        pip install passlib
         pip install git+https://github.com/TeskaLabs/asab.git#egg=asab[encryption]
     
     - name: Test with unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install bson
         pip install pymongo
+        pip install bcrypt
         pip install jwcrypto
         pip install git+https://github.com/TeskaLabs/asab.git#egg=asab[encryption]
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `v24.17-alpha1`
 
 ### Fix
+- Default provisioning tenant name mst pass validation (#368, `v24.17-alpha4`)
 - Fix the initialization and updating of built-in resources (#363, `v24.06-alpha15`)
 - Fix searching credentials with multiple filters (#362, `v24.06-alpha14`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.17
 
 ### Pre-releases
+- `v24.17-alpha4`
 - `v24.17-alpha3`
 - `v24.17-alpha2`
 - `v24.17-beta1`
@@ -19,6 +20,10 @@
 - When no communication channel is configured, invitation and password reset URLs are returned in admin responses (#364, `v24.17-alpha1`)
 - Listing assigned tenants and roles no longer requires resource authorization (#348, `v24.06-alpha13`)
 - List credentials from authorized tenant only (#348, `v24.06-alpha13`)
+
+### Refactoring
+- Deprecate passlib (#368, `v24.17-alpha4`)
+- Utility functions for password verification (#368, `v24.17-alpha4`)
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN apk add --no-cache  \
     cryptography \
     jwcrypto>=0.9.1 \
     fastjsonschema \
-    passlib \
     bcrypt \
     argon2_cffi \
     python-ldap \

--- a/seacatauth/communication/sms_smsbranacz.py
+++ b/seacatauth/communication/sms_smsbranacz.py
@@ -3,7 +3,7 @@ import logging
 import secrets
 import aiohttp
 import asab
-import passlib.hash
+import hashlib
 
 from . import CommunicationProviderABC
 
@@ -81,10 +81,9 @@ class SMSBranaCZProvider(CommunicationProviderABC):
 
 			time = datetime.datetime.now(datetime.timezone.utc).strftime(self.TimestampFormat)
 			salt = secrets.token_urlsafe(16)
-			auth = passlib.hash.hex_md5.hash(self.Password + time + salt)
 			url_params["time"] = time
 			url_params["salt"] = salt
-			url_params["auth"] = auth
+			url_params["auth"] = hashlib.md5((self.Password + time + salt).encode("utf-8")).hexdigest()
 
 			if self.MockMode:
 				L.log(

--- a/seacatauth/credentials/providers/abc.py
+++ b/seacatauth/credentials/providers/abc.py
@@ -45,10 +45,10 @@ class CredentialsProviderABC(asab.Configurable, abc.ABC):
 
 
 	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> str:
-		'''
+		"""
 		Locate credentials based on the vague 'ident', which could be the username, password, phone number etc.
 		Return credentials_id or return None if not found.
-		'''
+		"""
 		return None
 
 	async def get_by(self, key: str, value) -> Optional[dict]:
@@ -58,9 +58,9 @@ class CredentialsProviderABC(asab.Configurable, abc.ABC):
 		return None
 
 	async def get_login_descriptors(self, credentials_id) -> list:
-		'''
+		"""
 		Create a descriptor for the allowed login configurations
-		'''
+		"""
 		return []
 
 
@@ -71,12 +71,12 @@ class CredentialsProviderABC(asab.Configurable, abc.ABC):
 
 	@abc.abstractmethod
 	async def count(self, filtr: str = None) -> int:
-		'''
+		"""
 		Non-authoritative count of the credentials managed by the provider.
 		It is used for indicative information on the UI.
 
 		Should return None if unable to count credentials managed.
-		'''
+		"""
 		return None
 
 
@@ -93,17 +93,14 @@ class CredentialsProviderABC(asab.Configurable, abc.ABC):
 		return False
 
 
-	def _verify_password(self, hash: str, password: str):
+	def _verify_password(self, hash: str, password: str) -> bool:
+		"""
+		Check if the password matches the hash.
+		"""
 		if hash.startswith("$2b$") or hash.startswith("$2a$") or hash.startswith("$2y$"):
-			if generic.bcrypt_verify(hash, password):
-				return True
-			else:
-				return False
-		if hash.startswith("$argon2id$"):
-			if generic.argon2_verify(hash, password):
-				return True
-			else:
-				return False
+			return generic.bcrypt_verify(hash, password)
+		elif hash.startswith("$argon2id$"):
+			return generic.argon2_verify(hash, password)
 		else:
 			L.warning("Unknown password hash function: {}".format(hash[:4]))
 			return False

--- a/seacatauth/credentials/providers/abc.py
+++ b/seacatauth/credentials/providers/abc.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 import asab
 
+from ... import generic
+
 #
 
 L = logging.getLogger(__name__)
@@ -89,6 +91,22 @@ class CredentialsProviderABC(asab.Configurable, abc.ABC):
 
 	async def authenticate(self, credentials_id: str, credentials: dict) -> bool:
 		return False
+
+
+	def _verify_password(self, hash: str, password: str):
+		if hash.startswith("$2b$") or hash.startswith("$2a$") or hash.startswith("$2y$"):
+			if generic.bcrypt_verify(hash, password):
+				return True
+			else:
+				return False
+		if hash.startswith("$argon2id$"):
+			if generic.argon2_verify(hash, password):
+				return True
+			else:
+				return False
+		else:
+			L.warning("Unknown password hash function: {}".format(hash[:4]))
+			return False
 
 
 

--- a/seacatauth/credentials/providers/dictionary.py
+++ b/seacatauth/credentials/providers/dictionary.py
@@ -4,10 +4,9 @@ import hashlib
 import logging
 from typing import Optional
 
-from passlib.hash import bcrypt
-
 import asab
 from .abc import EditableCredentialsProviderABC
+from ... import generic
 
 #
 
@@ -23,7 +22,6 @@ class DictCredentialsService(asab.Service):
 		super().__init__(app, service_name)
 
 	def create_provider(self, provider_id, config_section_name):
-		# TODO: Check bcrypt.get_backend() - see https://passlib.readthedocs.io/en/stable/lib/passlib.hash.bcrypt.html#index-0
 		return DictCredentialsProvider(provider_id, config_section_name)
 
 
@@ -77,7 +75,7 @@ class DictCredentialsProvider(EditableCredentialsProviderABC):
 		if "phone" in credentials:
 			credentials_object["phone"] = credentials["phone"]
 		if "password" in credentials:
-			credentials_object["__password"] = bcrypt.hash(credentials["password"].encode("utf-8"))
+			credentials_object["__password"] = generic.bcrypt_hash(credentials["password"])
 
 		self.Dictionary[credentials_id] = credentials_object
 		return "{}:{}:{}".format(self.Type, self.ProviderID, credentials_id)
@@ -94,7 +92,7 @@ class DictCredentialsProvider(EditableCredentialsProviderABC):
 		# Update the password
 		if "password" in update:
 			new_pwd = update.pop("password")
-			credentials["__password"] = bcrypt.hash(new_pwd.encode('utf-8'))
+			credentials["__password"] = generic.bcrypt_hash(new_pwd)
 
 		for k, v in update.items():
 			credentials[k] = v
@@ -154,7 +152,7 @@ class DictCredentialsProvider(EditableCredentialsProviderABC):
 		if credentials_db is None:
 			return False
 
-		if bcrypt.verify(password, credentials_db["__password"]):
+		if generic.bcrypt_verify(credentials_db["__password"], password):
 			return True
 
 		return False

--- a/seacatauth/credentials/providers/htpasswd.py
+++ b/seacatauth/credentials/providers/htpasswd.py
@@ -35,9 +35,9 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 		self._Path = self.Config["path"]
 		self._Dict = {}
 		self._MTime = 0
-		self._refresh_credentials()
+		self._refresh()
 
-	def _refresh_credentials(self):
+	def _refresh(self):
 		if self._Dict and self._MTime == os.path.getmtime(self._Path):
 			# Reload not needed
 			return
@@ -53,7 +53,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 		"""
 		Locate search for the exact match of provided ident and the username in the htpasswd file
 		"""
-		self._refresh_credentials()
+		self._refresh()
 		if ident not in self._Dict:
 			return None
 		return "{}:{}:{}".format(self.Type, self.ProviderID, ident)
@@ -78,7 +78,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 		if not credentials_id.startswith(prefix):
 			raise KeyError("Credentials '{}' not found".format(credentials_id))
 
-		self._refresh_credentials()
+		self._refresh()
 
 		username = credentials_id[len(prefix):]
 		if username not in self._Dict:
@@ -103,7 +103,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 
 		password = credentials.get('password', '')
 
-		self._refresh_credentials()
+		self._refresh()
 		password_hash = self._Dict.get(username)
 		if not password_hash:
 			return False
@@ -115,6 +115,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 
 
 	async def count(self, filtr=None) -> int:
+		self._refresh()
 		if filtr is None:
 			return len(self._Dict)
 
@@ -128,7 +129,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 
 
 	async def search(self, filter: dict = None, **kwargs) -> list:
-		# TODO: Implement filtering and pagination
+		self._refresh()
 		if filter is not None:
 			return []
 		prefix = "{}:{}:".format(self.Type, self.ProviderID)
@@ -143,6 +144,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 
 
 	async def iterate(self, offset: int = 0, limit: int = -1, filtr: str = None):
+		self._refresh()
 		prefix = "{}:{}:".format(self.Type, self.ProviderID)
 
 		if filtr is None:

--- a/seacatauth/credentials/providers/htpasswd.py
+++ b/seacatauth/credentials/providers/htpasswd.py
@@ -1,8 +1,7 @@
 import logging
 import functools
+import os
 from typing import Optional
-
-from passlib.apache import HtpasswdFile
 
 import asab
 from .abc import CredentialsProviderABC
@@ -33,16 +32,29 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 
 	def __init__(self, provider_id, config_section_name):
 		super().__init__(provider_id, config_section_name)
-		self.HT = HtpasswdFile(self.Config['path'])
+		self._Path = self.Config["path"]
+		self._Dict = {}
+		self._MTime = 0
+		self._refresh_credentials()
+
+	def _refresh_credentials(self):
+		if self._Dict and self._MTime == os.path.getmtime(self._Path):
+			# Reload not needed
+			return
+
+		with open(self._Path, "r") as f:
+			for line in f:
+				username, password = line.strip().split(":", 1)
+				self._Dict[username] = password
 
 
 	async def locate(self, ident: str, ident_fields: dict = None, login_dict: dict = None) -> str:
 		# TODO: Implement ident_fields support
-		'''
+		"""
 		Locate search for the exact match of provided ident and the username in the htpasswd file
-		'''
-		self.HT.load_if_changed()
-		if ident not in frozenset(self.HT.users()):
+		"""
+		self._refresh_credentials()
+		if ident not in self._Dict:
 			return None
 		return "{}:{}:{}".format(self.Type, self.ProviderID, ident)
 
@@ -66,10 +78,10 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 		if not credentials_id.startswith(prefix):
 			raise KeyError("Credentials '{}' not found".format(credentials_id))
 
-		self.HT.load_if_changed()
+		self._refresh_credentials()
 
 		username = credentials_id[len(prefix):]
-		if username not in frozenset(self.HT.users()):
+		if username not in self._Dict:
 			raise KeyError("Credentials '{}' not found".format(credentials_id))
 
 		return {
@@ -91,8 +103,12 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 
 		password = credentials.get('password', '')
 
-		self.HT.load_if_changed()
-		if self.HT.check_password(username, password):
+		self._refresh_credentials()
+		password_hash = self._Dict.get(username)
+		if not password_hash:
+			return False
+
+		if self._verify_password(password_hash, password):
 			return True
 
 		return False
@@ -100,7 +116,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 
 	async def count(self, filtr=None) -> int:
 		if filtr is None:
-			return len(self.HT.users())
+			return len(self._Dict)
 
 		def filter_fnct(x, y):
 			if filtr in y:
@@ -108,7 +124,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 			else:
 				return x
 
-		return functools.reduce(filter_fnct, self.HT.users(), 0)
+		return functools.reduce(filter_fnct, self._Dict.keys(), 0)
 
 
 	async def search(self, filter: dict = None, **kwargs) -> list:
@@ -122,7 +138,7 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 				'_type': self.Type,
 				'_provider_id': self.ProviderID,
 				'username': username,
-			} for username in self.HT.users()
+			} for username in self._Dict
 		]
 
 
@@ -130,9 +146,9 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 		prefix = "{}:{}:".format(self.Type, self.ProviderID)
 
 		if filtr is None:
-			arr = self.HT.users()
+			arr = self._Dict
 		else:
-			arr = [u for u in self.HT.users() if filtr in u]
+			arr = [u for u in self._Dict if filtr in u]
 
 		for username in arr[offset:None if limit == -1 else limit + offset]:
 			yield {

--- a/seacatauth/credentials/providers/htpasswd.py
+++ b/seacatauth/credentials/providers/htpasswd.py
@@ -146,11 +146,11 @@ class HTPasswdCredentialsProvider(CredentialsProviderABC):
 		prefix = "{}:{}:".format(self.Type, self.ProviderID)
 
 		if filtr is None:
-			arr = self._Dict
+			arr = list(self._Dict.keys())
 		else:
 			arr = [u for u in self._Dict if filtr in u]
 
-		for username in arr[offset:None if limit == -1 else limit + offset]:
+		for username in arr[offset: None if limit == -1 else limit + offset]:
 			yield {
 				'_id': prefix + username,
 				'_type': self.Type,

--- a/seacatauth/credentials/providers/m2m_mongodb.py
+++ b/seacatauth/credentials/providers/m2m_mongodb.py
@@ -5,9 +5,8 @@ import asab.storage.exceptions
 
 import pymongo
 
-from passlib.hash import bcrypt
 from .mongodb import MongoDBCredentialsProvider
-
+from ... import generic
 from ...events import EventTypes
 
 #
@@ -79,7 +78,7 @@ class M2MMongoDBCredentialsProvider(MongoDBCredentialsProvider):
 		u = self.MongoDBStorageService.upsertor(self.CredentialsCollection, obj_id)
 
 		u.set("username", credentials["username"])
-		u.set("__password", bcrypt.hash(credentials["password"].encode("utf-8")))
+		u.set("__password", generic.bcrypt_hash(credentials["password"]))
 
 		credentials_id = await u.execute(event_type=EventTypes.M2M_CREDENTIALS_CREATED)
 

--- a/seacatauth/credentials/providers/mysql.py
+++ b/seacatauth/credentials/providers/mysql.py
@@ -3,11 +3,11 @@ from typing import Optional
 
 import asab
 import aiomysql
-import passlib.hash
 import pymysql
 import re
 
 from .abc import CredentialsProviderABC, EditableCredentialsProviderABC
+from ... import generic
 
 #
 
@@ -218,7 +218,7 @@ class MySQLCredentialsProvider(CredentialsProviderABC):
 		if dbcred[self.PasswordField].startswith("$2b$") \
 			or dbcred[self.PasswordField].startswith("$2a$") \
 			or dbcred[self.PasswordField].startswith("$2y$"):
-			if passlib.hash.bcrypt.verify(credentials["password"], dbcred[self.PasswordField]):
+			if generic.bcrypt_verify(dbcred[self.PasswordField], credentials["password"]):
 				return True
 			else:
 				return False
@@ -284,7 +284,7 @@ class EditableMySQLCredentialsProvider(EditableCredentialsProviderABC, MySQLCred
 
 		value = update.pop("password", None)
 		if value is not None:
-			new_credentials["__password"] = passlib.hash.bcrypt.hash(value.encode("utf-8"))
+			new_credentials["__password"] = generic.bcrypt_hash(value)
 
 		value = update.pop("enforce_factors", None)
 		if value is not None:

--- a/seacatauth/credentials/providers/xmongodb.py
+++ b/seacatauth/credentials/providers/xmongodb.py
@@ -10,7 +10,6 @@ import typing
 
 import bson.json_util
 
-from ... import generic
 from .abc import CredentialsProviderABC
 
 #
@@ -160,20 +159,28 @@ class XMongoDBCredentialsProvider(CredentialsProviderABC):
 		try:
 			dbcred = await self.get(credentials_id, include=[self.PasswordField])
 		except KeyError:
-			L.error("Authentication failed: Credentials not found", struct_data={"cid": credentials_id})
+			L.error("Authentication failed: Credentials not found.", struct_data={"cid": credentials_id})
 			return False
 
 		if dbcred.get("suspended") is True:
-			L.info("Authentication failed: Credentials suspended", struct_data={"cid": credentials_id})
+			L.info("Authentication failed: Credentials suspended.", struct_data={"cid": credentials_id})
 			return False
 
-		if self.PasswordField not in dbcred:
-			L.error("Authentication failed: Login data contain no password", struct_data={"cid": credentials_id})
+		password = credentials.get("password")
+		if not password:
+			L.error("Authentication failed: Login data contain no password.", struct_data={"cid": credentials_id})
 			return False
 
-		if not self._authenticate_password(dbcred, credentials):
+		password_hash = dbcred.get(self.PasswordField)
+		if not password_hash:
+			# Should not occur if login prologue happened correctly
+			L.error("Authentication failed: User has no password set.", struct_data={"cid": credentials_id})
+			return False
+
+		if self._verify_password(password_hash, password):
+			return True
+		else:
 			L.info("Authentication failed: Password verification failed", struct_data={"cid": credentials_id})
-			return False
 
 		return True
 
@@ -208,18 +215,3 @@ class XMongoDBCredentialsProvider(CredentialsProviderABC):
 					normalized[field] = db_obj[field]
 
 		return normalized
-
-
-	def _authenticate_password(self, dbcred, credentials):
-		# This is here for cryptoagility: if we migrate to a newer password hashing function,
-		# this if block will be extended
-		if dbcred[self.PasswordField].startswith("$2b$") \
-			or dbcred[self.PasswordField].startswith("$2a$") \
-			or dbcred[self.PasswordField].startswith("$2y$"):
-			if generic.bcrypt_verify(dbcred[self.PasswordField], credentials["password"]):
-				return True
-			else:
-				return False
-		else:
-			L.warning("Unknown password hash function: {}".format(dbcred[self.PasswordField][:4]))
-			return False

--- a/seacatauth/credentials/providers/xmongodb.py
+++ b/seacatauth/credentials/providers/xmongodb.py
@@ -4,13 +4,13 @@ from typing import Optional
 
 import asab
 import bson
-import passlib.hash
 import motor
 import motor.motor_asyncio
 import typing
 
 import bson.json_util
 
+from ... import generic
 from .abc import CredentialsProviderABC
 
 #
@@ -216,7 +216,7 @@ class XMongoDBCredentialsProvider(CredentialsProviderABC):
 		if dbcred[self.PasswordField].startswith("$2b$") \
 			or dbcred[self.PasswordField].startswith("$2a$") \
 			or dbcred[self.PasswordField].startswith("$2y$"):
-			if passlib.hash.bcrypt.verify(credentials["password"], dbcred[self.PasswordField]):
+			if generic.bcrypt_verify(dbcred[self.PasswordField], credentials["password"]):
 				return True
 			else:
 				return False

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -5,6 +5,8 @@ import typing
 import urllib.parse
 import aiohttp.web
 import asab
+import bcrypt
+import argon2
 
 from .session import SessionAdapter
 
@@ -276,6 +278,28 @@ def get_request_access_ips(request) -> list:
 	if ff is not None:
 		access_ips.extend(ff.split(", "))
 	return access_ips
+
+
+def bcrypt_hash(secret: bytes | str) -> str:
+	if isinstance(secret, str):
+		secret = secret.encode("utf-8")
+	return bcrypt.hashpw(secret, bcrypt.gensalt()).decode("utf-8")
+
+
+def bcrypt_verify(hash: bytes | str, secret: bytes | str) -> bool:
+	if isinstance(hash, str):
+		hash = hash.encode("utf-8")
+	if isinstance(secret, str):
+		secret = secret.encode("utf-8")
+	return bcrypt.checkpw(secret, hash)
+
+
+def argon2_hash(secret: bytes | str) -> str:
+	return argon2.PasswordHasher().hash(secret)
+
+
+def argon2_verify(hash: bytes | str, secret: bytes | str) -> bool:
+	return argon2.PasswordHasher().verify(hash, secret)
 
 
 def generate_ergonomic_token(length: int):

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -29,7 +29,7 @@ _PROVISIONING_CONFIG_DEFAULTS = {
 	"credentials_name": "provisioning-superuser",
 	"credentials_provider_id": "provisioning",
 	"role_name": "superuser",
-	"tenant": "provisioning-tenant",
+	"tenant": "provisioningtenant",
 	"admin_ui_url": "",
 	"admin_ui_client_id": "asab-webui-auth",
 	"admin_ui_client_name": "ASAB WebUI",

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import urllib.parse
-import passlib.pwd
+import secrets
 
 import asab.exceptions
 import asab.storage.exceptions
@@ -76,7 +76,7 @@ class ProvisioningService(asab.Service):
 			self.CredentialsService.CredentialProviders.move_to_end(existing_provider)
 
 		# Create provisioning user
-		password = passlib.pwd.genword(length=16)
+		password = secrets.token_urlsafe(16)
 		self.SuperuserID = await provider.create({
 			"username": self.SuperuserName,
 			"password": password


### PR DESCRIPTION
# Issue
- Passlib is no longer maintained plus lately it started throwing warnings when used with bcrypt backend (see https://github.com/pyca/bcrypt/issues/684).

# Summary
- Passlib removed from Dockerfile.
- `passlib.hash.bcrypt` replaced by `bcypt` directly.
- `passlib.hash.argon2` replaced by `argon2` directly.
- `passlib.pwd` replaced by `secrets`.
- `passlib.hash.md5` replaced by `hashlib.md5`.
- `passlib.apache` replaced by custom htpasswd file reader.
- Created utility methods for password hashing and validation in `seacatauth.generic`.
- Method `_verify_password` added to CredentialsProviderABC so that it can be used by any credential provider.
- Default provisioning tenant name must not contain `-`.