### PR TITLE
Fix AttributeError in failed login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.17
 
 ### Pre-releases
+- `v24.17-alpha9`
 - `v24.17-alpha8`
 - `v24.17-alpha7`
 - `v24.17-alpha6`
@@ -14,6 +15,7 @@
 - `v24.17-alpha1`
 
 ### Fix
+- Fix AttributeError in failed login (#376, `v24.17-alpha9`)
 - Deny password change when old password verification fails (#374, `v24.17-alpha7`)
 - Authorize into last active tenant (#373, `v24.17-alpha6`)
 - Default provisioning tenant name mst pass validation (#368, `v24.17-alpha4`)

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -298,7 +298,7 @@ class AuthenticationService(asab.Service):
 
 		# Fail if we have a fake login session
 		if login.CredentialsId == "":
-			L.log(asab.LOG_NOTICE, "Login failed: Fake login session", struct_data={"lsid": login.Id})
+			L.log(asab.LOG_NOTICE, "Login failed: Fake login session", struct_data={"lsid": login_session.Id})
 			return False
 
 		# First make sure that the user is not suspended


### PR DESCRIPTION
# Issue
Fake login session results in traceback because of AttributeError.

# Solution
Fix incorrect reference.