### PR TITLE
Run Batman with warning when there is no ElasticSearch URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.29
 
 ### Pre-releases
+- v24.29-alpha6
 - v24.29-alpha5
 - v24.29-alpha4
 - v24.29-alpha3
@@ -14,6 +15,7 @@
 - Handle session decryption error (#410, `v24.29-alpha2`)
 
 ### Features
+- Run Batman with warning when there is no ElasticSearch URL (#413, `v24.29-alpha6`)
 - Disable editing of managed resources and clients (#409, `v24.29-alpha4`)
 - Global roles propagated to tenants (#395, `v24.29-alpha3`)
 - Sort clients alphabetically by client name (#408, `v24.29-alpha2`)

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -66,6 +66,10 @@ class ElasticSearchIntegration(asab.config.Configurable):
 		self.RoleService = self.App.get_service("seacatauth.RoleService")
 		self.ResourceService = self.App.get_service("seacatauth.ResourceService")
 
+		if not self.Config.get("url"):
+			L.warning("No ElasticSearch URL provided. Batman module will not be active.")
+			return
+
 		self.Kibana = KibanaUtils(self.App, config_section_name, config)
 
 		elasticsearch_url = self.Config.get("url")


### PR DESCRIPTION
The app does not crash at init when ElasticSearch URL is missing in config. It displays a warning instead.