### PR TITLE
Consistent use of item-specific not-found exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.17
 
 ### Pre-releases
+- `v24.17-alpha5`
 - `v24.17-alpha4`
 - `v24.17-alpha3`
 - `v24.17-alpha2`
@@ -23,6 +24,7 @@
 - List credentials from authorized tenant only (#348, `v24.06-alpha13`)
 
 ### Refactoring
+- Consistent use of item-specific not-found exceptions (#371, `v24.17-alpha5`)
 - Deprecate passlib (#368, `v24.17-alpha4`)
 - Utility functions for password verification (#368, `v24.17-alpha4`)
 

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -6,6 +6,7 @@ import asab
 import asab.exceptions
 
 from ...events import EventTypes
+from ... import exceptions
 
 #
 
@@ -170,7 +171,10 @@ class ResourceService(asab.Service):
 
 
 	async def get(self, resource_id: str):
-		data = await self.StorageService.get(self.ResourceCollection, resource_id)
+		try:
+			data = await self.StorageService.get(self.ResourceCollection, resource_id)
+		except KeyError:
+			raise exceptions.ResourceNotFoundError(resource_id)
 		if not await self.is_editable_resource(data):
 			data["editable"] = False
 		if self.is_global_only_resource(data["_id"]):

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -84,7 +84,7 @@ class ResourceService(asab.Service):
 		},
 	}
 	GlobalOnlyResources = frozenset({
-		"authz:superuser", "authz:impersonate", "authz:tenant:access", "seacat:credentials:access", "seacat:credentials:edit",
+		"authz:superuser", "authz:impersonate", "authz:tenant:access",
 		"seacat:session:access", "seacat:session:terminate", "seacat:resource:access", "seacat:resource:edit",
 		"seacat:client:access", "seacat:client:edit", "seacat:tenant:create"})
 

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -60,7 +60,7 @@ class RoleService(asab.Service):
 				query_filter["tenant"] = {"$in": [tenant, None]}
 		if filter:
 			# List roles that match "QUERY...", "*/QUERY..." or "TENANT/QUERY..."
-			query_filter["_id"] = {"$regex": "^(.+/)?{}".format(filter)}
+			query_filter["_id"] = {"$regex": "^(.+/)?{}".format(re.escape(filter))}
 		if resource is not None:
 			query_filter["resources"] = resource
 		if active_only is True:
@@ -83,6 +83,29 @@ class RoleService(asab.Service):
 			"count": count,
 			"data": roles,
 		}
+
+
+	async def iterate(
+		self, tenant: str | None, page: int = 0, limit: int = None, filter: str = None, *, resource: str = None,
+	):
+		assert tenant != "*"  # Use tenant=None
+		query_filter = {"tenant": tenant}
+		if filter:
+			# List roles that match "QUERY...", "*/QUERY..." or "TENANT/QUERY..."
+			query_filter["_id"] = {"$regex": "^(.+/)?{}".format(re.escape(filter))}
+		if resource is not None:
+			query_filter["resources"] = resource
+
+		collection = self.StorageService.Database[self.RoleCollection]
+		cursor = collection.find(query_filter)
+
+		cursor.sort("_c", -1)
+		if limit is not None:
+			cursor.skip(limit * page)
+			cursor.limit(limit)
+
+		async for role in cursor:
+			yield role
 
 
 	async def get(self, role_id: str):

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -335,10 +335,7 @@ class RoleService(asab.Service):
 
 		tenant, _ = role_id.split("/", 1)
 		if verify_tenant and tenant != "*":
-			try:
-				await self.TenantService.get_tenant(tenant)
-			except KeyError:
-				raise exceptions.TenantNotFoundError(tenant)
+			await self.TenantService.get_tenant(tenant)
 
 		if verify_credentials:
 			try:

--- a/seacatauth/decorators.py
+++ b/seacatauth/decorators.py
@@ -150,10 +150,7 @@ async def _authorize_tenant(request):
 	else:
 		# Check if tenant exists
 		tenant_service = request.App.get_service("seacatauth.TenantService")
-		try:
-			await tenant_service.get_tenant(requested_tenant)
-		except KeyError as e:
-			raise exceptions.TenantNotFoundError(requested_tenant) from e
+		await tenant_service.get_tenant(requested_tenant)
 
 		if requested_tenant in request.Session.Authorization.Authz:
 			# Tenant accessible

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -72,6 +72,15 @@ class RoleNotFoundError(SeacatAuthError, KeyError):
 		super().__init__("Role {!r} not found".format(self.Role), *args)
 
 
+class ResourceNotFoundError(SeacatAuthError, KeyError):
+	"""
+	Resource not found
+	"""
+	def __init__(self, resource_id, *args):
+		self.ResourceId = resource_id
+		super().__init__("Resource {!r} not found".format(self.ResourceId), *args)
+
+
 class CredentialsNotFoundError(SeacatAuthError, KeyError):
 	"""
 	Credentials not found

--- a/seacatauth/tenant/providers/mongodb.py
+++ b/seacatauth/tenant/providers/mongodb.py
@@ -131,21 +131,17 @@ class MongoDBTenantProvider(EditableTenantsProviderABC):
 
 	async def delete(self, tenant_id: str) -> Optional[bool]:
 		"""
-		Delete tenant. Also delete all its roles and assignments.
+		Delete tenant
 		"""
 		await self.MongoDBStorageService.delete(self.TenantsCollection, tenant_id)
 		L.log(asab.LOG_NOTICE, "Tenant deleted.", struct_data={"tenant": tenant_id})
 
 
 	async def get(self, tenant_id) -> Optional[dict]:
-		# Fetch the tenant from a Mongo
-		tenant = await self.MongoDBStorageService.get(
-			self.TenantsCollection,
-			# bson.ObjectId(tenant_id)
-			tenant_id
-		)
-
-		return tenant
+		"""
+		Get tenant
+		"""
+		return await self.MongoDBStorageService.get(self.TenantsCollection, tenant_id)
 
 
 	# async def register(self, register_info, credentials_id):

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -62,7 +62,10 @@ class TenantService(asab.Service):
 
 
 	async def get_tenant(self, tenant_id: str):
-		return await self.TenantsProvider.get(tenant_id)
+		try:
+			return await self.TenantsProvider.get(tenant_id)
+		except KeyError:
+			raise exceptions.TenantNotFoundError(tenant_id)
 
 
 	async def create_tenant(
@@ -241,10 +244,7 @@ class TenantService(asab.Service):
 		assert tenant != "*"
 
 		if verify_tenant:
-			try:
-				await self.get_tenant(tenant)
-			except KeyError:
-				raise exceptions.TenantNotFoundError(tenant)
+			await self.get_tenant(tenant)
 
 		if verify_credentials:
 			credential_service = self.App.get_service("seacatauth.CredentialsService")
@@ -317,11 +317,8 @@ class TenantService(asab.Service):
 			elif tenant in user_tenants:
 				tenants.add(tenant)
 			elif has_access_to_all_tenants:
-				try:
-					await self.get_tenant(tenant)
-					tenants.add(tenant)
-				except KeyError:
-					raise exceptions.TenantNotFoundError(tenant)
+				await self.get_tenant(tenant)
+				tenants.add(tenant)
 			else:
 				raise exceptions.TenantAccessDeniedError(tenant, credential_id)
 


### PR DESCRIPTION
- CredentialsService, TenantService, RoleService and ResourceService all raise their dedicated `xxxNotFoundError`s (which inherit from KeyError).
- Resources `seacat:credentials:access` and `seacat:credentials:edit` are not considered global-only.
- Non-superusers cannot edit credentials outside their tenant.