### PR TITLE
Configurable basic password requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## v24.20
+
+### Pre-releases
+- `v24.20-alpha1`
+
+### Breaking changes
+- Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
+
+### Features
+- Configurable password criteria (#372, `v24.20-alpha1`)
+
+---
+
+
 ## v24.17
 
 ### Pre-releases

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -186,6 +186,13 @@ asab.Config.add_defaults({
 	},
 
 	"seacatauth:password": {
+		# Minimum password requirements
+		"min_length": 12,
+		"min_lowercase_count": 2,
+		"min_uppercase_count": 2,
+		"min_digit_count": 2,
+		"min_special_count": 2,
+
 		# Timeout for password reset requests
 		"password_reset_expiration": "3 d",
 	},

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -186,7 +186,8 @@ asab.Config.add_defaults({
 	},
 
 	"seacatauth:password": {
-		# Minimum password requirements
+		# Password requirements
+		"max_length": 64,
 		"min_length": 10,
 		"min_lowercase_count": 1,
 		"min_uppercase_count": 1,

--- a/seacatauth/__init__.py
+++ b/seacatauth/__init__.py
@@ -187,11 +187,11 @@ asab.Config.add_defaults({
 
 	"seacatauth:password": {
 		# Minimum password requirements
-		"min_length": 12,
-		"min_lowercase_count": 2,
-		"min_uppercase_count": 2,
-		"min_digit_count": 2,
-		"min_special_count": 2,
+		"min_length": 10,
+		"min_lowercase_count": 1,
+		"min_uppercase_count": 1,
+		"min_digit_count": 1,
+		"min_special_count": 1,
 
 		# Timeout for password reset requests
 		"password_reset_expiration": "3 d",

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -31,11 +31,14 @@ class ChangePasswordHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_put("/password", self.admin_request_password_reset)
+		web_app.router.add_get("/account/password/policy", self.password_policy)
 		web_app.router.add_put("/account/password-change", self.change_password)
+		web_app.router.add_get("/public/password/policy", self.password_policy)
 		web_app.router.add_put("/public/password-reset", self.reset_password)
 		web_app.router.add_put("/public/lost-password", self.lost_password)
 
 		web_app_public = app.PublicWebContainer.WebApp
+		web_app_public.router.add_get("/public/password/policy", self.password_policy)
 		web_app_public.router.add_put("/public/password-reset", self.reset_password)
 		web_app_public.router.add_put("/public/lost-password", self.lost_password)
 
@@ -44,6 +47,14 @@ class ChangePasswordHandler(object):
 		web_app.router.add_put("/public/password-change", self.change_password)
 		web_app_public.router.add_put("/public/password-change", self.change_password)
 		# <<<
+
+
+	async def password_policy(self, request):
+		"""
+		Get minimum password requirements
+		"""
+		response_data = await self.ChangePasswordService.password_policy()
+		return asab.web.rest.json_response(request, response_data)
 
 
 	@asab.web.rest.json_schema_handler({

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -86,6 +86,10 @@ class ChangePasswordHandler(object):
 				"cid": credentials_id, "from_ip": from_ip})
 			await self.LastActivityService.update_last_activity(
 				EventCode.PASSWORD_CHANGE_FAILED, credentials_id=credentials_id, from_ip=from_ip)
+			return asab.web.rest.json_response(request, status=400, data={
+				"result": "FAILED",
+				"tech_message": "Authentication failed.",
+			})
 
 		# Change the password
 		try:

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -86,8 +86,8 @@ class ChangePasswordHandler(object):
 				"cid": credentials_id, "from_ip": from_ip})
 			await self.LastActivityService.update_last_activity(
 				EventCode.PASSWORD_CHANGE_FAILED, credentials_id=credentials_id, from_ip=from_ip)
-			return asab.web.rest.json_response(request, status=400, data={
-				"result": "FAILED",
+			return asab.web.rest.json_response(request, status=401, data={
+				"result": "UNAUTHORIZED",
 				"tech_message": "Authentication failed.",
 			})
 

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -4,6 +4,7 @@ import datetime
 import re
 
 import asab
+import asab.exceptions
 
 from ... import exceptions
 from ...generic import generate_ergonomic_token
@@ -27,6 +28,7 @@ class ChangePasswordService(asab.Service):
 	def __init__(self, app, cred_service, service_name="seacatauth.ChangePasswordService"):
 		super().__init__(app, service_name)
 
+		self.PasswordMaxLength = asab.Config.getint("seacatauth:password", "max_length")
 		self.PasswordMinLength = asab.Config.getint("seacatauth:password", "min_length")
 		self.PasswordMinLowerCount = asab.Config.getint("seacatauth:password", "min_lowercase_count")
 		self.PasswordMinUpperCount = asab.Config.getint("seacatauth:password", "min_uppercase_count")
@@ -213,6 +215,10 @@ class ChangePasswordService(asab.Service):
 
 
 	def verify_password_strength(self, password: str):
+		if len(password) > self.PasswordMaxLength:
+			raise asab.exceptions.ValidationError(
+				"Password cannot be longer than {} characters.".format(self.PasswordMaxLength))
+
 		if len(password) < self.PasswordMinLength:
 			raise exceptions.WeakPasswordError(
 				"Password must be {} or more characters long.".format(self.PasswordMinLength))

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -109,6 +109,19 @@ class ChangePasswordService(asab.Service):
 		return await self._create_password_reset_token(credentials_id=credentials["_id"], expiration=expiration)
 
 
+	async def password_policy(self) -> dict:
+		"""
+		Password validation requirements
+		"""
+		return {
+			"min_length": self.PasswordMinLength,
+			"min_lowercase_count": self.PasswordMinLowerCount,
+			"min_uppercase_count": self.PasswordMinUpperCount,
+			"min_digit_count": self.PasswordMinDigitCount,
+			"min_special_count": self.PasswordMinSpecialCount,
+		}
+
+
 	async def init_password_reset_by_admin(
 		self,
 		credentials: dict,

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -219,11 +219,11 @@ class ChangePasswordService(asab.Service):
 
 		if len(re.findall(r"[a-z]", password)) < self.PasswordMinLowerCount:
 			raise exceptions.WeakPasswordError(
-				"Password must contain at least {} uppercase letters.".format(self.PasswordMinLowerCount))
+				"Password must contain at least {} lowercase letters.".format(self.PasswordMinLowerCount))
 
 		if len(re.findall(r"[A-Z]", password)) < self.PasswordMinUpperCount:
 			raise exceptions.WeakPasswordError(
-				"Password must contain at least {} lowercase letters.".format(self.PasswordMinUpperCount))
+				"Password must contain at least {} uppercase letters.".format(self.PasswordMinUpperCount))
 
 		if len(re.findall(r"[0-9]", password)) < self.PasswordMinDigitCount:
 			raise exceptions.WeakPasswordError(

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -1,5 +1,7 @@
 import typing
 
+import asab.exceptions
+
 
 class SeacatAuthError(Exception):
 	"""
@@ -105,6 +107,14 @@ class CredentialsSuspendedError(SeacatAuthError):
 	def __init__(self, credentials_id, *args):
 		self.CredentialsId = credentials_id
 		super().__init__("Credentials {!r} suspended".format(self.CredentialsId), *args)
+
+
+class WeakPasswordError(SeacatAuthError, asab.exceptions.ValidationError):
+	"""
+	Password does not comply with configured policies
+	"""
+	def __init__(self, message, *args):
+		super().__init__(message, *args)
 
 
 class UnauthorizedTenantAccessError(AccessDeniedError):


### PR DESCRIPTION
# Summary

Introducing configurable minimum requirements for user passwords.

This is the default config:
```ini
[seacatauth:password]
min_length=10
max_length=64
min_lowercase_count=1
min_uppercase_count=1
min_digit_count=1
min_special_count=1
```

The requirements are available at `GET /public/password/policy` and `GET /account/password/policy`. Example response:
```json
{
	"min_length": 10,
	"min_lowercase_count": 1,
	"min_uppercase_count": 1,
	"min_digit_count": 1,
	"min_special_count": 1
}
```

This endpoint should be used by the UI to give the user relevant hints on password strength.

# Compatibility

Dynamic password requirements are supported by
- [Seacat Auth Webui v24.19-alpha](https://github.com/TeskaLabs/seacat-auth-webui/releases/tag/v24.19-alpha) and later
- [Seacat Account Webui v24.08-beta](http://gitlab.teskalabs.int/ateska/webui-microfrontends-poc/-/tags/v24.08-beta) and later