### PR TITLE
Rename SessionAdapter to Session and move to seacatauth.models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.05
 
 ### Pre-releases
+- v25.05-alpha6
 - v25.05-alpha5
 - v25.05-alpha4
 - v25.05-alpha3
@@ -18,6 +19,7 @@
 - Provisioning service initialization uses system Session object (#439, v25.05-alpha2)
 
 ### Refactoring
+- Rename SessionAdapter to Session and move to seacatauth.models (#443, v25.05-alpha6)
 - Refactor communication module, merge message builders into communication providers (#442, v25.05-alpha5)
 - Remove session adapter's dependency on session service (#441, v25.05-alpha4)
 

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -6,7 +6,7 @@ import asab
 
 from .. import AuditLogger, generic
 from ..generic import nginx_introspection
-from ..session import SessionAdapter
+from ..session import Session
 
 #
 
@@ -82,7 +82,7 @@ class M2MIntrospectHandler(object):
 
 		# Find session object
 		try:
-			session = await self.SessionService.get_by(SessionAdapter.FN.Credentials.Id, credentials_id)
+			session = await self.SessionService.get_by(Session.FN.Credentials.Id, credentials_id)
 		except KeyError:
 			session = None
 

--- a/seacatauth/authn/m2m.py
+++ b/seacatauth/authn/m2m.py
@@ -6,7 +6,7 @@ import asab
 
 from .. import AuditLogger, generic
 from ..generic import nginx_introspection
-from ..session import Session
+from ..models import Session
 
 #
 

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -12,13 +12,12 @@ from .login_session import LoginSession
 from .. import exceptions, generic, AuditLogger
 from ..last_activity import EventCode
 from ..authz import build_credentials_authz
-
+from ..models import Session
 from ..session import (
 	credentials_session_builder,
 	authz_session_builder,
 	authentication_session_builder,
 	available_factors_session_builder,
-	Session,
 )
 
 from ..events import EventTypes

--- a/seacatauth/authn/service.py
+++ b/seacatauth/authn/service.py
@@ -18,7 +18,7 @@ from ..session import (
 	authz_session_builder,
 	authentication_session_builder,
 	available_factors_session_builder,
-	SessionAdapter,
+	Session,
 )
 
 from ..events import EventTypes
@@ -327,7 +327,7 @@ class AuthenticationService(asab.Service):
 				break
 		return authenticated
 
-	async def login(self, login_session, root_session: SessionAdapter | None = None, from_info: list = None):
+	async def login(self, login_session, root_session: Session | None = None, from_info: list = None):
 		"""
 		Build and create a root session
 		"""
@@ -437,8 +437,8 @@ class AuthenticationService(asab.Service):
 			},
 		)
 		session_builders.append((
-			(SessionAdapter.FN.Authentication.ImpersonatorCredentialsId, impersonator_cid),
-			(SessionAdapter.FN.Authentication.ImpersonatorSessionId, impersonator_session.SessionId),
+			(Session.FN.Authentication.ImpersonatorCredentialsId, impersonator_cid),
+			(Session.FN.Authentication.ImpersonatorSessionId, impersonator_session.SessionId),
 		))
 
 		session = await self.SessionService.create_session(

--- a/seacatauth/batman/grafana.py
+++ b/seacatauth/batman/grafana.py
@@ -5,7 +5,7 @@ import aiohttp.client_exceptions
 import asab
 import asab.config
 
-from seacatauth.authz import build_credentials_authz
+from ..authz import build_credentials_authz
 
 #
 

--- a/seacatauth/cookie/service.py
+++ b/seacatauth/cookie/service.py
@@ -10,7 +10,9 @@ import asab.storage
 import asab.exceptions
 
 from .. import exceptions
-from ..session.adapter import SessionAdapter, CookieData
+from ..models import Session
+
+from ..models.session import CookieData
 from ..session.builders import cookie_session_builder
 from .. import AuditLogger
 
@@ -117,7 +119,7 @@ class CookieService(asab.Service):
 				"Cookie value is not base64", query={"cookie_value": cookie_value}) from e
 
 		try:
-			session = await self.SessionService.get_by(SessionAdapter.FN.Cookie.Id, cookie_value)
+			session = await self.SessionService.get_by(Session.FN.Cookie.Id, cookie_value)
 		except KeyError as e:
 			raise exceptions.SessionNotFoundError(
 				"Session not found", query={"cookie_value": cookie_value}) from e
@@ -204,7 +206,7 @@ class CookieService(asab.Service):
 		return session
 
 
-	async def extend_session_expiration(self, session: SessionAdapter, client: dict = None):
+	async def extend_session_expiration(self, session: Session, client: dict = None):
 		expiration = client.get("session_expiration") if client else None
 		if expiration:
 			expiration = datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=expiration)

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -11,7 +11,7 @@ import typing
 from .policy import CredentialsPolicy
 from .providers.abc import CredentialsProviderABC, EditableCredentialsProviderABC
 from .. import AuditLogger, generic, exceptions
-from ..session import SessionAdapter
+from ..session import Session
 
 #
 
@@ -239,7 +239,7 @@ class CredentialsService(asab.Service):
 				return False
 
 
-	async def list(self, session: SessionAdapter, search_params: generic.SearchParams, try_global_search: bool = False):
+	async def list(self, session: Session, search_params: generic.SearchParams, try_global_search: bool = False):
 		"""
 		List credentials that are members of currently authorized tenants.
 		Global_search lists all credentials, regardless of tenants, but this requires superuser authorization.
@@ -346,7 +346,7 @@ class CredentialsService(asab.Service):
 		self.register_provider(provider)
 
 
-	async def create_credentials(self, provider_id: str, credentials_data: dict, session: SessionAdapter = None):
+	async def create_credentials(self, provider_id: str, credentials_data: dict, session: Session = None):
 		# Record the requester's ID for logging purposes
 		agent_cid = session.Credentials.Id if session is not None else None
 
@@ -409,7 +409,7 @@ class CredentialsService(asab.Service):
 
 
 	# TODO: Implement editing for M2M credentials
-	async def update_credentials(self, credentials_id: str, update_dict: dict, session: SessionAdapter = None):
+	async def update_credentials(self, credentials_id: str, update_dict: dict, session: Session = None):
 		"""
 		Validate the input data in the update dict according to active policies
 		and update credentials in the respective provider.
@@ -649,7 +649,7 @@ class CredentialsService(asab.Service):
 
 
 def _authorize_searched_tenants(
-	session: SessionAdapter,
+	session: Session,
 	search_params: generic.SearchParams,
 	try_global_search: bool = False
 ) -> typing.Optional[typing.Iterable[str]]:
@@ -685,7 +685,7 @@ def _authorize_searched_tenants(
 
 
 def _authorize_searched_roles(
-	session: SessionAdapter,
+	session: Session,
 	search_params: generic.SearchParams
 ) -> typing.Optional[typing.Iterable[str]]:
 	"""

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -11,7 +11,7 @@ import typing
 from .policy import CredentialsPolicy
 from .providers.abc import CredentialsProviderABC, EditableCredentialsProviderABC
 from .. import AuditLogger, generic, exceptions
-from ..session import Session
+from ..models import Session
 
 #
 

--- a/seacatauth/decorators.py
+++ b/seacatauth/decorators.py
@@ -5,7 +5,7 @@ import inspect
 import aiohttp.web
 import asab
 
-from seacatauth import exceptions
+from . import exceptions
 
 #
 

--- a/seacatauth/models/__init__.py
+++ b/seacatauth/models/__init__.py
@@ -1,0 +1,5 @@
+from .session import Session
+
+__all__ = [
+	"Session",
+]

--- a/seacatauth/models/session.py
+++ b/seacatauth/models/session.py
@@ -5,8 +5,8 @@ import datetime
 import typing
 import asab
 
-from seacatauth import AuditLogger
-from seacatauth.authz.rbac.service import RBACService
+from .. import AuditLogger
+from ..authz.rbac.service import RBACService
 
 
 L = logging.getLogger(__name__)

--- a/seacatauth/models/session.py
+++ b/seacatauth/models/session.py
@@ -5,8 +5,8 @@ import datetime
 import typing
 import asab
 
-from .. import AuditLogger
-from ..authz.rbac.service import RBACService
+from seacatauth import AuditLogger
+from seacatauth.authz.rbac.service import RBACService
 
 
 L = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ class BatmanData:
 	Token: typing.Optional[str]
 
 
-class SessionAdapter:
+class Session:
 	"""
 	Light object that represent a momentary view on the persisted session
 	"""
@@ -438,44 +438,44 @@ class SessionAdapter:
 
 def rest_get(session_dict):
 	data = {
-		"_id": session_dict.get(SessionAdapter.FN.SessionId),
-		"_c": session_dict.get(SessionAdapter.FN.CreatedAt),
-		"_m": session_dict.get(SessionAdapter.FN.ModifiedAt),
-		"_v": session_dict.get(SessionAdapter.FN.Version),
-		"type": session_dict.get(SessionAdapter.FN.Session.Type),
-		"expiration": session_dict.get(SessionAdapter.FN.Session.Expiration),
-		"max_expiration": session_dict.get(SessionAdapter.FN.Session.MaxExpiration),
-		"credentials_id": session_dict.get(SessionAdapter.FN.Credentials.Id),
-		"authn_time": session_dict.get(SessionAdapter.FN.Authentication.AuthnTime),
-		"login_descriptor": session_dict.get(SessionAdapter.FN.Authentication.LoginDescriptor),
-		"login_factors": session_dict.get(SessionAdapter.FN.Authentication.LoginFactors),
-		"tenants": session_dict.get(SessionAdapter.FN.Authorization.AssignedTenants),
-		"resources": session_dict.get(SessionAdapter.FN.Authorization.Authz),
-		"track_id": session_dict.get(SessionAdapter.FN.Session.TrackId),
+		"_id": session_dict.get(Session.FN.SessionId),
+		"_c": session_dict.get(Session.FN.CreatedAt),
+		"_m": session_dict.get(Session.FN.ModifiedAt),
+		"_v": session_dict.get(Session.FN.Version),
+		"type": session_dict.get(Session.FN.Session.Type),
+		"expiration": session_dict.get(Session.FN.Session.Expiration),
+		"max_expiration": session_dict.get(Session.FN.Session.MaxExpiration),
+		"credentials_id": session_dict.get(Session.FN.Credentials.Id),
+		"authn_time": session_dict.get(Session.FN.Authentication.AuthnTime),
+		"login_descriptor": session_dict.get(Session.FN.Authentication.LoginDescriptor),
+		"login_factors": session_dict.get(Session.FN.Authentication.LoginFactors),
+		"tenants": session_dict.get(Session.FN.Authorization.AssignedTenants),
+		"resources": session_dict.get(Session.FN.Authorization.Authz),
+		"track_id": session_dict.get(Session.FN.Session.TrackId),
 	}
-	psid = session_dict.get(SessionAdapter.FN.Session.ParentSessionId)
+	psid = session_dict.get(Session.FN.Session.ParentSessionId)
 	if psid is not None:
 		data["parent_session_id"] = psid
 
-	client_id = session_dict.get(SessionAdapter.FN.OAuth2.ClientId)
+	client_id = session_dict.get(Session.FN.OAuth2.ClientId)
 	if client_id is not None:
 		data["client_id"] = client_id
-	scope = session_dict.get(SessionAdapter.FN.OAuth2.Scope)
+	scope = session_dict.get(Session.FN.OAuth2.Scope)
 	if scope is not None:
 		data["scope"] = scope
 
-	if session_dict.get(SessionAdapter.FN.OAuth2.AccessToken) is not None:
+	if session_dict.get(Session.FN.OAuth2.AccessToken) is not None:
 		data["access_token"] = True
-	if session_dict.get(SessionAdapter.FN.Cookie.Id) is not None:
+	if session_dict.get(Session.FN.Cookie.Id) is not None:
 		data["cookie"] = True
 
-	if session_dict.get(SessionAdapter.FN.Authentication.IsAnonymous) is True:
+	if session_dict.get(Session.FN.Authentication.IsAnonymous) is True:
 		data["anonymous"] = True
 
-	impersonator_cid = session_dict.get(SessionAdapter.FN.Authentication.ImpersonatorCredentialsId)
+	impersonator_cid = session_dict.get(Session.FN.Authentication.ImpersonatorCredentialsId)
 	if impersonator_cid is not None:
 		data["impersonator_cid"] = impersonator_cid
-	impersonator_sid = session_dict.get(SessionAdapter.FN.Authentication.ImpersonatorSessionId)
+	impersonator_sid = session_dict.get(Session.FN.Authentication.ImpersonatorSessionId)
 	if impersonator_sid is not None:
 		data["impersonator_sid"] = impersonator_sid
 
@@ -484,15 +484,15 @@ def rest_get(session_dict):
 
 # TODO: Use ASAB Authorization, this is a temporary solution.
 def build_system_session(session_service, session_id):
-	session = SessionAdapter({
-		SessionAdapter.FN.SessionId: session_id,
-		SessionAdapter.FN.Version: 0,
-		SessionAdapter.FN.CreatedAt: datetime.datetime.now(datetime.UTC),
-		SessionAdapter.FN.ModifiedAt: None,
-		SessionAdapter.FN.Session.Type: "SYSTEM",
-		SessionAdapter.FN.Session.Expiration: datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30),
-		SessionAdapter.FN.Authorization.Authz: {"*": ["authz:superuser"]},
-		SessionAdapter.FN.Credentials.Id: "SYSTEM",
+	session = Session({
+		Session.FN.SessionId: session_id,
+		Session.FN.Version: 0,
+		Session.FN.CreatedAt: datetime.datetime.now(datetime.UTC),
+		Session.FN.ModifiedAt: None,
+		Session.FN.Session.Type: "SYSTEM",
+		Session.FN.Session.Expiration: datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30),
+		Session.FN.Authorization.Authz: {"*": ["authz:superuser"]},
+		Session.FN.Credentials.Id: "SYSTEM",
 	})
 	AuditLogger.log(asab.LOG_NOTICE, "Created new system session.", struct_data={"session_id": session.SessionId})
 	return session

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -16,7 +16,7 @@ import jwcrypto.jwk
 import jwcrypto.jws
 
 from ..generic import update_url_query_params
-from ..session.adapter import SessionAdapter
+from ..models import Session
 from .. import exceptions
 from . import pkce
 from ..authz import build_credentials_authz
@@ -105,10 +105,10 @@ class OpenIdConnectService(asab.Service):
 
 	async def refresh_session(
 		self,
-		session: SessionAdapter,
+		session: Session,
 		expires_at: typing.Optional[datetime.datetime] = None,
 		requested_scope: typing.Optional[typing.Iterable] = None,
-	) -> SessionAdapter:
+	) -> Session:
 		"""
 		Update/rebuild the session according to its authorization parameters
 
@@ -166,7 +166,7 @@ class OpenIdConnectService(asab.Service):
 		)
 
 		if expires_at:
-			session_builders.append(((SessionAdapter.FN.Session.Expiration, expires_at),))
+			session_builders.append(((Session.FN.Session.Expiration, expires_at),))
 
 		session = await self.SessionService.update_session(session.SessionId, session_builders)
 
@@ -418,7 +418,7 @@ class OpenIdConnectService(asab.Service):
 		Invalidate a valid token. Currently only access_token type is supported.
 		"""
 		try:
-			session: SessionAdapter = await self.get_session_by_access_token(token)
+			session: Session = await self.get_session_by_access_token(token)
 		except exceptions.SessionNotFoundError:
 			return
 
@@ -480,7 +480,7 @@ class OpenIdConnectService(asab.Service):
 
 
 	async def create_authorization_code(
-		self, session: SessionAdapter,
+		self, session: Session,
 		code_challenge: str | None = None,
 		code_challenge_method: str | None = None,
 	) -> str:
@@ -521,7 +521,7 @@ class OpenIdConnectService(asab.Service):
 
 	async def create_access_token(
 		self,
-		session: SessionAdapter,
+		session: Session,
 		expires_at: datetime.datetime,
 	) -> str:
 		"""
@@ -546,7 +546,7 @@ class OpenIdConnectService(asab.Service):
 
 	async def create_refresh_token(
 		self,
-		session: SessionAdapter,
+		session: Session,
 		expires_at: datetime.datetime,
 	) -> str:
 		"""

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -8,7 +8,7 @@ import asab.storage.exceptions
 
 from ..client.service import CLIENT_TEMPLATES
 from ..generic import SessionContext
-from ..session.adapter import build_system_session
+from ..models import build_system_session
 
 #
 

--- a/seacatauth/session/__init__.py
+++ b/seacatauth/session/__init__.py
@@ -1,7 +1,5 @@
 from .service import SessionService
 from .handler import SessionHandler
-from .adapter import SessionAdapter
-
 from .builders import credentials_session_builder
 from .builders import authz_session_builder
 from .builders import cookie_session_builder
@@ -12,7 +10,6 @@ from .builders import external_login_session_builder
 __all__ = [
 	"SessionService",
 	"SessionHandler",
-	"SessionAdapter",
 	"credentials_session_builder",
 	"authz_session_builder",
 	"cookie_session_builder",

--- a/seacatauth/session/algorithmic.py
+++ b/seacatauth/session/algorithmic.py
@@ -10,7 +10,7 @@ import datetime
 import asab.web.rest
 import asab.metrics
 
-from .adapter import SessionAdapter
+from ..models import Session
 from .. import exceptions
 from ..authz import build_credentials_authz
 
@@ -59,7 +59,7 @@ class AlgorithmicSessionProvider:
 	async def create_anonymous_session(
 		self, created_at, track_id, client_dict, scope,
 		redirect_uri: str = None
-	) -> SessionAdapter:
+	) -> Session:
 		session = await self._build_anonymous_session(created_at, track_id, client_dict, scope, redirect_uri)
 		self.AnonymousSessionCounter.add("sessions", 1)
 		return session
@@ -67,20 +67,20 @@ class AlgorithmicSessionProvider:
 	async def _build_anonymous_session(
 		self, created_at, track_id, client_dict, scope,
 		redirect_uri: str = None
-	) -> SessionAdapter:
+	) -> Session:
 		session_dict = {
-			SessionAdapter.FN.SessionId: SessionAdapter.ALGORITHMIC_SESSION_ID,
-			SessionAdapter.FN.Version: None,
-			SessionAdapter.FN.CreatedAt: created_at,
-			SessionAdapter.FN.ModifiedAt: created_at,
-			SessionAdapter.FN.Session.TrackId: track_id,
-			SessionAdapter.FN.OAuth2.ClientId: client_dict["_id"],
-			SessionAdapter.FN.OAuth2.Scope: scope,
-			SessionAdapter.FN.Credentials.Id: client_dict["anonymous_cid"],
-			SessionAdapter.FN.Authentication.IsAnonymous: True,
+			Session.FN.SessionId: Session.ALGORITHMIC_SESSION_ID,
+			Session.FN.Version: None,
+			Session.FN.CreatedAt: created_at,
+			Session.FN.ModifiedAt: created_at,
+			Session.FN.Session.TrackId: track_id,
+			Session.FN.OAuth2.ClientId: client_dict["_id"],
+			Session.FN.OAuth2.Scope: scope,
+			Session.FN.Credentials.Id: client_dict["anonymous_cid"],
+			Session.FN.Authentication.IsAnonymous: True,
 		}
 		await self._add_session_authz(session_dict, client_dict["anonymous_cid"], scope)
-		return SessionAdapter(session_dict)
+		return Session(session_dict)
 
 
 	async def _add_session_authz(self, session_dict: dict, credentials_id: str, scope: set):
@@ -103,11 +103,11 @@ class AlgorithmicSessionProvider:
 				"authz": authz
 			}
 
-		session_dict[SessionAdapter.FN.Authorization.AssignedTenants] = available_tenants
-		session_dict[SessionAdapter.FN.Authorization.Authz] = authz
+		session_dict[Session.FN.Authorization.AssignedTenants] = available_tenants
+		session_dict[Session.FN.Authorization.Authz] = authz
 
 
-	async def deserialize(self, token_value) -> SessionAdapter | None:
+	async def deserialize(self, token_value) -> Session | None:
 		"""
 		Parse JWT token and build a SessionAdapter using the token data.
 		"""
@@ -139,7 +139,7 @@ class AlgorithmicSessionProvider:
 		return session
 
 
-	def serialize(self, session: SessionAdapter) -> str:
+	def serialize(self, session: Session) -> str:
 		"""
 		Serialize SessionAdapter into a minimal JWT token string.
 		"""

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -2,7 +2,7 @@ import logging
 import secrets
 import datetime
 
-from .adapter import SessionAdapter
+from ..models import Session
 from ..authz import build_credentials_authz
 
 #
@@ -16,24 +16,24 @@ async def credentials_session_builder(credentials_service, credentials_id, scope
 	scope = scope or frozenset()
 	credentials = await credentials_service.get(credentials_id, include=["__totp"])
 	data = [
-		(SessionAdapter.FN.Credentials.Id, credentials_id),
-		(SessionAdapter.FN.Credentials.CreatedAt, credentials.get("_c")),
-		(SessionAdapter.FN.Credentials.ModifiedAt, credentials.get("_m")),
+		(Session.FN.Credentials.Id, credentials_id),
+		(Session.FN.Credentials.CreatedAt, credentials.get("_c")),
+		(Session.FN.Credentials.ModifiedAt, credentials.get("_m")),
 	]
 	# "profile", "email" and "phone" are scope values defined by OIDC
 	# (https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims)
 	# The values prefixed with "userinfo:" are kept for backwards compatibility
 	# TODO: Remove the "userinfo:" scope values
 	if "profile" in scope or "userinfo:username" in scope or "userinfo:*" in scope:
-		data.append((SessionAdapter.FN.Credentials.Username, credentials.get("username")))
+		data.append((Session.FN.Credentials.Username, credentials.get("username")))
 	if "email" in scope or "userinfo:email" in scope or "userinfo:*" in scope:
-		data.append((SessionAdapter.FN.Credentials.Email, credentials.get("email")))
+		data.append((Session.FN.Credentials.Email, credentials.get("email")))
 	if "phone" in scope or "userinfo:phone" in scope or "userinfo:*" in scope:
-		data.append((SessionAdapter.FN.Credentials.Phone, credentials.get("phone")))
+		data.append((Session.FN.Credentials.Phone, credentials.get("phone")))
 	if "profile" in scope or "userinfo:data" in scope or "userinfo:*" in scope:
-		data.append((SessionAdapter.FN.Credentials.CustomData, credentials.get("data")))
+		data.append((Session.FN.Credentials.CustomData, credentials.get("data")))
 	if "profile" in scope or "userinfo:authn" in scope or "userinfo:*" in scope:
-		data.append((SessionAdapter.FN.Authentication.TOTPSet, credentials.get("__totp") not in (None, "")))
+		data.append((Session.FN.Authentication.TOTPSet, credentials.get("__totp") not in (None, "")))
 	return data
 
 
@@ -45,7 +45,7 @@ async def external_login_session_builder(external_login_service, credentials_id)
 		except KeyError:
 			# BACK COMPAT
 			external_logins[result["t"]] = result["s"]
-	return ((SessionAdapter.FN.Authentication.ExternalLoginOptions, external_logins),)
+	return ((Session.FN.Authentication.ExternalLoginOptions, external_logins),)
 
 
 async def authz_session_builder(
@@ -60,34 +60,34 @@ async def authz_session_builder(
 	authz = await build_credentials_authz(tenant_service, role_service, credentials_id, tenants, exclude_resources)
 	user_tenants = list(set(await tenant_service.get_tenants(credentials_id)).union(tenants))
 	return (
-		(SessionAdapter.FN.Authorization.Authz, authz),
-		(SessionAdapter.FN.Authorization.AssignedTenants, user_tenants),
+		(Session.FN.Authorization.Authz, authz),
+		(Session.FN.Authorization.AssignedTenants, user_tenants),
 	)
 
 
 def authentication_session_builder(login_descriptor):
-	yield (SessionAdapter.FN.Authentication.AuthnTime, datetime.datetime.now(datetime.UTC))
+	yield (Session.FN.Authentication.AuthnTime, datetime.datetime.now(datetime.UTC))
 	if login_descriptor is not None:
-		yield (SessionAdapter.FN.Authentication.LoginDescriptor, login_descriptor["id"])
-		yield (SessionAdapter.FN.Authentication.LoginFactors, [
+		yield (Session.FN.Authentication.LoginDescriptor, login_descriptor["id"])
+		yield (Session.FN.Authentication.LoginFactors, [
 			factor["type"] for factor in login_descriptor["factors"]])
 
 
 async def available_factors_session_builder(authentication_service, credentials_id):
 	factors = await authentication_service.get_eligible_factors(credentials_id)
-	return ((SessionAdapter.FN.Authentication.AvailableFactors, factors),)
+	return ((Session.FN.Authentication.AvailableFactors, factors),)
 
 
 def cookie_session_builder():
 	# TODO: Shorten back to 32 bytes once unencrypted cookies are obsoleted
 	token_length = 16 + 32  # The first part is AES CBC init vector, the second is the actual token
-	yield (SessionAdapter.FN.Cookie.Id, secrets.token_bytes(token_length))
+	yield (Session.FN.Cookie.Id, secrets.token_bytes(token_length))
 
 
 def oauth2_session_builder(client_id: str, scope: frozenset | None, nonce: str = None, redirect_uri: str = None):
-	yield (SessionAdapter.FN.OAuth2.Scope, scope)
-	yield (SessionAdapter.FN.OAuth2.ClientId, client_id)
+	yield (Session.FN.OAuth2.Scope, scope)
+	yield (Session.FN.OAuth2.ClientId, client_id)
 	if redirect_uri is not None:
-		yield (SessionAdapter.FN.OAuth2.RedirectUri, redirect_uri)
+		yield (Session.FN.OAuth2.RedirectUri, redirect_uri)
 	if nonce is not None:
-		yield (SessionAdapter.FN.OAuth2.Nonce, nonce)
+		yield (Session.FN.OAuth2.Nonce, nonce)

--- a/seacatauth/session/handler.py
+++ b/seacatauth/session/handler.py
@@ -5,7 +5,7 @@ import asab.web.rest
 import bson
 
 from seacatauth.decorators import access_control
-from .adapter import SessionAdapter
+from ..models import Session
 
 #
 
@@ -84,7 +84,7 @@ class SessionHandler(object):
 		session_id = request.match_info["session_id"]
 		session = (await self.SessionService.get(session_id)).rest_get()
 		children = await self.SessionService.list(query_filter={
-			SessionAdapter.FN.Session.ParentSessionId: bson.ObjectId(session_id)
+			Session.FN.Session.ParentSessionId: bson.ObjectId(session_id)
 		})
 		if children["count"] > 0:
 			session["children"] = children
@@ -138,7 +138,7 @@ class SessionHandler(object):
 		page = int(request.query.get("p", 1)) - 1
 		limit = int(request.query.get("i", 10))
 		sessions = await self.SessionService.list(page, limit, query_filter={
-			SessionAdapter.FN.Credentials.Id: credentials_id
+			Session.FN.Credentials.Id: credentials_id
 		})
 		return asab.web.rest.json_response(request, sessions)
 

--- a/seacatauth/session/handler.py
+++ b/seacatauth/session/handler.py
@@ -4,7 +4,7 @@ import asab
 import asab.web.rest
 import bson
 
-from seacatauth.decorators import access_control
+from ..decorators import access_control
 from ..models import Session
 
 #


### PR DESCRIPTION
- `SessionAdapter` is renamed to `Session` and moved to `seacatauth.models.session`.
- This is to avoid circular dependencies since SessionAdapter is used everywhere.