### PR TITLE
Do not automatically assign tenant to its creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 ## v24.45
 
 ### Pre-releases
+- v24.45-alpha3
 - v24.45-alpha2
 - v24.45-alpha1
 
 ### Fix
 - Fix role error in provisioning startup (#428, v24.45-alpha2)
 - Log more details when message delivery fails (#427, v24.45-alpha1)
+
+### Features
+- Do not automatically assign tenant to its creator (#429, v24.45-alpha3)
 
 ---
 


### PR DESCRIPTION
The `POST /tenant` endpoint has a new query parameter `assign_me`. When it is set to `yes`, the sender is automatically assigned as the admin of the newly created tenant. If the parameter is false (default), there is no automatic assignment when the tenant is created.

:warning: This changes the behavior of Seacat Admin UI versions lower than `v24.47`. For the best experience, use Seacat Admin UI `v24.47` or later.