### PR TITLE
Do not log failed LDAP login as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.20
 
 ### Pre-releases
+- `v24.20-alpha4`
 - `v24.20-alpha3`
 - `v24.20-alpha2`
 - `v24.20-alpha1`
@@ -11,6 +12,7 @@
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
 
 ### Fix
+- Do not log failed LDAP login as error (#381, `v24.20-alpha4`)
 - Properly handle Argon2 verification error in login call (#378, `v24.20-alpha3`)
 
 ### Features

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -360,7 +360,8 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 		try:
 			lc.simple_bind_s(dn, password)
 		except ldap.INVALID_CREDENTIALS:
-			L.error("LDAP: Invalid credentials", struct_data={"dn": dn})
+			L.log(asab.LOG_NOTICE, "Authentication failed: Invalid LDAP credentials.", struct_data={
+				"cid": credentials_id, "dn": dn})
 			return False
 
 		lc.unbind_s()


### PR DESCRIPTION
# Issue
When LDAP user tries to log in with incorrect password, it is logged as ERROR. The log level should be lower since it is not an application failure.

# Solution
Log level decreased to NOTICE.