### PR TITLE
Custom tenant-related authorization error response codes

### DIFF
--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -454,12 +454,17 @@ class AuthorizeHandler(object):
 					has_access_to_all_tenants=self.OpenIdConnectService.RBACService.can_access_all_tenants(
 						root_session.Authorization.Authz)
 				)
-			except exceptions.AccessDeniedError:
+			except exceptions.NoTenantsError:
 				raise OAuthAuthorizeError(
-					AuthErrorResponseCode.AccessDenied, client_id,
+					AuthErrorResponseCode.NoTenants, client_id,
 					redirect_uri=redirect_uri,
 					state=state,
-					struct_data={"reason": "tenant_not_found"}
+				)
+			except exceptions.AccessDeniedError:
+				raise OAuthAuthorizeError(
+					AuthErrorResponseCode.TenantAccessDenied, client_id,
+					redirect_uri=redirect_uri,
+					state=state,
 				)
 
 			if auth_token_type == "openid":
@@ -516,12 +521,18 @@ class AuthorizeHandler(object):
 					requested_scope, anonymous_cid,
 					has_access_to_all_tenants=self.OpenIdConnectService.RBACService.can_access_all_tenants(authz)
 				)
-			except exceptions.AccessDeniedError:
+			except exceptions.NoTenantsError:
 				raise OAuthAuthorizeError(
-					AuthErrorResponseCode.AccessDenied, client_id,
+					AuthErrorResponseCode.NoTenants, client_id,
 					redirect_uri=redirect_uri,
 					state=state,
-					struct_data={"reason": "tenant_not_found"})
+				)
+			except exceptions.AccessDeniedError:
+				raise OAuthAuthorizeError(
+					AuthErrorResponseCode.TenantAccessDenied, client_id,
+					redirect_uri=redirect_uri,
+					state=state,
+				)
 
 			if auth_token_type == "openid":
 				new_session = await self.OpenIdConnectService.create_anonymous_oidc_session(

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -427,7 +427,7 @@ class OpenIdConnectService(asab.Service):
 		scope: typing.Iterable,
 		credentials_id: str,
 		has_access_to_all_tenants: bool = False
-	):
+	) -> typing.Optional[str]:
 		"""
 		Extract tenants from requested scope and return the first accessible one.
 		"""
@@ -435,13 +435,10 @@ class OpenIdConnectService(asab.Service):
 			tenants: set = await self.TenantService.get_tenants_by_scope(
 				scope, credentials_id, has_access_to_all_tenants)
 		except exceptions.TenantNotFoundError as e:
-			L.error("Tenant not found", struct_data={"tenant": e.Tenant})
+			L.error("Tenant not found.", struct_data={"tenant": e.Tenant})
 			raise exceptions.AccessDeniedError(subject=credentials_id)
 		except exceptions.TenantAccessDeniedError as e:
-			L.error("Tenant access denied", struct_data={"tenant": e.Tenant, "cid": credentials_id})
-			raise exceptions.AccessDeniedError(subject=credentials_id)
-		except exceptions.NoTenantsError:
-			L.error("Tenant access denied", struct_data={"cid": credentials_id})
+			L.log(asab.LOG_NOTICE, "Tenant access denied.", struct_data={"tenant": e.Tenant, "cid": credentials_id})
 			raise exceptions.AccessDeniedError(subject=credentials_id)
 
 		if tenants:

--- a/seacatauth/openidconnect/utils.py
+++ b/seacatauth/openidconnect/utils.py
@@ -21,6 +21,10 @@ class AuthErrorResponseCode:
 	RequestUriNotSupported = "request_uri_not_supported"
 	RegistrationNotSupported = "registration_not_supported"
 
+	# Custom response codes
+	TenantAccessDenied = "tenant_access_denied"
+	NoTenants = "no_tenants"
+
 
 class TokenRequestErrorResponseCode:
 	# OAuth2.0 token request error response codes defined in RFC6749

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -319,6 +319,8 @@ class TenantService(asab.Service):
 			elif has_access_to_all_tenants:
 				await self.get_tenant(tenant)
 				tenants.add(tenant)
+			elif not user_tenants:
+				raise exceptions.NoTenantsError(credential_id)
 			else:
 				raise exceptions.TenantAccessDeniedError(tenant, credential_id)
 


### PR DESCRIPTION
When a tenant is requested in scope and the user does not have access to that tenant:
-  if the user has access to no tenant, the authorization fails with `no_tenants` instead of the generic ~~`access_denied`~~.
-  if the user has access to other tenants, the authorization fails with `tenant_access_denied` instead of the generic ~~`access_denied`~~.