### PR TITLE
Handle session decryption error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## v24.29
 
 ### Pre-releases
+- v24.29-alpha2
+- v24.29-alpha2
+- v24.29-alpha1
+
+### Fix
+- Handle session decryption error (#410, `v24.29-alpha2`)
 
 ### Features
 - Sort clients alphabetically by client name (#408, `v24.29-alpha2`)


### PR DESCRIPTION
# Issue

Sessions created before https://github.com/TeskaLabs/asab/pull/587 trigger an unhandled ValueError in later versions.

# Solution

ValueError caught and logged with a warning.