### PR TITLE
Delete client cookie on introspection failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.20
 
 ### Pre-releases
+- `v24.20-alpha6`
 - `v24.20-alpha5`
 - `v24.20-alpha4`
 - `v24.20-alpha3`
@@ -13,6 +14,7 @@
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
 
 ### Fix
+- Delete client cookie on introspection failure (#385, `v24.20-alpha6`)
 - Extend session expiration at cookie entrypoint (#383, `v24.20-alpha5`)
 - Do not log failed LDAP login as error (#381, `v24.20-alpha4`)
 - Properly handle Argon2 verification error in login call (#378, `v24.20-alpha3`)

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -172,7 +172,7 @@ class CookieHandler(object):
 				response = aiohttp.web.HTTPUnauthorized()
 
 		if response.status_code != 200:
-			self.CookieService.delete_session_cookie(response)
+			self.CookieService.delete_session_cookie(response, client_id)
 			return response
 
 		return response
@@ -263,7 +263,7 @@ class CookieHandler(object):
 		cookie_domain = client.get("cookie_domain") or None
 
 		if response.status_code != 200:
-			self.CookieService.delete_session_cookie(response)
+			self.CookieService.delete_session_cookie(response, client_id)
 			return response
 
 		if anonymous_session_created:

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -3,6 +3,7 @@ import datetime
 import hashlib
 import re
 import logging
+import typing
 
 import asab
 import asab.storage
@@ -296,8 +297,9 @@ class CookieService(asab.Service):
 		)
 
 
-	def delete_session_cookie(self, response):
+	def delete_session_cookie(self, response, client_id: typing.Optional[str] = None):
 		"""
 		Add a Set-Cookie header to the response to unset Seacat Session cookie
 		"""
-		response.del_cookie(self.CookieName)
+		cookie_name = self.get_cookie_name(client_id)
+		response.del_cookie(cookie_name)


### PR DESCRIPTION
# Issue
When the client cookie introspection fails, the user is logged out completely because their SSO (root) cookie is deleted. When I log into one app and then navigate to another one that uses cookie introspection, my SSO cookie is deleted and I'm required to log in again.

# Solution
Delete the client cookie instead of the SSO cookie so that a new cookie can be obtained via the authorization code flow without login if needed.
