### PR TITLE
Properly handle Argon2 VerifyMismatchError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 ## v24.20
 
 ### Pre-releases
+- `v24.20-alpha3`
 - `v24.20-alpha2`
 - `v24.20-alpha1`
 
 ### Breaking changes
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
+
+### Fix
+- Properly handle Argon2 verification error in login call (#378, `v24.20-alpha3`)
 
 ### Features
 - Implement OAuth refresh tokens (#358, `v24.20-alpha2`)

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -299,7 +299,10 @@ def argon2_hash(secret: bytes | str) -> str:
 
 
 def argon2_verify(hash: bytes | str, secret: bytes | str) -> bool:
-	return argon2.PasswordHasher().verify(hash, secret)
+	try:
+		return argon2.PasswordHasher().verify(hash, secret)
+	except argon2.exceptions.VerifyMismatchError:
+		return False
 
 
 def generate_ergonomic_token(length: int):


### PR DESCRIPTION
# Issue

#375 and #359 introduced a bug in password verification: Incorrect password triggers a stacktrace.

# Solution

Handle the raised error and return False where it is expected.