### PR TITLE
Deny password change when old password verification fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.17
 
 ### Pre-releases
+- `v24.17-alpha7`
 - `v24.17-alpha6`
 - `v24.17-alpha5`
 - `v24.17-alpha4`
@@ -12,6 +13,7 @@
 - `v24.17-alpha1`
 
 ### Fix
+- Deny password change when old password verification fails (#374, `v24.17-alpha7`)
 - Authorize into last active tenant (#373, `v24.17-alpha6`)
 - Default provisioning tenant name mst pass validation (#368, `v24.17-alpha4`)
 - Fix the initialization and updating of built-in resources (#363, `v24.06-alpha15`)

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -75,6 +75,7 @@ class ChangePasswordHandler(object):
 				"cid": credentials_id, "from_ip": from_ip})
 			await self.LastActivityService.update_last_activity(
 				EventCode.PASSWORD_CHANGE_FAILED, credentials_id=credentials_id, from_ip=from_ip)
+			return asab.web.rest.json_response(request, status=401, data={"result": "FAILED"})
 
 		# Change the password
 		try:


### PR DESCRIPTION
# Issue
When an incorrect old password is entered in the Change password form, authentication failure is logged, but the password change still proceeds. This is a serious security bug.

# Solution
The server responds with 401 immediately after the failed old password verification. 

This should be considered a hotfix - a proper refactoring is needed:
- ChangePasswordHandler should not perform any verification or flow control.
- ChangePasswordService needs to conduct the entire password change process, including sending the messages etc.
- ChangePasswordService needs to have a specific Error class for every unhappy flow. The Handler must catch those and translate them into HTTP responses.
- Unit tests must be created for all ChangePasswordService methods.