### PR TITLE
Hash passwords using argon2 instead of bcrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.17
 
 ### Pre-releases
+- `v24.17-alpha8`
 - `v24.17-alpha7`
 - `v24.17-alpha6`
 - `v24.17-alpha5`
@@ -20,6 +21,7 @@
 - Fix searching credentials with multiple filters (#362, `v24.06-alpha14`)
 
 ### Features
+- Hash passwords using argon2 instead of bcrypt (#375, `v24.17-alpha8`)
 - Improve resource sorting and filtering (#370, `v24.17-alpha3`)
 - User invitations are enabled by default (#367, `v24.17-alpha2`)
 - When invitation cannot be created because the user already exists, the invitation is re-sent (#364, `v24.17-alpha1`)

--- a/seacatauth/credentials/providers/m2m_mongodb.py
+++ b/seacatauth/credentials/providers/m2m_mongodb.py
@@ -79,7 +79,7 @@ class M2MMongoDBCredentialsProvider(MongoDBCredentialsProvider):
 		u = self.MongoDBStorageService.upsertor(self.CredentialsCollection, obj_id)
 
 		u.set("username", credentials["username"])
-		u.set("__password", generic.bcrypt_hash(credentials["password"]))
+		u.set("__password", generic.argon2_hash(credentials["password"]))
 
 		credentials_id = await u.execute(event_type=EventTypes.M2M_CREDENTIALS_CREATED)
 

--- a/seacatauth/credentials/providers/mongodb.py
+++ b/seacatauth/credentials/providers/mongodb.py
@@ -173,7 +173,7 @@ class MongoDBCredentialsProvider(EditableCredentialsProviderABC):
 		# Update password
 		v = update.pop("password", None)
 		if v is not None:
-			u.set("__password", generic.bcrypt_hash(v))
+			u.set("__password", generic.argon2_hash(v))
 
 		# Update basic credentials
 		for key, value in update.items():

--- a/seacatauth/credentials/providers/mysql.py
+++ b/seacatauth/credentials/providers/mysql.py
@@ -284,7 +284,7 @@ class EditableMySQLCredentialsProvider(EditableCredentialsProviderABC, MySQLCred
 
 		value = update.pop("password", None)
 		if value is not None:
-			new_credentials["__password"] = generic.bcrypt_hash(value)
+			new_credentials["__password"] = generic.argon2_hash(value)
 
 		value = update.pop("enforce_factors", None)
 		if value is not None:


### PR DESCRIPTION
closes #340 

- New passwords are hashed using Argon2, which is more secure than Bcrypt.
- Bcrypt is still supported for existing passwords.