### PR TITLE
Upgrade CI/CD action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Docker Metadata action
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       id: meta
       with:
           images:  teskalabs/seacat-auth
@@ -85,13 +85,13 @@ jobs:
             type=semver,pattern={{raw}}
     
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_USER }} 
         password: ${{ secrets.DOCKER_PASSWORD }}  
       
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true
@@ -99,7 +99,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Create Docker Starter
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1.2
       with:
         files: example/docker
         dest: seacat-auth-docker-starter.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
         python-version: ["3.11", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -45,10 +45,10 @@ jobs:
         python-version: ["3.11", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -72,7 +72,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
     - name: Docker Metadata action
       uses: docker/metadata-action@v3
@@ -105,7 +105,7 @@ jobs:
         dest: seacat-auth-docker-starter.zip
 
     - name: Upload Docker Starter
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: seacat-auth-docker-starter
         path: ${{ github.workspace }}/seacat-auth-docker-starter.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 ## v24.36
 
 ### Pre-releases
-- v24.36-alpha2
+- v24.36-alpha3
+- ~~v24.36-alpha2~~
 - v24.36-alpha1
 - v24.29-alpha7
 - v24.29-alpha6
 
 ### Fix
-- Sort assigned tenants and roles alphabetically (#417, `v24.36-alpha2`)
+- Upgrade CI/CD action versions (#418, `v24.36-alpha3`)
+- Sort assigned tenants and roles alphabetically (#417, `v24.36-alpha3`)
 - Do not check tenant existence when unassigning tenant (#415, `v24.29-alpha8`)
 - Hotfix: Session expiration in userinfo must match access token expiration (#414, `v24.29-alpha7`)
 


### PR DESCRIPTION
# Issue
CICD failing because some github actions have been obsoleted. Example:
https://github.com/TeskaLabs/seacat-auth/actions/runs/10831948469

# Solution
Upgrade to latest action versions.