### PR TITLE
Extend session expiration on cookie request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.20
 
 ### Pre-releases
+- `v24.20-alpha5`
 - `v24.20-alpha4`
 - `v24.20-alpha3`
 - `v24.20-alpha2`
@@ -12,6 +13,7 @@
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
 
 ### Fix
+- Extend session expiration at cookie entrypoint (#383, `v24.20-alpha5`)
 - Do not log failed LDAP login as error (#381, `v24.20-alpha4`)
 - Properly handle Argon2 verification error in login call (#378, `v24.20-alpha3`)
 

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -474,6 +474,8 @@ class CookieHandler(object):
 				L.error("Failed to produce session track ID")
 				raise aiohttp.web.HTTPBadRequest() from e
 
+		session = await self.CookieService.extend_session_expiration(session, client)
+
 		# Construct the response
 		if client.get("cookie_domain") not in (None, ""):
 			cookie_domain = client["cookie_domain"]

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -267,6 +267,17 @@ class CookieService(asab.Service):
 		return session
 
 
+	async def extend_session_expiration(self, session: SessionAdapter, client: dict = None):
+		expiration = client.get("session_expiration") if client else None
+		if expiration:
+			expiration = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=expiration)
+		else:
+			expiration = datetime.datetime.now(datetime.UTC) + self.SessionService.Expiration
+		session_builders = (((SessionAdapter.FN.Session.Expiration, expiration),),)
+		# TODO: Also extend root session if needed
+		return await self.SessionService.update_session(session.SessionId, session_builders)
+
+
 	def set_session_cookie(self, response, cookie_value, client_id=None, cookie_domain=None, secure=None):
 		"""
 		Add a Set-Cookie header to the response.

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -273,9 +273,8 @@ class CookieService(asab.Service):
 			expiration = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=expiration)
 		else:
 			expiration = datetime.datetime.now(datetime.UTC) + self.SessionService.Expiration
-		session_builders = (((SessionAdapter.FN.Session.Expiration, expiration),),)
-		# TODO: Also extend root session if needed
-		return await self.SessionService.update_session(session.SessionId, session_builders)
+
+		return await self.SessionService.touch(session, expiration, override_cooldown=True)
 
 
 	def set_session_cookie(self, response, cookie_value, client_id=None, cookie_domain=None, secure=None):

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -471,12 +471,16 @@ class AuthorizeHandler(object):
 					requested_expiration=AuthorizationCode.Expiration
 				)
 			elif auth_token_type == "cookie":
+				# Use client-defined expiration instead of AuthorizationCode.Expiration so that the session gets
+				# extended properly at the introspection later
+				# TODO: Revise this once cookies are moved to the token collection
+				expiration = client_dict.get("session_expiration")
 				new_session = await self.CookieService.create_cookie_client_session(
 					root_session, client_id, requested_scope,
 					nonce=nonce,
 					redirect_uri=redirect_uri,
 					tenants=[authorized_tenant] if authorized_tenant else None,
-					requested_expiration=AuthorizationCode.Expiration
+					requested_expiration=expiration
 				)
 				# Cookie flow implicitly redirects to the cookie entry point and puts the final redirect_uri in the query
 				redirect_uri = await self._build_cookie_entry_redirect_uri(client_dict, redirect_uri)

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -446,7 +446,6 @@ class SessionService(asab.Service):
 
 	def _calculate_extended_expiration(self, session: SessionAdapter, expires: datetime.datetime = None):
 		if session.Session.Expiration >= session.Session.MaxExpiration:
-			print("already maxxed out")
 			return None
 
 		if expires is None:
@@ -458,7 +457,6 @@ class SessionService(asab.Service):
 
 		if expires < session.Session.Expiration:
 			# Do not shorten the session!
-			print("Do not shorten the session!")
 			return None
 		if session.Session.MaxExpiration is not None and expires > session.Session.MaxExpiration:
 			# Do not cross maximum expiration


### PR DESCRIPTION
# Issue

#358 introduced a bug where client cookie sessions are created with short expiration, which is not extended later and the session expires in a few minutes, logging the user out.

The session was supposed to be extended at the cookie entrypoint, when the auth code is exchanged for a cookie (same as with OAuth token request), but there seems to be no code doing so.


# Solution

- [x] Extend client cookie session at the cookie entrypoint (similarly to the `refresh_session` method in OAuth token request).
- [x] Make sure the root session gets extended too.
- [x] Make sure client cookie sessions are periodically extended during introspection.