### PR TITLE
Fix token request for self-encoded (algorithmic) sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Default password criteria are more restrictive (#372, `v24.20-alpha1`, Compatible with Seacat Auth Webui v24.19-alpha and later, Seacat Account Webui v24.08-beta and later)
 
 ### Fix
+- Fix token request for self-encoded (algorithmic) sessions (#404, `v24.20-alpha12`)
 - Fix AttributeError in credentials update (#399, `v24.20-alpha11`)
 - Catch token decoding errors when finding sessions (#397, `v24.20-alpha10`)
 - Properly encrypt cookie value in session update (#394, `v24.20-alpha8`)

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -354,7 +354,7 @@ class AuthorizeHandler(object):
 		authenticated = root_session is not None and not root_session.is_anonymous()
 		allow_anonymous = "anonymous" in requested_scope
 		if allow_anonymous:
-			if client_dict.get("authorize_anonymous_users", False):
+			if not client_dict.get("authorize_anonymous_users", False):
 				raise OAuthAuthorizeError(
 					AuthErrorResponseCode.InvalidScope, client_id,
 					redirect_uri=redirect_uri,

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -1,16 +1,13 @@
 import logging
-import datetime
-
 import aiohttp.web
+import jwcrypto.jws
+import jwcrypto.jwt
+import json
 
 import asab
 import asab.web.rest
 import asab.web.rest.json
 import asab.exceptions
-
-import jwcrypto.jws
-import jwcrypto.jwt
-import json
 
 from .. import pkce
 from ..utils import TokenRequestErrorResponseCode

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -172,22 +172,20 @@ class TokenHandler(object):
 			"grant_type": "authorization_code",
 			"from_ip": from_ip})
 
+		# Client can limit the session scope to a subset of the scope granted at authorization time
+		scope = form_data.get("scope")
+
 		# Generate new auth tokens
 		if session.is_algorithmic():
-			new_access_token = await self.SessionService.Algorithmic.serialize(session)
-			access_token_expires_in = (
-				session.Session.Expiration - datetime.datetime.now(datetime.timezone.utc)).total_seconds()
+			new_access_token = self.SessionService.Algorithmic.serialize(session)
+			access_token_expires_in = self.SessionService.AnonymousExpiration
 			new_refresh_token, refresh_token_expires_in = None, None
 		else:
 			new_access_token, access_token_expires_in = await self.OpenIdConnectService.create_access_token(session)
 			new_refresh_token, refresh_token_expires_in = await self.OpenIdConnectService.create_refresh_token(session)
-
-		# Client can limit the session scope to a subset of the scope granted at authorization time
-		scope = form_data.get("scope")
-
-		# Refresh the session data
-		session = await self.OpenIdConnectService.refresh_session(
-			session, requested_scope=scope, expires_in=refresh_token_expires_in)
+			# Refresh the session data
+			session = await self.OpenIdConnectService.refresh_session(
+				session, requested_scope=scope, expires_in=refresh_token_expires_in)
 
 		# Response
 		response_payload = {

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -542,8 +542,7 @@ class OpenIdConnectService(asab.Service):
 				code_verifier=code_verifier)
 		if token_data.get("sa"):
 			# Session is algorithmic (self-encoded token)
-			algo_token = self.StorageService.aes_decrypt(token_data["sid"])
-			return await self.SessionService.Algorithmic.deserialize(algo_token.decode("ascii"))
+			return await self.SessionService.Algorithmic.deserialize(token_data["sid"])
 		else:
 			# Session is in the DB
 			return await self.SessionService.get(token_data["sid"])


### PR DESCRIPTION
# Issue
Token request fails if `anonymous` is in scope.

# Solution
- Fixed incorrect check on `client["authorize_anonymous_users"]`.
- Fixed broken AlgorithmicSession attributes in token request.
