### PR TITLE
Encrypt cookie value in session update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## v24.20
 
 ### Pre-releases
-- `v24.20-alpha12`
 - `v24.20-alpha11`
 - `v24.20-alpha10`
 - `v24.20-alpha9`
@@ -20,7 +19,7 @@
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
 
 ### Fix
-- Properly encrypt cookie value in session update (#394, `v24.20-alpha12`)
+- Properly encrypt cookie value in session update (#394, `v24.20-alpha11`)
 - Properly parse URL query before adding new parameters (#393, `v24.20-alpha11`)
 - Delete client cookie on introspection failure (#385, `v24.20-alpha6`)
 - Extend session expiration at cookie entrypoint (#383, `v24.20-alpha5`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.20
 
 ### Pre-releases
+- `v24.20-alpha12`
 - `v24.20-alpha11`
 - `v24.20-alpha10`
 - `v24.20-alpha9`
@@ -19,6 +20,7 @@
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
 
 ### Fix
+- Properly encrypt cookie value in session update (#394, `v24.20-alpha12`)
 - Properly parse URL query before adding new parameters (#393, `v24.20-alpha11`)
 - Delete client cookie on introspection failure (#385, `v24.20-alpha6`)
 - Extend session expiration at cookie entrypoint (#383, `v24.20-alpha5`)

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -252,7 +252,11 @@ class SessionService(asab.Service):
 
 		for session_builder in session_builders:
 			for key, value in session_builder:
-				upsertor.set(key, value, encrypt=(key in SessionAdapter.EncryptedAttributes))
+				if key in SessionAdapter.EncryptedIdentifierFields and value is not None:
+					value = SessionAdapter.EncryptedPrefix + self.aes_encrypt(value)
+					upsertor.set(key, value)
+				else:
+					upsertor.set(key, value, encrypt=(key in SessionAdapter.EncryptedAttributes))
 
 		await upsertor.execute(event_type=EventTypes.SESSION_UPDATED)
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -260,6 +260,10 @@ class SessionService(asab.Service):
 
 		await upsertor.execute(event_type=EventTypes.SESSION_UPDATED)
 
+		L.log(asab.LOG_NOTICE, "Session updated.", struct_data={
+			"sid": session_id,
+			"type": session_dict.get(SessionAdapter.FN.Session.Type),
+		})
 		return await self.get(session_id)
 
 


### PR DESCRIPTION
# Issue
Successful re-login leads to logout. This is caused by session cookie value being stored improperly in the DB. This happens only in root SSO session update, i.e. re-login.

# Solution
Cookie value must be encrypted in session update the same way it is done in session creation.