### PR TITLE
Print ASAB version during Docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v24.29
+
+### Pre-releases
+
+### Features
+- Print ASAB version during Docker build (#406, `v24.29-alpha1`)
+
+---
+
+
 ## v24.20
 
 ### Pre-releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN apk add --no-cache  \
 # There is a broken pydantic dependency in webauthn.
 # Remove the version lock once this is fixed.
 
+RUN cat /usr/lib/python3.11/site-packages/asab/__version__.py
+
 RUN mkdir -p /app/seacat-auth
 WORKDIR /app/seacat-auth
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.18 AS stage1
 LABEL maintainer="TeskaLabs Ltd (support@teskalabs.com)"
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN set -ex \
   && apk update \


### PR DESCRIPTION
This is to easily find the used ASAB version in CI/CD build log.