### PR TITLE
Catch token decoding errors when finding sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.20
 
 ### Pre-releases
+- `v24.20-alpha10`
 - `v24.20-alpha9`
 - `v24.20-alpha8`
 - `v24.20-alpha7`
@@ -18,6 +19,7 @@
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
 
 ### Fix
+- Catch token decoding errors when finding sessions (#397, `v24.20-alpha10`)
 - Properly encrypt cookie value in session update (#394, `v24.20-alpha8`)
 - Properly parse URL query before adding new parameters (#393, `v24.20-alpha8`)
 - Delete client cookie on introspection failure (#385, `v24.20-alpha6`)

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -530,6 +530,10 @@ class OpenIdConnectService(asab.Service):
 		except binascii.Error as e:
 			L.error("Corrupt authorization code format: Base64 decoding failed.", struct_data={"code": code})
 			raise exceptions.SessionNotFoundError("Corrupt authorization code format") from e
+		except UnicodeEncodeError as e:
+			L.error("Corrupt authorization code format: ASCII decoding failed.", struct_data={"code": code})
+			raise exceptions.SessionNotFoundError("Corrupt authorization code format") from e
+
 		token_data = await self.TokenService.get(token_bytes, token_type=AuthorizationCode.TokenType)
 		if "cc" in token_data:
 			self.PKCE.evaluate_code_challenge(
@@ -552,8 +556,14 @@ class OpenIdConnectService(asab.Service):
 		try:
 			token_bytes = base64.urlsafe_b64decode(token_value.encode("ascii"))
 		except binascii.Error as e:
-			L.error("Corrupt access token format: Base64 decoding failed.", struct_data={"token_value": token_value})
+			L.error("Corrupt access token format: Base64 decoding failed.", struct_data={
+				"token_value": token_value})
 			raise exceptions.SessionNotFoundError("Corrupt access token format") from e
+		except UnicodeEncodeError as e:
+			L.error("Corrupt access token format: ASCII decoding failed.", struct_data={
+				"token_value": token_value})
+			raise exceptions.SessionNotFoundError("Corrupt access token format") from e
+
 		try:
 			token_data = await self.TokenService.get(token_bytes, token_type=AccessToken.TokenType)
 		except KeyError:
@@ -576,8 +586,14 @@ class OpenIdConnectService(asab.Service):
 		try:
 			token_bytes = base64.urlsafe_b64decode(token_value.encode("ascii"))
 		except binascii.Error as e:
-			L.error("Corrupt refresh token format: Base64 decoding failed.", struct_data={"token_value": token_value})
+			L.error("Corrupt refresh token format: Base64 decoding failed.", struct_data={
+				"token_value": token_value})
 			raise exceptions.SessionNotFoundError("Corrupt refresh token format") from e
+		except UnicodeEncodeError as e:
+			L.error("Corrupt refresh token format: ASCII decoding failed.", struct_data={
+				"token_value": token_value})
+			raise exceptions.SessionNotFoundError("Corrupt refresh token format") from e
+
 		try:
 			token_data = await self.TokenService.get(token_bytes, token_type=RefreshToken.TokenType)
 		except KeyError:


### PR DESCRIPTION
# Issue

Sending a non-base64 access token in Authorization header triggers an unhandled error.

# Solution

Catch the error and log the corrupt access token.

Also fixed for authorization codes and refresh tokens.