### PR TITLE
Remove expires_in from token response for anonymous sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v24.45
 
 ### Pre-releases
+- v24.45-alpha6
 - v24.45-alpha5
 - v24.45-alpha4
 - v24.45-alpha3
@@ -10,6 +11,7 @@
 - v24.45-alpha1
 
 ### Fix
+- Remove expires_in from token response for anonymous sessions (#434, v24.45-alpha6)
 - Catch and log ldap.INVALID_CREDENTIALS (#431, v24.45-alpha4)
 - Fix role error in provisioning startup (#428, v24.45-alpha2)
 - Log more details when message delivery fails (#427, v24.45-alpha1)

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -175,7 +175,7 @@ class TokenHandler(object):
 		# Generate new auth tokens
 		if session.is_algorithmic():
 			new_access_token = self.SessionService.Algorithmic.serialize(session)
-			access_token_expires_in = self.SessionService.AnonymousExpiration
+			access_token_expires_in = None
 			new_refresh_token, refresh_token_expires_in = None, None
 		else:
 			new_access_token, access_token_expires_in = await self.OpenIdConnectService.create_access_token(session)
@@ -190,8 +190,10 @@ class TokenHandler(object):
 			"scope": " ".join(session.OAuth2.Scope),
 			"access_token": new_access_token,
 			"id_token": await self.OpenIdConnectService.issue_id_token(session, access_token_expires_in),
-			"expires_in": int(access_token_expires_in),
 		}
+
+		if access_token_expires_in:
+			response_payload["expires_in"] = int(access_token_expires_in)
 
 		if new_refresh_token:
 			response_payload["refresh_token"] = new_refresh_token


### PR DESCRIPTION
# Issue
Anonymous sessions are algorithmic - they use self-encoded JWTokens instead of being stored in the database. These tokens have no `exp` attribute, but in the token response there is `expires_in` with default value, which is not true.

# Fix
Field `expires_in` removed from token response for anonymous sessions.