### PR TITLE
Catch and log ldap.INVALID_CREDENTIALS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@
 ## v24.45
 
 ### Pre-releases
+- v24.45-alpha4
 - v24.45-alpha3
 - v24.45-alpha2
 - v24.45-alpha1
 
 ### Fix
+- Catch and log ldap.INVALID_CREDENTIALS (#431, v24.45-alpha4)
 - Fix role error in provisioning startup (#428, v24.45-alpha2)
 - Log more details when message delivery fails (#427, v24.45-alpha1)
 

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -108,6 +108,9 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 		except ldap.SERVER_DOWN:
 			L.warning("LDAP server is down.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
 			return None
+		except ldap.INVALID_CREDENTIALS:
+			L.error("Invalid LDAP credentials.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
+			return None
 
 
 	async def search(self, filter: dict = None, sort: dict = None, page: int = 0, limit: int = 0, **kwargs) -> list:
@@ -118,6 +121,9 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 		except ldap.SERVER_DOWN:
 			L.warning("LDAP server is down.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
 			return []
+		except ldap.INVALID_CREDENTIALS:
+			L.error("Invalid LDAP credentials.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
+			return []
 
 
 	async def count(self, filtr=None) -> int:
@@ -127,6 +133,9 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 		except ldap.SERVER_DOWN:
 			L.warning("LDAP server is down.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
 			return None
+		except ldap.INVALID_CREDENTIALS:
+			L.error("Invalid LDAP credentials.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
+			return None
 
 
 	async def iterate(self, offset: int = 0, limit: int = -1, filtr: str = None):
@@ -135,6 +144,9 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 			results = await self.ProactorService.execute(self._search_worker, filterstr)
 		except ldap.SERVER_DOWN:
 			L.warning("LDAP server is down.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
+			return
+		except ldap.INVALID_CREDENTIALS:
+			L.error("Invalid LDAP credentials.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
 			return
 		for i in results[offset:(None if limit == -1 else limit + offset)]:
 			yield i
@@ -146,6 +158,9 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 		except ldap.SERVER_DOWN:
 			L.warning("LDAP server is down.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
 			return None
+		except ldap.INVALID_CREDENTIALS:
+			L.error("Invalid LDAP credentials.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
+			return None
 
 
 	async def authenticate(self, credentials_id: str, credentials: dict) -> bool:
@@ -155,6 +170,9 @@ class LDAPCredentialsProvider(CredentialsProviderABC):
 			return await self.ProactorService.execute(self._authenticate_worker, dn, password)
 		except ldap.SERVER_DOWN:
 			L.warning("LDAP server is down.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
+			return False
+		except ldap.INVALID_CREDENTIALS:
+			L.error("Invalid LDAP credentials.", struct_data={"provider_id": self.ProviderID, "uri": self.LdapUri})
 			return False
 
 


### PR DESCRIPTION
Prevent traceback and log an error instead.