### PR TITLE
Sync tenant roles with global roles

### DIFF
--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -5,6 +5,7 @@ import asab.storage.exceptions
 import asab
 import asab.exceptions
 
+from ... import exceptions
 from ...events import EventTypes
 
 #
@@ -83,7 +84,7 @@ class ResourceService(asab.Service):
 		},
 	}
 	GlobalOnlyResources = frozenset({
-		"authz:superuser", "authz:impersonate", "authz:tenant:access", "seacat:credentials:access", "seacat:credentials:edit",
+		"authz:superuser", "authz:impersonate", "authz:tenant:access", "seacat:credentials:edit",
 		"seacat:session:access", "seacat:session:terminate", "seacat:resource:access", "seacat:resource:edit",
 		"seacat:client:access", "seacat:client:edit", "seacat:tenant:create"})
 
@@ -170,7 +171,10 @@ class ResourceService(asab.Service):
 
 
 	async def get(self, resource_id: str):
-		data = await self.StorageService.get(self.ResourceCollection, resource_id)
+		try:
+			data = await self.StorageService.get(self.ResourceCollection, resource_id)
+		except KeyError:
+			raise exceptions.ResourceNotFoundError(resource_id)
 		if not await self.is_editable_resource(data):
 			data["editable"] = False
 		if self.is_global_only_resource(data["_id"]):

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -84,7 +84,7 @@ class ResourceService(asab.Service):
 		},
 	}
 	GlobalOnlyResources = frozenset({
-		"authz:superuser", "authz:impersonate", "authz:tenant:access", "seacat:credentials:edit",
+		"authz:superuser", "authz:impersonate", "authz:tenant:access",
 		"seacat:session:access", "seacat:session:terminate", "seacat:resource:access", "seacat:resource:edit",
 		"seacat:client:access", "seacat:client:edit", "seacat:tenant:create"})
 

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -33,6 +33,7 @@ class RoleHandler(object):
 		web_app.router.add_post("/role/{tenant}/{role_name}", self.create)
 		web_app.router.add_delete("/role/{tenant}/{role_name}", self.delete)
 		web_app.router.add_put("/role/{tenant}/{role_name}", self.update)
+		web_app.router.add_put("/sync-roles/{tenant}", self.sync_global_roles_into_tenant)
 
 
 	@access_control("authz:superuser")
@@ -206,3 +207,12 @@ class RoleHandler(object):
 			L.log(asab.LOG_NOTICE, "Role not found", struct_data={"role_id": e.Role})
 			return aiohttp.web.HTTPNotFound()
 		return asab.web.rest.json_response(request, data={"result": result})
+
+
+	@access_control("seacat:role:edit")
+	async def sync_global_roles_into_tenant(self, request, *, tenant):
+		"""
+		Copy/sync global roles into tenant space
+		"""
+		synced_roles = await self.RoleService.sync_global_roles_into_tenant(tenant)
+		return asab.web.rest.json_response(request, data={"result": "OK", "roles": synced_roles})

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -454,9 +454,11 @@ class RoleService(asab.Service):
 		synced_roles = []
 		async for global_role in self.iterate(tenant=None):
 			resources = set(global_role.get("resources", {}))
-			if resources.intersection(self.ResourceService.GlobalOnlyResources):
+			if global_only_resources := resources.intersection(self.ResourceService.GlobalOnlyResources):
 				# Roles that grant access to one or more global-only resources ("authz:superuser" etc.)
 				# will not be synced
+				L.log(asab.LOG_NOTICE, "Skipping role with access to global-only resources.", struct_data={
+					"role": global_role["_id"], "resources": global_only_resources})
 				continue
 			_, role_name = global_role["_id"].split("/")
 			tenant_role_id = "{}/{}".format(tenant_id, role_name)

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -72,6 +72,15 @@ class RoleNotFoundError(SeacatAuthError, KeyError):
 		super().__init__("Role {!r} not found".format(self.Role), *args)
 
 
+class ResourceNotFoundError(SeacatAuthError, KeyError):
+	"""
+	Resource not found
+	"""
+	def __init__(self, resource_id, *args):
+		self.ResourceId = resource_id
+		super().__init__("Resource {!r} not found".format(self.ResourceId), *args)
+
+
 class CredentialsNotFoundError(SeacatAuthError, KeyError):
 	"""
 	Credentials not found

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -160,14 +160,19 @@ class TenantHandler(object):
 				struct_data={"cid": credentials_id, "tenant": tenant_id})
 
 		# Create role
-		role = "{}/admin".format(tenant_id)
+		role = "{}/auth-admin".format(tenant_id)
 		try:
 			# Create admin role in tenant
 			await role_service.create(role)
 			# Assign tenant management resources
-			await role_service.update(role, resources_to_set=[
-				"seacat:tenant:access", "seacat:tenant:edit", "seacat:tenant:assign", "seacat:tenant:delete",
-				"seacat:role:access", "seacat:role:edit", "seacat:role:assign"])
+			await role_service.update(
+				role,
+				description="Manage tenant access, create, edit and assign tenant roles.",
+				resources_to_set=[
+					"seacat:tenant:access", "seacat:tenant:edit", "seacat:tenant:assign", "seacat:tenant:delete",
+					"seacat:role:access", "seacat:role:edit", "seacat:role:assign"
+				]
+			)
 		except Exception as e:
 			L.error("Error creating admin role: {}".format(e), exc_info=True, struct_data={"role": role})
 


### PR DESCRIPTION
- Implements feature of syncing tenant roles with global roles. Tenant roles can be created from global roles as if from a template.
- This sync is done automatically as a part of tenant creation call `POST /tenant`.
- For tenants that already exist, this sync can be triggered by `PUT /sync-roles/{tenant_id}`.
- This sync completely skips roles with access to one or more global-only resources (such as `authz:superuser`).