### PR TITLE
Effective session expiration must match Access Token expiration

### DIFF
--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -579,6 +579,9 @@ class OpenIdConnectService(asab.Service):
 			await self.TokenService.delete(token_bytes)
 			raise exceptions.SessionNotFoundError("Access token points to a nonexistent session")
 
+		# Effective session expiration must match Access Token expiration
+		session.Session.Expiration = token_data["exp"]
+
 		return session
 
 


### PR DESCRIPTION
# Issue
The `exp` claim in userinfo response does not correspond to actual session validity (but rather incorrectly to Refresh Token validity). Since the UI relies on this claim, it cannot show the "Session expired" warning properly.

# Solution
When retrieving session from the DB, its expiration is set to the expiration of the Access Token.