### PR TITLE
Fix handling of empty filter in LDAP credentials provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - v24.29-alpha6
 
 ### Fix
+- Fix handling of empty filter in LDAP credentials provider (#421, `v24.36-alpha3`)
 - Sort assigned tenants and roles alphabetically (#417, `v24.36-alpha2`)
 - Do not check tenant existence when unassigning tenant (#415, `v24.29-alpha8`)
 - Hotfix: Session expiration in userinfo must match access token expiration (#414, `v24.29-alpha7`)

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -288,11 +288,12 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 			yield i
 
 	def _build_search_filter(self, filtr=None):
-		if filtr is None:
+		if not filtr:
 			filterstr = self.Config["filter"]
 		else:
 			# The query filter is the intersection of the filter from config
 			# and the filter defined by the search request
+			# The username must START WITH the given filter string
 			filter_template = "(&{}({}=*%s*))".format(self.Config["filter"], self.Config["attrusername"])
 			assertion_values = ["{}".format(filtr.lower())]
 			filterstr = ldap.filter.filter_format(

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -176,20 +176,17 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 
 		# TODO: Validate credetials_id with regex
 
-		# Ensure that the base lies within configured base
-		base = base64.urlsafe_b64decode(credentials_id[len(prefix):]).decode("utf-8")
-		if not base.endswith(self.Config["base"]):
-			raise KeyError("Credentials {!r} do not end with {!r}".format(credentials_id, self.Config["base"]))
-
+		cn = base64.urlsafe_b64decode(credentials_id[len(prefix):]).decode("utf-8")
 		with self._ldap_client() as lc:
 			try:
 				sr = lc.search_s(
-					base,
+					cn,
 					ldap.SCOPE_BASE,
 					filterstr=self.Config["filter"],
 					attrlist=self.AttrList,
 				)
-			except ldap.NO_SUCH_OBJECT:
+			except ldap.NO_SUCH_OBJECT as e:
+				L.error(e)
 				sr = []
 
 		if len(sr) == 0:


### PR DESCRIPTION
- Proper evaluation of empty string filter in LDAP credentials provider.
- Removed problematic case-sensitive CN comparison: "CN=..." and "cn=..." must be considered the same.