### PR TITLE
Fix role error in provisioning startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## v24.45
 
 ### Pre-releases
+- v24.45-alpha2
 - v24.45-alpha1
 
 ### Fix
+- Fix role error in provisioning startup (#428, v24.45-alpha2)
 - Log more details when message delivery fails (#427, v24.45-alpha1)
 
 ---

--- a/example/docker/docker-compose.yml
+++ b/example/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
 
   # Database for SeaCat Auth

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -7,7 +7,6 @@ import asab.exceptions
 import asab.storage.exceptions
 
 from ..client.service import CLIENT_TEMPLATES
-from ..generic import SessionContext
 
 #
 

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -7,6 +7,7 @@ import asab.exceptions
 import asab.storage.exceptions
 
 from ..client.service import CLIENT_TEMPLATES
+from ..generic import SessionContext
 
 #
 
@@ -64,6 +65,7 @@ class ProvisioningService(asab.Service):
 
 		# TODO: ResourceService should be already initialized by the app
 		await self.ResourceService.initialize(app)
+		await self.RoleService.initialize(app)
 		await self.ClientService.initialize(app)
 
 		# Create provisioning credentials provider
@@ -95,17 +97,6 @@ class ProvisioningService(asab.Service):
 		except asab.exceptions.Conflict:
 			L.log(asab.LOG_NOTICE, "Tenant already assigned.", struct_data={
 				"cid": self.SuperuserID, "tenant": self.TenantID})
-
-		# Create superuser role
-		try:
-			await self.RoleService.create(self.SuperroleID)
-		except asab.exceptions.Conflict:
-			L.log(asab.LOG_NOTICE, "Role already exists.", struct_data={"role": self.SuperroleID})
-
-		# Ensure the role has superuser access
-		await self.RoleService.update(
-			role_id=self.SuperroleID,
-			resources_to_set=["authz:superuser"])
 
 		# Assign superuser role to the provisioning user
 		try:


### PR DESCRIPTION
# Issue

When service starts in provisioning mode:

```
12-Nov-2024 11:09:25.732780 ERROR asab.application Error during service initialization
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/asab/application.py", line 730, in _ensure_initialization
    await service.initialize(self)
  File "/app/seacat-auth/seacatauth/provisioning/service.py", line 101, in initialize
    await self.RoleService.create(self.SuperroleID)
  File "/app/seacat-auth/seacatauth/authz/role/service.py", line 236, in create
    self.validate_superuser_access()
  File "/app/seacat-auth/seacatauth/authz/role/service.py", line 298, in validate_superuser_access
    raise exceptions.AccessDeniedError(
seacatauth.exceptions.AccessDeniedError: Not authorized to access 'authz:superuser'.
```

# Solution

Remove duplicate superuser role initialization - it is already handled by RoleService.