### PR TITLE
Replace resource ID literals with constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.05
 
 ### Pre-releases
+- v25.05-alpha9
 - v25.05-alpha8
 - v25.05-alpha7
 - v25.05-alpha6
@@ -21,6 +22,7 @@
 - Provisioning service initialization uses system Session object (#439, v25.05-alpha2)
 
 ### Refactoring
+- Replace resource ID literals with constants (#446, v25.05-alpha9)
 - Refactor name proposer service into a function (#445, v25.05-alpha8)
 - Clean up imports and code style (#444, v25.05-alpha7)
 - Rename SessionAdapter to Session and move to seacatauth.models (#443, v25.05-alpha6)

--- a/seacatauth/authn/handler.py
+++ b/seacatauth/authn/handler.py
@@ -7,6 +7,7 @@ import aiohttp.web
 import urllib.parse
 import jwcrypto.jwk
 
+from ..models.const import ResourceId
 from .. import exceptions, AuditLogger, generic
 from ..last_activity import EventCode
 from ..decorators import access_control
@@ -429,7 +430,7 @@ class AuthenticationHandler(object):
 			"credentials_id": "mongodb:default:abc123def456",
 			"expiration": "5m"}
 	})
-	@access_control("authz:impersonate")
+	@access_control(ResourceId.IMPERSONATE)
 	async def impersonate(self, request, *, json_data):
 		"""
 		Impersonate another user
@@ -461,7 +462,7 @@ class AuthenticationHandler(object):
 		return response
 
 
-	@access_control("authz:impersonate")
+	@access_control(ResourceId.IMPERSONATE)
 	async def impersonate_and_redirect(self, request):
 		"""
 		Impersonate another user

--- a/seacatauth/authz/rbac/service.py
+++ b/seacatauth/authz/rbac/service.py
@@ -2,6 +2,7 @@ import logging
 import typing
 import asab
 
+from ...models.const import ResourceId
 from ...exceptions import TenantNotSpecifiedError
 
 
@@ -19,7 +20,7 @@ class RBACService(asab.Service):
 			resource
 			for resource in authz["*"]
 		)
-		return "authz:superuser" in global_resources
+		return ResourceId.SUPERUSER in global_resources
 
 	@staticmethod
 	def can_access_all_tenants(authz: dict) -> bool:
@@ -27,7 +28,7 @@ class RBACService(asab.Service):
 			resource
 			for resource in authz["*"]
 		)
-		return "authz:superuser" in global_resources or "authz:tenant:access" in global_resources
+		return ResourceId.SUPERUSER in global_resources or ResourceId.ACCESS_ALL_TENANTS in global_resources
 
 	@staticmethod
 	def has_resource_access(authz: dict, tenant: typing.Union[str, None], requested_resources: list) -> bool:

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -5,6 +5,7 @@ import asab
 import asab.web.rest
 import asab.exceptions
 
+from ...models.const import ResourceId
 from ... import exceptions
 from ...decorators import access_control
 
@@ -119,7 +120,7 @@ class ResourceHandler(object):
 		"properties": {
 			"description": {"type": "string"}}
 	})
-	@access_control("seacat:resource:edit")
+	@access_control(ResourceId.RESOURCE_EDIT)
 	async def create_or_undelete(self, request, *, json_data):
 		"""
 		Create a new resource or undelete a resource that has been soft-deleted
@@ -150,7 +151,7 @@ class ResourceHandler(object):
 			"description": {"type": "string"},
 		}
 	})
-	@access_control("seacat:resource:edit")
+	@access_control(ResourceId.RESOURCE_EDIT)
 	async def update(self, request, *, json_data):
 		"""
 		Update resource description or rename resource
@@ -171,7 +172,7 @@ class ResourceHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-	@access_control("seacat:resource:edit")
+	@access_control(ResourceId.RESOURCE_EDIT)
 	async def delete(self, request, *, credentials_id):
 		"""
 		Delete resource

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -4,6 +4,7 @@ import asab.storage.exceptions
 import asab
 import asab.exceptions
 
+from ...models.const import ResourceId
 from ...events import EventTypes
 from ... import exceptions
 
@@ -19,70 +20,70 @@ class ResourceService(asab.Service):
 
 	# TODO: gather these system resources automatically
 	_BuiltinResources = {
-		"authz:superuser": {
+		ResourceId.SUPERUSER: {
 			"description": "Grants superuser access, including the access to all tenants.",
 		},
-		"authz:impersonate": {
+		ResourceId.IMPERSONATE: {
 			"description": "Open a session as a different user.",
 		},
-		"authz:tenant:access": {
+		ResourceId.ACCESS_ALL_TENANTS: {
 			"description": "Grants non-superuser access to all tenants.",
 		},
-		"seacat:credentials:access": {
+		ResourceId.CREDENTIALS_ACCESS: {
 			"description": "List credentials and view credentials details.",
 		},
-		"seacat:credentials:edit": {
+		ResourceId.CREDENTIALS_EDIT: {
 			"description": "Edit and suspend credentials.",
 		},
-		"seacat:session:access": {
+		ResourceId.SESSION_ACCESS: {
 			"description": "List sessions and view session details.",
 		},
-		"seacat:session:terminate": {
+		ResourceId.SESSION_TERMINATE: {
 			"description": "Terminate sessions.",
 		},
-		"seacat:resource:access": {
+		ResourceId.RESOURCE_ACCESS: {
 			"description": "List resources and view resource details.",
 		},
-		"seacat:resource:edit": {
+		ResourceId.RESOURCE_EDIT: {
 			"description": "Edit and delete resources.",
 		},
-		"seacat:client:access": {
+		ResourceId.CLIENT_ACCESS: {
 			"description": "List clients and view client details.",
 		},
-		"seacat:client:edit": {
+		ResourceId.CLIENT_EDIT: {
 			"description": "Edit and delete clients.",
 		},
-		"seacat:tenant:access": {
+		ResourceId.TENANT_ACCESS: {
 			"description": "List tenants, view tenant detail and see tenant members.",
 		},
 		# "seacat:tenant:create": {  # Requires superuser for now
 		# 	"description": "Create new tenants.",
 		# },
-		"seacat:tenant:edit": {
+		ResourceId.TENANT_EDIT: {
 			"description": "Edit tenant data.",
 		},
-		"seacat:tenant:delete": {
+		ResourceId.TENANT_DELETE: {
 			"description": "Delete tenant.",
 		},
-		"seacat:tenant:assign": {
+		ResourceId.TENANT_ASSIGN: {
 			"description": "Assign and unassign tenant members, invite new users to tenant.",
 		},
-		"seacat:role:access": {
+		ResourceId.ROLE_ACCESS: {
 			"description": "Search tenant roles, view role detail and list role bearers.",
 		},
-		"seacat:role:edit": {
+		ResourceId.ROLE_EDIT: {
 			"description":
 				"Create, edit and delete tenant roles. "
 				"This does not enable the bearer to assign Seacat system resources.",
 		},
-		"seacat:role:assign": {
+		ResourceId.ROLE_ASSIGN: {
 			"description": "Assign and unassign tenant roles.",
 		},
 	}
 	GlobalOnlyResources = frozenset({
-		"authz:superuser", "authz:impersonate", "authz:tenant:access",
-		"seacat:session:access", "seacat:session:terminate", "seacat:resource:access", "seacat:resource:edit",
-		"seacat:client:access", "seacat:client:edit", "seacat:tenant:create"})
+		ResourceId.SUPERUSER, ResourceId.IMPERSONATE, ResourceId.ACCESS_ALL_TENANTS,
+		ResourceId.SESSION_ACCESS, ResourceId.SESSION_TERMINATE, ResourceId.RESOURCE_ACCESS, ResourceId.RESOURCE_EDIT,
+		ResourceId.CLIENT_ACCESS, ResourceId.CLIENT_EDIT})
 
 
 	def __init__(self, app, service_name="seacatauth.ResourceService"):

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -5,6 +5,7 @@ import asab.web.rest
 import asab.storage.exceptions
 import asab.exceptions
 
+from ....models.const import ResourceId
 from .... import exceptions
 from ....decorators import access_control
 from .... import generic
@@ -33,7 +34,7 @@ class RoleHandler(object):
 		web_app.router.add_put("/role/{tenant}/{role_name}", self.update)
 
 
-	@access_control("authz:superuser")
+	@access_control(ResourceId.SUPERUSER)
 	async def list_all(self, request):
 		"""
 		List roles from all tenants
@@ -130,7 +131,7 @@ class RoleHandler(object):
 			},
 		}
 	})
-	@access_control("seacat:role:edit")
+	@access_control(ResourceId.ROLE_EDIT)
 	async def create(self, request, *, tenant, json_data):
 		"""
 		Create a new role
@@ -167,7 +168,7 @@ class RoleHandler(object):
 		})
 
 
-	@access_control("seacat:role:edit")
+	@access_control(ResourceId.ROLE_EDIT)
 	async def delete(self, request, *, tenant):
 		"""
 		Delete role
@@ -205,7 +206,7 @@ class RoleHandler(object):
 			},
 		}
 	})
-	@access_control("seacat:role:edit")
+	@access_control(ResourceId.ROLE_EDIT)
 	async def update(self, request, *, json_data, tenant):
 		"""
 		Edit role description and resources

--- a/seacatauth/authz/role/handler/roles.py
+++ b/seacatauth/authz/role/handler/roles.py
@@ -4,6 +4,7 @@ import asab
 import asab.web.rest
 import asab.exceptions
 
+from ....models.const import ResourceId
 from ....decorators import access_control
 
 
@@ -76,7 +77,7 @@ class RolesHandler(object):
 				"type": "array",
 				"items": {"type": "string"}}}
 	})
-	@access_control("seacat:role:assign")
+	@access_control(ResourceId.ROLE_ASSIGN)
 	async def set_roles(self, request, *, json_data, tenant, resources):
 		"""
 		Set credentials' roles
@@ -96,7 +97,7 @@ class RolesHandler(object):
 		requested_roles = json_data["roles"]
 
 		# Determine whether global roles will be un/assigned
-		if "authz:superuser" in resources:
+		if ResourceId.SUPERUSER in resources:
 			include_global = True
 		elif tenant == "*":
 			L.log(asab.LOG_NOTICE, "Not authorized to manage global roles.", struct_data={
@@ -110,7 +111,7 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-	@access_control("seacat:role:assign")
+	@access_control(ResourceId.ROLE_ASSIGN)
 	async def assign_role(self, request, *, tenant):
 		"""
 		Assign role to credentials
@@ -141,7 +142,7 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@access_control("seacat:role:assign")
+	@access_control(ResourceId.ROLE_ASSIGN)
 	async def unassign_role(self, request, *, tenant):
 		"""
 		Unassign role from credentials

--- a/seacatauth/batman/elasticsearch.py
+++ b/seacatauth/batman/elasticsearch.py
@@ -10,6 +10,7 @@ import random
 import asab.config
 import asab.tls
 
+from ..models.const import ResourceId
 from ..authz import build_credentials_authz
 
 
@@ -44,7 +45,7 @@ class ElasticSearchIntegration(asab.config.Configurable):
 		"tenant_indices": "tenant-{tenant}-*",
 
 		# IDs of Elasticsearch resources
-		"elasticsearch_superuser_resource_id": "authz:superuser",  # Superuser access to the entire Elasticsearch cluster
+		"elasticsearch_superuser_resource_id": ResourceId.SUPERUSER,  # Superuser access to the entire Elasticsearch cluster
 	}
 
 
@@ -351,7 +352,7 @@ class ElasticSearchIntegration(asab.config.Configurable):
 		for tenant_id, authorized_resources in authz.items():
 			if tenant_id == "*":
 				# Seacat superuser is mapped to Elasticsearch "superuser" role
-				if "authz:superuser" in authorized_resources:
+				if ResourceId.SUPERUSER in authorized_resources:
 					elk_roles.add("superuser")
 				continue
 			elk_roles.add(get_index_access_role_name(tenant_id, "read"))

--- a/seacatauth/client/handler.py
+++ b/seacatauth/client/handler.py
@@ -3,6 +3,7 @@ import asab
 import asab.web.rest
 import asab.exceptions
 
+from ..models.const import ResourceId
 from ..decorators import access_control
 from .. import generic, exceptions
 from .service import REGISTER_CLIENT_SCHEMA, UPDATE_CLIENT_SCHEMA, CLIENT_TEMPLATES, is_client_confidential
@@ -31,7 +32,7 @@ class ClientHandler(object):
 		web_app.router.add_delete("/client/{client_id}", self.delete)
 
 
-	@access_control("seacat:client:access")
+	@access_control(ResourceId.CLIENT_ACCESS)
 	async def list(self, request):
 		"""
 		List registered clients
@@ -70,7 +71,7 @@ class ClientHandler(object):
 		})
 
 
-	@access_control("seacat:client:access")
+	@access_control(ResourceId.CLIENT_ACCESS)
 	async def get(self, request):
 		"""
 		Get client by client_id
@@ -80,7 +81,7 @@ class ClientHandler(object):
 		return asab.web.rest.json_response(request, result)
 
 
-	@access_control("seacat:client:access")
+	@access_control(ResourceId.CLIENT_ACCESS)
 	async def features(self, request):
 		"""
 		Get schema of supported client metadata
@@ -97,7 +98,7 @@ class ClientHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(REGISTER_CLIENT_SCHEMA)
-	@access_control("seacat:client:edit")
+	@access_control(ResourceId.CLIENT_EDIT)
 	async def register(self, request, *, json_data):
 		"""
 		Register a new client
@@ -123,7 +124,7 @@ class ClientHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(UPDATE_CLIENT_SCHEMA)
-	@access_control("seacat:client:edit")
+	@access_control(ResourceId.CLIENT_EDIT)
 	async def update(self, request, *, json_data):
 		"""
 		Edit an existing client
@@ -143,7 +144,7 @@ class ClientHandler(object):
 		)
 
 
-	@access_control("seacat:client:edit")
+	@access_control(ResourceId.CLIENT_EDIT)
 	async def reset_secret(self, request):
 		"""
 		Reset client secret
@@ -162,7 +163,7 @@ class ClientHandler(object):
 		)
 
 
-	@access_control("seacat:client:edit")
+	@access_control(ResourceId.CLIENT_EDIT)
 	async def delete(self, request):
 		"""
 		Delete a client

--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -4,6 +4,7 @@ import asab
 import asab.web.rest
 import asab.web.webcrypto
 
+from ...models.const import ResourceId
 from ... import exceptions, generic, AuditLogger
 from ...last_activity import EventCode
 from ...decorators import access_control
@@ -217,7 +218,7 @@ class ChangePasswordHandler(object):
 			"expiration": {"type": "number"},
 		}
 	})
-	@access_control("seacat:credentials:edit")
+	@access_control(ResourceId.CREDENTIALS_EDIT)
 	async def admin_request_password_reset(self, request, *, json_data):
 		"""
 		Send a password reset link to specified user

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -5,6 +5,7 @@ import asab.web.webcrypto
 import asab.exceptions
 import asab.utils
 
+from ..models.const import ResourceId
 from .. import exceptions, generic
 from ..decorators import access_control
 from .schemas import (
@@ -292,7 +293,7 @@ class CredentialsHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(CREATE_CREDENTIALS)
-	@access_control("seacat:credentials:edit")
+	@access_control(ResourceId.CREDENTIALS_EDIT)
 	async def create_credentials(self, request, *, json_data):
 		"""
 		Create new credentials
@@ -347,7 +348,7 @@ class CredentialsHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(UPDATE_CREDENTIALS)
-	@access_control("seacat:credentials:edit")
+	@access_control(ResourceId.CREDENTIALS_EDIT)
 	async def update_credentials(self, request, *, json_data):
 		"""
 		Update credentials
@@ -397,7 +398,7 @@ class CredentialsHandler(object):
 			}
 		}
 	})
-	@access_control("seacat:credentials:edit")
+	@access_control(ResourceId.CREDENTIALS_EDIT)
 	async def enforce_factors(self, request, *, json_data):
 		"""
 		Specify authentication factors to be enforced from the user
@@ -419,7 +420,7 @@ class CredentialsHandler(object):
 		return asab.web.rest.json_response(request, {"result": result})
 
 
-	@access_control("seacat:credentials:edit")
+	@access_control(ResourceId.CREDENTIALS_EDIT)
 	async def delete_credentials(self, request, *, credentials_id):
 		"""
 		Delete credentials

--- a/seacatauth/credentials/policy.py
+++ b/seacatauth/credentials/policy.py
@@ -3,6 +3,7 @@ import logging
 import re
 import fastjsonschema
 
+from ..models.const import ResourceId
 from .schemas import USERNAME_PATTERN
 
 
@@ -168,7 +169,7 @@ class CredentialsPolicy:
 			return self.RBACService.has_resource_access(
 				authz,
 				tenant=None,
-				requested_resources=["seacat:credentials:edit"],
+				requested_resources=[ResourceId.CREDENTIALS_EDIT],
 			)
 
 		policy = self.UpdatePolicy.get(attribute)
@@ -185,7 +186,7 @@ class CredentialsPolicy:
 			return self.RBACService.has_resource_access(
 				authz,
 				tenant=None,
-				requested_resources=["seacat:credentials:edit"],
+				requested_resources=[ResourceId.CREDENTIALS_EDIT],
 			)
 
 		# TODO: Check configurable resource-based policy

--- a/seacatauth/credentials/registration/handler.py
+++ b/seacatauth/credentials/registration/handler.py
@@ -9,6 +9,7 @@ import asab.web.rest
 import asab.utils
 import asab.exceptions
 
+from ...models.const import ResourceId
 from ...decorators import access_control
 
 
@@ -62,7 +63,7 @@ class RegistrationHandler(object):
 			"email": {"type": "string"},
 		}
 	})
-	@access_control("seacat:tenant:assign")
+	@access_control(ResourceId.TENANT_ASSIGN)
 	async def public_create_invitation(self, request, *, tenant, credentials_id, json_data):
 		"""
 		Common user request to invite a new user to join specified tenant and create an account
@@ -118,7 +119,7 @@ class RegistrationHandler(object):
 			},
 		},
 	})
-	@access_control("seacat:tenant:assign")
+	@access_control(ResourceId.TENANT_ASSIGN)
 	async def admin_create_invitation(self, request, *, tenant, credentials_id, json_data):
 		"""
 		Admin request to register a new user and invite them to the specified tenant.
@@ -230,7 +231,7 @@ class RegistrationHandler(object):
 		return credentials_id, None
 
 
-	@access_control("seacat:tenant:assign")
+	@access_control(ResourceId.TENANT_ASSIGN)
 	async def resend_invitation(self, request):
 		"""
 		Resend invitation to an already invited user and extend the expiration of the invitation.

--- a/seacatauth/decorators.py
+++ b/seacatauth/decorators.py
@@ -4,6 +4,7 @@ import inspect
 import aiohttp.web
 import asab
 
+from .models.const import ResourceId
 from . import exceptions
 
 
@@ -107,7 +108,7 @@ def access_control(resource=None):
 			# (if the decorator specifies a required `resource`)
 			if resource is not None:
 				if resource not in request.Resources \
-					and "authz:superuser" not in request.Resources:
+					and ResourceId.SUPERUSER not in request.Resources:
 					L.log(asab.LOG_NOTICE, "Unauthorized resource access", struct_data={
 						"cid": request.CredentialsId,
 						"tenant": request.Tenant,
@@ -152,7 +153,7 @@ async def _authorize_tenant(request):
 			# Tenant accessible
 			# Add resources from all roles under the requested_tenant
 			available_resources = available_resources.union(request.Session.Authorization.Authz.get(requested_tenant))
-		elif "authz:superuser" in available_resources:
+		elif ResourceId.SUPERUSER in available_resources:
 			# Bypassing tenant-access check as superuser
 			pass
 		else:

--- a/seacatauth/external_login/handler/admin.py
+++ b/seacatauth/external_login/handler/admin.py
@@ -2,8 +2,9 @@ import logging
 import asab
 import asab.web.rest
 
-from ..service import ExternalLoginService
 from ...decorators import access_control
+from ...models.const import ResourceId
+from ..service import ExternalLoginService
 from ..exceptions import ExternalAccountNotFoundError
 
 
@@ -29,7 +30,7 @@ class ExternalLoginAdminHandler(object):
 		web_app.router.add_delete("/admin/ext-login/{provider_type}/{sub}", self.remove_external_account)
 
 
-	@access_control("authz:superuser")
+	@access_control(ResourceId.SUPERUSER)
 	async def list_external_accounts(self, request):
 		"""
 		List user's external login accounts
@@ -39,7 +40,7 @@ class ExternalLoginAdminHandler(object):
 		return asab.web.rest.json_response(request, data)
 
 
-	@access_control("authz:superuser")
+	@access_control(ResourceId.SUPERUSER)
 	async def get_external_account(self, request):
 		"""
 		Get external login account detail
@@ -53,7 +54,7 @@ class ExternalLoginAdminHandler(object):
 			return asab.web.rest.json_response(request, {"result": "NOT-FOUND"}, status=404)
 
 
-	@access_control("authz:superuser")
+	@access_control(ResourceId.SUPERUSER)
 	async def remove_external_account(self, request):
 		"""
 		Remove external login account

--- a/seacatauth/models/const.py
+++ b/seacatauth/models/const.py
@@ -1,8 +1,5 @@
-import asab.web.auth
-
-
 class ResourceId:
-	SUPERUSER = asab.web.auth.SUPERUSER_RESOURCE_ID
+	SUPERUSER = "authz:superuser"
 	IMPERSONATE = "authz:impersonate"
 	ACCESS_ALL_TENANTS = "authz:tenant:access"
 

--- a/seacatauth/models/const.py
+++ b/seacatauth/models/const.py
@@ -1,0 +1,28 @@
+import asab.web.auth
+
+
+class ResourceId:
+	SUPERUSER = asab.web.auth.SUPERUSER_RESOURCE_ID
+	IMPERSONATE = "authz:impersonate"
+	ACCESS_ALL_TENANTS = "authz:tenant:access"
+
+	CREDENTIALS_ACCESS = "seacat:credentials:access"
+	CREDENTIALS_EDIT = "seacat:credentials:edit"
+
+	TENANT_ACCESS = "seacat:tenant:access"
+	TENANT_EDIT = "seacat:tenant:edit"
+	TENANT_DELETE = "seacat:tenant:delete"
+	TENANT_ASSIGN = "seacat:tenant:assign"
+
+	ROLE_ACCESS = "seacat:role:access"
+	ROLE_EDIT = "seacat:role:edit"
+	ROLE_ASSIGN = "seacat:role:assign"
+
+	RESOURCE_ACCESS = "seacat:resource:access"
+	RESOURCE_EDIT = "seacat:resource:edit"
+
+	CLIENT_ACCESS = "seacat:client:access"
+	CLIENT_EDIT = "seacat:client:edit"
+
+	SESSION_ACCESS = "seacat:session:access"
+	SESSION_TERMINATE = "seacat:session:terminate"

--- a/seacatauth/models/session.py
+++ b/seacatauth/models/session.py
@@ -5,6 +5,7 @@ import datetime
 import typing
 import asab
 
+from ..models.const import ResourceId
 from .. import AuditLogger
 from ..authz.rbac.service import RBACService
 
@@ -491,7 +492,7 @@ def build_system_session(session_service, session_id):
 		Session.FN.ModifiedAt: None,
 		Session.FN.Session.Type: "SYSTEM",
 		Session.FN.Session.Expiration: datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=30),
-		Session.FN.Authorization.Authz: {"*": ["authz:superuser"]},
+		Session.FN.Authorization.Authz: {"*": [ResourceId.SUPERUSER]},
 		Session.FN.Credentials.Id: "SYSTEM",
 	})
 	AuditLogger.log(asab.LOG_NOTICE, "Created new system session.", struct_data={"session_id": session.SessionId})

--- a/seacatauth/openidconnect/service.py
+++ b/seacatauth/openidconnect/service.py
@@ -13,6 +13,7 @@ import jwcrypto.jwt
 import jwcrypto.jwk
 import jwcrypto.jws
 
+from ..models.const import ResourceId
 from ..generic import update_url_query_params
 from ..models import Session
 from .. import exceptions
@@ -137,7 +138,7 @@ class OpenIdConnectService(asab.Service):
 
 		# Exclude critical resource grants from impersonated sessions
 		if root_session.Authentication.ImpersonatorSessionId is not None:
-			exclude_resources = {"authz:superuser", "authz:impersonate"}
+			exclude_resources = {ResourceId.SUPERUSER, ResourceId.IMPERSONATE}
 		else:
 			exclude_resources = set()
 
@@ -378,9 +379,9 @@ class OpenIdConnectService(asab.Service):
 
 	async def authorize_tenants_by_scope(self, scope, session, client_id):
 		has_access_to_all_tenants = self.RBACService.has_resource_access(
-			session.Authorization.Authz, tenant=None, requested_resources=["authz:superuser"]) \
+			session.Authorization.Authz, tenant=None, requested_resources=[ResourceId.SUPERUSER]) \
 			or self.RBACService.has_resource_access(
-			session.Authorization.Authz, tenant=None, requested_resources=["authz:tenant:access"])
+			session.Authorization.Authz, tenant=None, requested_resources=[ResourceId.ACCESS_ALL_TENANTS])
 		try:
 			tenants = await self.TenantService.get_tenants_by_scope(
 				scope, session.Credentials.Id, has_access_to_all_tenants)

--- a/seacatauth/session/handler.py
+++ b/seacatauth/session/handler.py
@@ -3,6 +3,7 @@ import asab
 import asab.web.rest
 import bson
 
+from ..models.const import ResourceId
 from ..decorators import access_control
 from ..models import Session
 
@@ -40,7 +41,7 @@ class SessionHandler(object):
 		# <<<
 
 
-	@access_control("seacat:session:access")
+	@access_control(ResourceId.SESSION_ACCESS)
 	async def session_list(self, request):
 		"""
 		List sessions
@@ -72,7 +73,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, data)
 
 
-	@access_control("seacat:session:access")
+	@access_control(ResourceId.SESSION_ACCESS)
 	async def session_detail(self, request):
 		"""
 		Get session detail
@@ -87,7 +88,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, session)
 
 
-	@access_control("seacat:session:terminate")
+	@access_control(ResourceId.SESSION_TERMINATE)
 	async def session_delete(self, request):
 		"""
 		Terminate a session
@@ -100,7 +101,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, response)
 
 
-	@access_control("authz:superuser")
+	@access_control(ResourceId.SUPERUSER)
 	async def delete_all(self, request, *, credentials_id):
 		"""
 		Terminate all sessions
@@ -112,7 +113,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-	@access_control("seacat:session:access")
+	@access_control(ResourceId.SESSION_ACCESS)
 	async def search_by_credentials_id(self, request):
 		"""
 		List all active sessions of given credentials
@@ -139,7 +140,7 @@ class SessionHandler(object):
 		return asab.web.rest.json_response(request, sessions)
 
 
-	@access_control("seacat:session:terminate")
+	@access_control(ResourceId.SESSION_TERMINATE)
 	async def delete_by_credentials_id(self, request, *, credentials_id):
 		"""
 		Terminate all sessions of given credentials

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -13,6 +13,7 @@ import asab
 import asab.storage
 import pymongo
 
+from ..models.const import ResourceId
 from .. import exceptions
 from ..events import EventTypes
 from ..models import Session
@@ -741,7 +742,7 @@ class SessionService(asab.Service):
 		# TODO: Choose builders based on scope
 		# Make sure dangerous resources are removed from impersonated sessions
 		if root_session.Authentication.ImpersonatorSessionId is not None:
-			exclude_resources = {"authz:superuser", "authz:impersonate"}
+			exclude_resources = {ResourceId.SUPERUSER, ResourceId.IMPERSONATE}
 		else:
 			exclude_resources = set()
 

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -3,6 +3,7 @@ import asab.web.rest
 import asab.exceptions
 import asab.utils
 
+from ..models.const import ResourceId
 from .. import exceptions
 from ..decorators import access_control
 from . import schemas
@@ -92,7 +93,7 @@ class TenantHandler(object):
 			for tenant, rs in request.Session.Authorization.Authz.items():
 				if tenant == "*":
 					continue
-				if "seacat:tenant:access" in rs:
+				if ResourceId.TENANT_ACCESS in rs:
 					tenants.append(await self.TenantService.get_tenant(tenant))
 			count = len(tenants)
 			return asab.web.rest.json_response(request, data={"data": tenants, "count": count})
@@ -122,7 +123,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data=result)
 
 
-	@access_control("seacat:tenant:access")
+	@access_control(ResourceId.TENANT_ACCESS)
 	async def get(self, request):
 		"""
 		Get tenant detail
@@ -133,7 +134,7 @@ class TenantHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schemas.CREATE_TENANT)
-	@access_control("authz:superuser")  # TODO: "seacat:tenant:create"
+	@access_control(ResourceId.SUPERUSER)  # TODO: "seacat:tenant:create"
 	async def create(self, request, *, credentials_id, json_data):
 		"""
 		Create a tenant
@@ -177,7 +178,7 @@ class TenantHandler(object):
 			request, data={"id": tenant_id})
 
 	@asab.web.rest.json_schema_handler(schemas.UPDATE_TENANT)
-	@access_control("seacat:tenant:edit")
+	@access_control(ResourceId.TENANT_EDIT)
 	async def update_tenant(self, request, *, json_data, tenant):
 		"""
 		Update tenant description and/or its structured data
@@ -186,7 +187,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data=result)
 
 
-	@access_control("seacat:tenant:delete")
+	@access_control(ResourceId.TENANT_DELETE)
 	async def delete(self, request, *, tenant):
 		"""
 		Delete a tenant. Also delete all its roles and assignments linked to this tenant.
@@ -196,7 +197,7 @@ class TenantHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schemas.SET_TENANTS)
-	@access_control("seacat:tenant:assign")
+	@access_control(ResourceId.TENANT_ASSIGN)
 	async def set_tenants(self, request, *, json_data):
 		"""
 		Specify a set of accessible tenants for requested credentials ID
@@ -220,7 +221,7 @@ class TenantHandler(object):
 		)
 
 
-	@access_control("seacat:tenant:assign")
+	@access_control(ResourceId.TENANT_ASSIGN)
 	async def assign_tenant(self, request, *, tenant):
 		"""
 		Grant specified tenant access to requested credentials
@@ -232,7 +233,7 @@ class TenantHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@access_control("seacat:tenant:assign")
+	@access_control(ResourceId.TENANT_ASSIGN)
 	async def unassign_tenant(self, request, *, tenant):
 		"""
 		Revoke specified tenant access to requested credentials
@@ -292,8 +293,8 @@ class TenantHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schemas.BULK_ASSIGN_TENANTS)
-	@access_control("authz:superuser")
-	# TODO: For single tenant bulks, require only "seacat:tenant:assign"
+	@access_control(ResourceId.SUPERUSER)
+	# TODO: For single tenant bulks, require only ResourceId.TENANT_ASSIGN
 	async def bulk_assign_tenants(self, request, *, json_data):
 		"""
 		Grant tenant access and/or assign roles to a list of credentials
@@ -368,8 +369,8 @@ class TenantHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schemas.BULK_UNASSIGN_TENANTS)
-	@access_control("authz:superuser")
-	# TODO: For single tenant bulks, require only "seacat:tenant:assign"
+	@access_control(ResourceId.SUPERUSER)
+	# TODO: For single tenant bulks, require only ResourceId.TENANT_ASSIGN
 	async def bulk_unassign_tenants(self, request, *, json_data):
 		"""
 		Revoke tenant access and/or unassign roles from a list of credentials

--- a/seacatauth/tenant/service.py
+++ b/seacatauth/tenant/service.py
@@ -4,6 +4,7 @@ import asab
 import asab.storage.exceptions
 import asab.exceptions
 
+from ..models.const import ResourceId
 from .. import exceptions
 
 
@@ -196,7 +197,7 @@ class TenantService(asab.Service):
 					"message": message,
 				}
 			# Check permission
-			if not rbac_svc.has_resource_access(session.Authorization.Authz, tenant, ["seacat:tenant:assign"]):
+			if not rbac_svc.has_resource_access(session.Authorization.Authz, tenant, [ResourceId.TENANT_ASSIGN]):
 				message = "Not authorized for tenant assignment."
 				L.error(message, struct_data={
 					"agent_cid": session.Credentials.Id,
@@ -210,7 +211,7 @@ class TenantService(asab.Service):
 
 		for tenant in tenants_to_unassign:
 			# Check permission
-			if not rbac_svc.has_resource_access(session.Authorization.Authz, tenant, ["seacat:tenant:assign"]):
+			if not rbac_svc.has_resource_access(session.Authorization.Authz, tenant, [ResourceId.TENANT_ASSIGN]):
 				message = "Not authorized for tenant unassignment."
 				L.error(message, struct_data={
 					"agent_cid": session.Credentials.Id,


### PR DESCRIPTION
All resource IDs are now collected in `seacatauth.models.const.ResourceId` as constants.