### PR TITLE
Replace attribute editable: false with readonly: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 ## v24.29
 
 ### Pre-releases
+- v24.29-alpha5
 - v24.29-alpha4
 - v24.29-alpha3
 - v24.29-alpha2
 - v24.29-alpha1
 
 ### Fix
+- Non-editable items are marked with read_only flag (#411, `v24.29-alpha5`)
 - Handle session decryption error (#410, `v24.29-alpha2`)
 
 ### Features

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -100,19 +100,8 @@ class ResourceService(asab.Service):
 		await self._ensure_builtin_resources()
 
 
-	def is_resource_editable(self, resource: dict):
-		resource_id = resource["_id"]
-		if resource_id in self._BuiltinResources:
-			return False
-
-		if resource.get("managed_by"):
-			return False
-		else:
-			return True
-
-
 	def assert_resource_is_editable(self, resource: dict):
-		if not self.is_resource_editable(resource):
+		if resource.get("read_only"):
 			raise exceptions.NotEditableError("Resource is not editable.")
 
 
@@ -306,8 +295,8 @@ class ResourceService(asab.Service):
 
 
 	def normalize_resource(self, resource: dict):
-		if not self.is_resource_editable(resource):
-			resource["editable"] = False
+		if resource["_id"] in self._BuiltinResources or resource.get("managed_by"):
+			resource["read_only"] = True
 		if self.is_global_only_resource(resource["_id"]):
 			resource["global_only"] = True
 		return resource

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -174,9 +174,8 @@ class RoleHandler(object):
 		except exceptions.RoleNotFoundError:
 			return asab.web.rest.json_response(request, status=404, data={
 				"result": "ERROR", "tech_err": "Role not found."})
-		except exceptions.NotEditableError:
-			return asab.web.rest.json_response(request, status=405, data={
-				"result": "ERROR", "tech_err": "Role is not editable."})
+		except exceptions.NotEditableError as e:
+			return e.json_response(request)
 		return asab.web.rest.json_response(request, result)
 
 
@@ -233,7 +232,6 @@ class RoleHandler(object):
 		except exceptions.RoleNotFoundError:
 			return asab.web.rest.json_response(request, status=404, data={
 				"result": "ERROR", "tech_err": "Role not found."})
-		except exceptions.NotEditableError:
-			return asab.web.rest.json_response(request, status=405, data={
-				"result": "ERROR", "tech_err": "Role is not editable."})
+		except exceptions.NotEditableError as e:
+			return e.json_response(request)
 		return asab.web.rest.json_response(request, data={"result": result})

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -312,7 +312,7 @@ class RoleService(asab.Service):
 			L.log(asab.LOG_NOTICE, "Role not found.", struct_data={"role_id": role_id})
 			raise e
 
-		self.assert_role_is_editable(role_current)
+		assert_role_is_editable(role_current)
 
 		# Unassign the role from all credentials
 		await self.delete_role_assignments(role_current)
@@ -342,7 +342,7 @@ class RoleService(asab.Service):
 			L.log(asab.LOG_NOTICE, "Role not found.", struct_data={"role_id": role_id})
 			raise e
 
-		self.assert_role_is_editable(role_current)
+		assert_role_is_editable(role_current)
 
 		# Verify that role tenant exists
 		tenant_id = self._role_tenant_id(role_id)
@@ -626,7 +626,8 @@ class RoleService(asab.Service):
 		return await self.StorageService.get(self.CredentialsRolesCollection, assignment_id)
 
 
-	def assert_role_is_editable(self, role: dict):
-		if role.get("read_only"):
-			L.log(asab.LOG_NOTICE, "Role is not editable.", struct_data={"role_id": role["_id"]})
-			raise exceptions.NotEditableError("Role is not editable.")
+def assert_role_is_editable(role: dict):
+	if role.get("read_only"):
+		L.log(asab.LOG_NOTICE, "Role is not editable.", struct_data={"role_id": role["_id"]})
+		raise exceptions.NotEditableError("Role is not editable.")
+	return True

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -312,9 +312,7 @@ class RoleService(asab.Service):
 			L.log(asab.LOG_NOTICE, "Role not found.", struct_data={"role_id": role_id})
 			raise e
 
-		if not role_current.get("editable", True):
-			L.log(asab.LOG_NOTICE, "Role is not editable.", struct_data={"role_id": role_id})
-			raise exceptions.NotEditableError("Role is not editable.", role_id=role_id)
+		self.assert_role_is_editable(role_current)
 
 		# Unassign the role from all credentials
 		await self.delete_role_assignments(role_current)
@@ -344,9 +342,7 @@ class RoleService(asab.Service):
 			L.log(asab.LOG_NOTICE, "Role not found.", struct_data={"role_id": role_id})
 			raise e
 
-		if not role_current.get("editable", True):
-			L.log(asab.LOG_NOTICE, "Role is not editable.", struct_data={"role_id": role_id})
-			raise exceptions.NotEditableError("Role is not editable.", role_id=role_id)
+		self.assert_role_is_editable(role_current)
 
 		# Verify that role tenant exists
 		tenant_id = self._role_tenant_id(role_id)
@@ -628,3 +624,9 @@ class RoleService(asab.Service):
 	async def get_assigned_role(self, credentials_id: str, role_id: str):
 		assignment_id = "{} {}".format(credentials_id, role_id)
 		return await self.StorageService.get(self.CredentialsRolesCollection, assignment_id)
+
+
+	def assert_role_is_editable(self, role: dict):
+		if role.get("read_only"):
+			L.log(asab.LOG_NOTICE, "Role is not editable.", struct_data={"role_id": role["_id"]})
+			raise exceptions.NotEditableError("Role is not editable.")

--- a/seacatauth/authz/role/view/abc.py
+++ b/seacatauth/authz/role/view/abc.py
@@ -49,5 +49,5 @@ class RoleView(abc.ABC):
 
 	def _normalize_role(self, role: dict):
 		if role.get("managed_by"):
-			role["editable"] = False
+			role["read_only"] = True
 		return role

--- a/seacatauth/authz/role/view/propagated_role.py
+++ b/seacatauth/authz/role/view/propagated_role.py
@@ -81,6 +81,6 @@ class PropagatedRoleView(RoleView):
 		role["type"] = "tenant"
 		role["global_role_id"] = role["_id"]
 		role["_id"] = self._global_role_id_to_tenant(role["_id"])
-		role["editable"] = False
+		role["read_only"] = True
 		role["tenant"] = self.TenantId
 		return role

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -430,7 +430,7 @@ class ClientService(asab.Service):
 		"""
 		# TODO: Use M2M credentials provider.
 		client = await self.get(client_id)
-		self.assert_client_is_editable(client)
+		assert_client_is_editable(client)
 		upsertor = self.StorageService.upsertor(self.ClientCollection, obj_id=client_id, version=client["_v"])
 		client_secret, client_secret_expires_at = self._generate_client_secret()
 		client_secret_hash = generic.argon2_hash(client_secret)
@@ -447,7 +447,7 @@ class ClientService(asab.Service):
 
 	async def update(self, client_id: str, **kwargs):
 		client = await self.get(client_id)
-		self.assert_client_is_editable(client)
+		assert_client_is_editable(client)
 		client_update = {}
 		for k, v in kwargs.items():
 			if k not in CLIENT_METADATA_SCHEMA:
@@ -492,7 +492,7 @@ class ClientService(asab.Service):
 
 	async def delete(self, client_id: str):
 		client = await self.get(client_id)
-		self.assert_client_is_editable(client)
+		assert_client_is_editable(client)
 		await self.StorageService.delete(self.ClientCollection, client_id)
 		self._delete_from_cache(client_id)
 		L.log(asab.LOG_NOTICE, "Client deleted.", struct_data={"client_id": client_id})
@@ -591,12 +591,6 @@ class ClientService(asab.Service):
 			raise exceptions.ClientAuthenticationError("Incorrect client secret.", client_id=client_id)
 
 		return client_id
-
-
-	def assert_client_is_editable(self, client: dict):
-		if client.get("read_only"):
-			raise exceptions.NotEditableError("Client is not editable.")
-		return True
 
 
 	def _get_credentials_from_authorization_header(
@@ -789,3 +783,10 @@ def is_client_confidential(client: dict):
 		return True
 	else:
 		raise NotImplementedError("Unsupported token_endpoint_auth_method: {!r}".format(token_endpoint_auth_method))
+
+
+def assert_client_is_editable(client: dict):
+	if client.get("read_only"):
+		L.log(asab.LOG_NOTICE, "Client is not editable.", struct_data={"client_id": client["_id"]})
+		raise exceptions.NotEditableError("Client is not editable.")
+	return True

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -594,7 +594,7 @@ class ClientService(asab.Service):
 
 
 	def assert_client_is_editable(self, client: dict):
-		if not client.get("editable", True):
+		if client.get("read_only"):
 			raise exceptions.NotEditableError("Client is not editable.")
 		return True
 
@@ -748,7 +748,7 @@ class ClientService(asab.Service):
 	def _normalize_client(self, client: dict):
 		client["client_id"] = client["_id"]
 		if client.get("managed_by"):
-			client["editable"] = False
+			client["read_only"] = True
 		cookie_svc = self.App.get_service("seacatauth.CookieService")
 		client["cookie_name"] = cookie_svc.get_cookie_name(client["_id"])
 		return client


### PR DESCRIPTION
# Issue

The `editable` flag is awkward and error-prone to work with, because it is considered `true` by default. `item.get("editable")` is usually just None or False, which both cast to False

# Solution

Use `read_only` flag which is false by default.