### PR TITLE
Duplicating roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v24.36
+
+### Pre-releases
+- v24.36-alpha1
+
+### Features
+- Duplicating roles (#416, `v24.36-alpha1`)
+
+---
+
+
 ## v24.29
 
 ### Pre-releases

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -138,11 +138,21 @@ class RoleHandler(object):
 	async def create(self, request, *, tenant, json_data):
 		"""
 		Create a new role
+
+		---
+		parameters:
+		-	name: copy
+			in: query
+			description:
+				Copy resources and description from a specified existing role.
+				Resources non-applicable for the new role will be excluded.
+			schema:
+				type: string
 		"""
 		role_name = request.match_info["role_name"]
 		role_id = "{}/{}".format(tenant, role_name)
 		try:
-			role_id = await self.RoleService.create(role_id, **json_data)
+			role_id = await self.RoleService.create(role_id, from_role=request.query.get("copy"), **json_data)
 		except exceptions.ResourceNotFoundError as e:
 			return asab.web.rest.json_response(request, status=404, data={
 				"result": "ERROR",


### PR DESCRIPTION
# Summary

- Endpoint `POST /role/{tenant}/{role_name}` now has an option to copy resources and description from another role.
- This can be done using a new optional query parameter `copy={role_id}`.
