### PR TITLE
Fix attribute error in credentials update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.20
 
 ### Pre-releases
+- `v24.20-alpha11`
 - `v24.20-alpha10`
 - `v24.20-alpha9`
 - `v24.20-alpha8`
@@ -19,6 +20,7 @@
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
 
 ### Fix
+- Fix AttributeError in credentials update (#399, `v24.20-alpha11`)
 - Catch token decoding errors when finding sessions (#397, `v24.20-alpha10`)
 - Properly encrypt cookie value in session update (#394, `v24.20-alpha8`)
 - Properly parse URL query before adding new parameters (#393, `v24.20-alpha8`)

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -733,6 +733,7 @@ class CredentialsService(asab.Service):
 		"""
 		Check if the target user is a member of currently authorized tenant
 		"""
+		tenant_service = self.App.get_service("seacatauth.TenantService")
 		if not session:
 			return False
 		if session.is_superuser():
@@ -740,7 +741,7 @@ class CredentialsService(asab.Service):
 		for tenant_id in session.Authorization.Authz.keys():
 			if tenant_id == "*":
 				continue
-			if await self.TenantService.has_tenant_assigned(credentials_id, tenant_id):
+			if await tenant_service.has_tenant_assigned(credentials_id, tenant_id):
 				# User is member of currently authorized tenant
 				return True
 		# The request and the target credentials have no tenant in common


### PR DESCRIPTION
# Issue

**Updating credentials does not work since #371 (`v24.17-alpha5`)**

Updating credentials causes the following error:
```
26-Jun-2024 12:28:52.929632 ERROR asab.web [sd uuid="615d4178-f178-4012-88a3-724f249001b0" path="/account/credentials" status="500" X-Forwarded-For="fd00:10:17:68:5c85:fb59:2af5:8b9b" Connection="Upgrade" Host="upstream-seacat-auth-8900" Content-Length="36" User-Agent="Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0" Accept="application/json, text/plain, */*" Accept-Language="en-US,en;q=0.5" Accept-Encoding="gzip, deflate, br, zstd" Referer="https://cake1/" Content-Type="application/json" Origin="https://cake1" sec-fetch-dest="empty" sec-fetch-mode="cors" sec-fetch-site="same-origin" priority="u=1" Cookie="SeaCatSCI_QBOAFDNWZ52WDP22=pvtOPB6eMsyAvou6PUQvq3-VVq-Gkbzwbdi2Fqueaz-NnWG5L9kywAOyrDnPfOQu; SeaCatSCI_BGCFPK5ONDUD7PWP=LMpXVJ4kMx6IcWi-HDpvo_aMXDgT9aM99VyaFciOwzSpMHHYJWN-7R20em6Bt7je; SeaCatSCI=1AicdvmVuj7X97IWiStIW5fltD0d39k27bU8J6oN0MPtii8ljKpaUFufJt4F2525"] Exception when handling web request
Traceback (most recent call last):
File "/usr/lib/python3.11/site-packages/asab/web/rest/json.py", line 98, in JsonExceptionMiddleware
response = await handler(request)
^^^^^^^^^^^^^^^^^^^^^^
File "/app/seacat-auth/seacatauth/middleware.py", line 23, in app_middleware
return await handler(request)
^^^^^^^^^^^^^^^^^^^^^^
File "/app/seacat-auth/seacatauth/middleware.py", line 88, in private_auth_middleware
return await handler(request)
^^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3.11/site-packages/asab/web/rest/json.py", line 305, in validator
return await func(*args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/seacat-auth/seacatauth/decorators.py", line 130, in wrapper
return await handler(*args, **kwargs, **handler_kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/seacat-auth/seacatauth/credentials/handler.py", line 381, in update_my_credentials
result = await self.CredentialsService.update_credentials(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/seacat-auth/seacatauth/credentials/service.py", line 531, in update_credentials
if not await self.can_access_credentials(session, credentials_id):
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/app/seacat-auth/seacatauth/credentials/service.py", line 743, in can_access_credentials
if await self.TenantService.has_tenant_assigned(credentials_id, tenant_id):
^^^^^^^^^^^^^^^^^^
AttributeError: 'CredentialsService' object has no attribute 'TenantService'
26-Jun-2024 12:28:52.930707 NOTICE asab.web.al [sd I="10.17.175.236" al.m="PUT" al.p="/account/credentials" al.c="500" D="0.0033781947568058968" al.B="36" al.b="103" al.A="Mozilla/5.0 (X11; Linux x86_64; rv:127.0) Gecko/20100101 Firefox/127.0" Ix="fd00:10:17:68:5c85:fb59:2af5:8b9b"] 

```

# Solution

Tenant service must be accessed via `App.get_service()`.
