### PR TITLE
Avoid stacktrace when LDAP credentials server is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## v24.39
 
 ### Pre-releases
+- v24.39-alpha3
 - v24.39-alpha2
 - v24.39-alpha1
 
 ### Fix
+- Avoid logging stacktrace when LDAP credentials server is down (#426, `v24.39-alpha3`)
 - Log the credentials out when they are suspended (#425, `v24.39-alpha2`)
 - Fix credentials custom data editing (#424, `v24.39-alpha1`)
 


### PR DESCRIPTION
When a request to LDAP credentials server fails with `ldap.SERVER_DOWN`, a warning is logged instead of unhandled stacktrace:

```
04-Oct-2024 18:40:10.574199 WARNING seacatauth.credentials.providers.ldap [sd provider_id="ad" uri="ldap://ad.example.int"] LDAP server is down.
```