### PR TITLE
Hotfix: Ignore client secret if client is configured as public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - ASAB WebUI v24.47 and later
 
 ### Pre-releases
+- v24.45-beta2
+- v24.45-beta
 - v24.45-alpha7
 - v24.45-alpha6
 - v24.45-alpha5
@@ -13,6 +15,9 @@
 - v24.45-alpha3
 - v24.45-alpha2
 - v24.45-alpha1
+
+### Patch
+- Hotfix: Ignore client secret if client is configured as public (#434, v24.45-beta2)
 
 ### Fix
 - Remove expires_in from token response for anonymous sessions (#434, v24.45-alpha6)

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -566,6 +566,15 @@ class ClientService(asab.Service):
 		# Check if used authentication method matches the pre-configured one
 		expected_auth_method = client_dict.get("token_endpoint_auth_method", "client_secret_basic")
 		if auth_method != expected_auth_method:
+
+			# TODO: Remove this temporary workaround
+			# >>>
+			if expected_auth_method == "none":
+				# Client is configured as public
+				# -> skip secret verification even if secret is provided in the request
+				return client_id
+			# <<<
+
 			raise exceptions.ClientAuthenticationError(
 				"Unexpected authentication method (expected {!r}, got {!r}).".format(
 					expected_auth_method, auth_method),


### PR DESCRIPTION
**This is a temporary solution for ASAB Maestro deployments.**

If a public client (`token_endpoint_auth_method: 'none'`) tries to authenticate using a client secret, ignore it instead of denying the request.