### PR TITLE
Authorize into last active tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `v24.17-alpha1`
 
 ### Fix
--Authorize into last active tenant (#373, `v24.17-alpha6`)
+- Authorize into last active tenant (#373, `v24.17-alpha6`)
 - Default provisioning tenant name mst pass validation (#368, `v24.17-alpha4`)
 - Fix the initialization and updating of built-in resources (#363, `v24.06-alpha15`)
 - Fix searching credentials with multiple filters (#362, `v24.06-alpha14`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.17
 
 ### Pre-releases
+- `v24.17-alpha6`
 - `v24.17-alpha5`
 - `v24.17-alpha4`
 - `v24.17-alpha3`
@@ -11,6 +12,7 @@
 - `v24.17-alpha1`
 
 ### Fix
+-Authorize into last active tenant (#373, `v24.17-alpha6`)
 - Default provisioning tenant name mst pass validation (#368, `v24.17-alpha4`)
 - Fix the initialization and updating of built-in resources (#363, `v24.06-alpha15`)
 - Fix searching credentials with multiple filters (#362, `v24.06-alpha14`)

--- a/seacatauth/last_activity/service.py
+++ b/seacatauth/last_activity/service.py
@@ -30,7 +30,6 @@ class LastActivityService(asab.Service):
 
 
 	async def update_last_activity(self, event_code: EventCode, credentials_id: str, **kwargs):
-		print(event_code, kwargs)
 		assert isinstance(credentials_id, str)
 		kwargs["_c"] = datetime.datetime.now(datetime.timezone.utc)
 

--- a/seacatauth/last_activity/service.py
+++ b/seacatauth/last_activity/service.py
@@ -30,6 +30,7 @@ class LastActivityService(asab.Service):
 
 
 	async def update_last_activity(self, event_code: EventCode, credentials_id: str, **kwargs):
+		print(event_code, kwargs)
 		assert isinstance(credentials_id, str)
 		kwargs["_c"] = datetime.datetime.now(datetime.timezone.utc)
 

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -283,7 +283,6 @@ class AuthorizeHandler(object):
 		Authentication Code Flow
 		"""
 		scope = scope.split(" ")
-		print(scope)
 
 		# Authorize the client and check that all the request parameters are valid by the client's settings
 		try:

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -12,6 +12,7 @@ from ... import client, generic, AuditLogger
 from ... import exceptions
 from ..utils import AuthErrorResponseCode, AUTHORIZE_PARAMETERS
 from ..pkce import InvalidCodeChallengeMethodError, InvalidCodeChallengeError
+from ...last_activity import EventCode
 
 #
 
@@ -282,6 +283,7 @@ class AuthorizeHandler(object):
 		Authentication Code Flow
 		"""
 		scope = scope.split(" ")
+		print(scope)
 
 		# Authorize the client and check that all the request parameters are valid by the client's settings
 		try:
@@ -531,6 +533,12 @@ class AuthorizeHandler(object):
 			"from_ip": from_info,
 			"scope": scope,
 		})
+		await self.OpenIdConnectService.LastActivityService.update_last_activity(
+			EventCode.AUTHORIZE_SUCCESS,
+			credentials_id=new_session.Credentials.Id,
+			tenants=list(tenants),
+			scope=list(scope)
+		)
 		return await self.reply_with_successful_response(
 			new_session, scope, redirect_uri, state,
 			code_challenge=code_challenge,

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -57,6 +57,7 @@ class OpenIdConnectService(asab.Service):
 		self.TenantService = app.get_service("seacatauth.TenantService")
 		self.RBACService = app.get_service("seacatauth.RBACService")
 		self.RoleService = app.get_service("seacatauth.RoleService")
+		self.LastActivityService = app.get_service("seacatauth.LastActivityService")
 		self.PKCE = pkce.PKCE()  # TODO: Restructure. This is OAuth, but not OpenID Connect!
 
 		self.PublicApiBaseUrl = app.PublicOpenIdConnectApiUrl


### PR DESCRIPTION
- On successful authorization request, the authorized tenant is remembered for every credentials.
- When authorization request is made with `tenant` in scope, the last authorized tenant is used.