### PR TITLE
Disable editing of managed items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.29
 
 ### Pre-releases
+- v24.29-alpha4
 - v24.29-alpha3
 - v24.29-alpha2
 - v24.29-alpha1
@@ -11,6 +12,7 @@
 - Handle session decryption error (#410, `v24.29-alpha2`)
 
 ### Features
+- Disable editing of managed resources and clients (#409, `v24.29-alpha4`)
 - Global roles propagated to tenants (#395, `v24.29-alpha3`)
 - Sort clients alphabetically by client name (#408, `v24.29-alpha2`)
 - Print ASAB version during Docker build (#406, `v24.29-alpha1`)

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -100,21 +100,20 @@ class ResourceService(asab.Service):
 		await self._ensure_builtin_resources()
 
 
-	async def is_editable_resource(self, resource: dict | str):
-		if isinstance(resource, str):
-			resource_id = resource
-			if resource_id in self._BuiltinResources:
-				return False
-			resource = await self.get(resource_id)
-		else:
-			resource_id = resource["_id"]
-			if resource_id in self._BuiltinResources:
-				return False
+	def is_resource_editable(self, resource: dict):
+		resource_id = resource["_id"]
+		if resource_id in self._BuiltinResources:
+			return False
 
 		if resource.get("managed_by"):
 			return False
 		else:
 			return True
+
+
+	def assert_resource_is_editable(self, resource: dict):
+		if not self.is_resource_editable(resource):
+			raise exceptions.NotEditableError("Resource is not editable.")
 
 
 	def is_global_only_resource(self, resource_id):
@@ -158,11 +157,7 @@ class ResourceService(asab.Service):
 		resources = []
 		count = await collection.count_documents(query_filter)
 		async for resource_dict in cursor:
-			if not await self.is_editable_resource(resource_dict):
-				resource_dict["editable"] = False
-			if self.is_global_only_resource(resource_dict["_id"]):
-				resource_dict["global_only"] = True
-			resources.append(resource_dict)
+			resources.append(self.normalize_resource(resource_dict))
 
 		return {
 			"data": resources,
@@ -172,14 +167,10 @@ class ResourceService(asab.Service):
 
 	async def get(self, resource_id: str):
 		try:
-			data = await self.StorageService.get(self.ResourceCollection, resource_id)
+			resource = await self.StorageService.get(self.ResourceCollection, resource_id)
 		except KeyError:
 			raise exceptions.ResourceNotFoundError(resource_id)
-		if not await self.is_editable_resource(data):
-			data["editable"] = False
-		if self.is_global_only_resource(data["_id"]):
-			data["global_only"] = True
-		return data
+		return self.normalize_resource(resource)
 
 
 	async def create(self, resource_id: str, description: str = None, is_managed_by_seacat_auth=False):
@@ -210,8 +201,7 @@ class ResourceService(asab.Service):
 
 	async def update(self, resource_id: str, description: str):
 		resource = await self.get(resource_id)
-		if not await self.is_editable_resource(resource):
-			raise asab.exceptions.ValidationError("Built-in resource cannot be modified")
+		self.assert_resource_is_editable(resource)
 		await self._update(resource, description)
 
 
@@ -236,8 +226,7 @@ class ResourceService(asab.Service):
 
 	async def delete(self, resource_id: str, hard_delete: bool = False):
 		resource = await self.get(resource_id)
-		if not await self.is_editable_resource(resource):
-			raise asab.exceptions.ValidationError("Built-in resource cannot be modified")
+		self.assert_resource_is_editable(resource)
 
 		# Remove the resource from all roles
 		role_svc = self.App.get_service("seacatauth.RoleService")
@@ -292,8 +281,7 @@ class ResourceService(asab.Service):
 		"""
 		# Get existing resource details and roles
 		resource = await self.get(resource_id)
-		if not await self.is_editable_resource(resource):
-			raise asab.exceptions.ValidationError("Built-in resource cannot be renamed")
+		self.assert_resource_is_editable(resource)
 
 		role_svc = self.App.get_service("seacatauth.RoleService")
 		roles = await role_svc.list(resource=resource_id)
@@ -315,3 +303,11 @@ class ResourceService(asab.Service):
 			"new_resource": resource_id,
 			"n_roles": roles["count"],
 		})
+
+
+	def normalize_resource(self, resource: dict):
+		if not self.is_resource_editable(resource):
+			resource["editable"] = False
+		if self.is_global_only_resource(resource["_id"]):
+			resource["global_only"] = True
+		return resource

--- a/seacatauth/client/handler.py
+++ b/seacatauth/client/handler.py
@@ -174,18 +174,14 @@ class ClientHandler(object):
 
 
 	def _rest_normalize(self, client: dict):
-		cookie_service = self.ClientService.App.get_service("seacatauth.CookieService")
-
 		rest_data = {
 			k: v
 			for k, v in client.items()
 			if not k.startswith("__")
 		}
-		rest_data["client_id"] = rest_data["_id"]
 		rest_data["client_id_issued_at"] = int(rest_data["_c"].timestamp())
 		if "__client_secret" in client:
 			rest_data["client_secret"] = True
 			if "client_secret_expires_at" in rest_data:
 				rest_data["client_secret_expires_at"] = int(rest_data["client_secret_expires_at"].timestamp())
-		rest_data["cookie_name"] = cookie_service.get_cookie_name(rest_data["_id"])
 		return rest_data

--- a/seacatauth/client/handler.py
+++ b/seacatauth/client/handler.py
@@ -140,11 +140,7 @@ class ClientHandler(object):
 		try:
 			await self.ClientService.update(client_id, **json_data)
 		except exceptions.NotEditableError as e:
-			return asab.web.rest.json_response(
-				request,
-				status=405,
-				data=e.rest_payload(),
-			)
+			return e.json_response(request)
 		return asab.web.rest.json_response(
 			request,
 			data={"result": "OK"},
@@ -160,11 +156,7 @@ class ClientHandler(object):
 		try:
 			client_secret, client_secret_expires_at = await self.ClientService.reset_secret(client_id)
 		except exceptions.NotEditableError as e:
-			return asab.web.rest.json_response(
-				request,
-				status=405,
-				data=e.rest_payload(),
-			)
+			return e.json_response(request)
 		response_data = {"client_secret": client_secret}
 		if client_secret_expires_at:
 			response_data["client_secret_expires_at"] = client_secret_expires_at
@@ -183,11 +175,7 @@ class ClientHandler(object):
 		try:
 			await self.ClientService.delete(client_id)
 		except exceptions.NotEditableError as e:
-			return asab.web.rest.json_response(
-				request,
-				status=405,
-				data=e.rest_payload(),
-			)
+			return e.json_response(request)
 		return asab.web.rest.json_response(
 			request,
 			data={"result": "OK"},

--- a/seacatauth/client/handler.py
+++ b/seacatauth/client/handler.py
@@ -5,7 +5,7 @@ import asab.web.rest
 import asab.exceptions
 
 from ..decorators import access_control
-from .. import generic
+from .. import generic, exceptions
 from .service import REGISTER_CLIENT_SCHEMA, UPDATE_CLIENT_SCHEMA, CLIENT_TEMPLATES, is_client_confidential
 
 #
@@ -137,7 +137,14 @@ class ClientHandler(object):
 		client_id = request.match_info["client_id"]
 		if "preferred_client_id" in json_data:
 			raise asab.exceptions.ValidationError("Cannot update attribute 'preferred_client_id'.")
-		await self.ClientService.update(client_id, **json_data)
+		try:
+			await self.ClientService.update(client_id, **json_data)
+		except exceptions.NotEditableError as e:
+			return asab.web.rest.json_response(
+				request,
+				status=405,
+				data=e.rest_payload(),
+			)
 		return asab.web.rest.json_response(
 			request,
 			data={"result": "OK"},
@@ -150,7 +157,14 @@ class ClientHandler(object):
 		Reset client secret
 		"""
 		client_id = request.match_info["client_id"]
-		client_secret, client_secret_expires_at = await self.ClientService.reset_secret(client_id)
+		try:
+			client_secret, client_secret_expires_at = await self.ClientService.reset_secret(client_id)
+		except exceptions.NotEditableError as e:
+			return asab.web.rest.json_response(
+				request,
+				status=405,
+				data=e.rest_payload(),
+			)
 		response_data = {"client_secret": client_secret}
 		if client_secret_expires_at:
 			response_data["client_secret_expires_at"] = client_secret_expires_at
@@ -166,7 +180,14 @@ class ClientHandler(object):
 		Delete a client
 		"""
 		client_id = request.match_info["client_id"]
-		await self.ClientService.delete(client_id)
+		try:
+			await self.ClientService.delete(client_id)
+		except exceptions.NotEditableError as e:
+			return asab.web.rest.json_response(
+				request,
+				status=405,
+				data=e.rest_payload(),
+			)
 		return asab.web.rest.json_response(
 			request,
 			data={"result": "OK"},

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -75,15 +75,6 @@ class RoleNotFoundError(SeacatAuthError, KeyError):
 		super().__init__("Role {!r} not found".format(self.Role), *args)
 
 
-class NotEditableError(SeacatAuthError):
-	"""
-	Target item is not editable
-	"""
-	def __init__(self, message="Item is not editable", *args, **kwargs):
-		self.Kwargs = kwargs
-		super().__init__(message, *args)
-
-
 class ResourceNotFoundError(SeacatAuthError, KeyError):
 	"""
 	Resource not found

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -100,6 +100,12 @@ class NotEditableError(SeacatAuthError):
 		self.Kwargs = kwargs
 		super().__init__(message, *args)
 
+	def rest_payload(self):
+		return {
+			"result": "ERROR",
+			"tech_err": "Item is not editable."
+		}
+
 
 class LoginPrologueDeniedError(SeacatAuthError):
 	"""

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -92,6 +92,15 @@ class CredentialsNotFoundError(SeacatAuthError, KeyError):
 		super().__init__("Credentials {!r} not found".format(self.CredentialsId), *args)
 
 
+class NotEditableError(SeacatAuthError):
+	"""
+	Target item is not editable
+	"""
+	def __init__(self, message="Item is not editable", *args, **kwargs):
+		self.Kwargs = kwargs
+		super().__init__(message, *args)
+
+
 class LoginPrologueDeniedError(SeacatAuthError):
 	"""
 	Seacat login prologue was denied

--- a/seacatauth/exceptions.py
+++ b/seacatauth/exceptions.py
@@ -1,6 +1,7 @@
 import typing
 
 import asab.exceptions
+import asab.web.rest
 
 
 class SeacatAuthError(Exception):
@@ -105,6 +106,13 @@ class NotEditableError(SeacatAuthError):
 			"result": "ERROR",
 			"tech_err": "Item is not editable."
 		}
+
+	def json_response(self, request):
+		return asab.web.rest.json_response(
+			request,
+			status=405,
+			data=self.rest_payload(),
+		)
 
 
 class LoginPrologueDeniedError(SeacatAuthError):


### PR DESCRIPTION
# Summary
- Clients and resources with non-empty `managed_by` attribute are considered non-editable.
- Non-editable items are marked with `editable: False` in REST responses.
- Attempts to edit or delete non-editable items raise `seacatauth.exceptions.NotEditableError` which is translated to HTTP response with code 405 and the following body:
```
{
	"result": "ERROR",
	"tech_err": "Item is not editable."
}
```