### PR TITLE
Remove tenant list from JWT

### DIFF
--- a/seacatauth/session/algorithmic.py
+++ b/seacatauth/session/algorithmic.py
@@ -89,21 +89,18 @@ class AlgorithmicSessionProvider:
 		"""
 		data = self.AuthzCache.get((credentials_id, frozenset(scope)))
 		if data and datetime.datetime.now(datetime.timezone.utc) < data["exp"]:
-			available_tenants = data["available_tenants"]
 			authz = data["authz"]
 		else:
-			available_tenants = await self.TenantService.get_tenants(credentials_id)
 			requested_tenants = await self.TenantService.get_tenants_by_scope(
 				scope, credentials_id)
 			authz = await build_credentials_authz(
 				self.TenantService, self.RoleService, credentials_id, requested_tenants)
 			self.AuthzCache[(credentials_id, frozenset(scope))] = {
 				"exp": datetime.datetime.now(datetime.timezone.utc) + self.AuthzCacheExpiration,
-				"available_tenants": available_tenants,
 				"authz": authz
 			}
 
-		session_dict[Session.FN.Authorization.AssignedTenants] = available_tenants
+		session_dict[Session.FN.Authorization.AssignedTenants] = []
 		session_dict[Session.FN.Authorization.Authz] = authz
 
 

--- a/seacatauth/session/builders.py
+++ b/seacatauth/session/builders.py
@@ -47,7 +47,7 @@ async def external_login_session_builder(external_login_service, credentials_id)
 
 async def authz_session_builder(
 	tenant_service, role_service, credentials_id,
-	tenants=None, exclude_resources=None
+	tenants=None, exclude_resources=None, show_tenant_list=False
 ):
 	"""
 	Add 'authz' dict with currently authorized tenants and their resources
@@ -55,10 +55,15 @@ async def authz_session_builder(
 	"""
 	tenants = tenants or []
 	authz = await build_credentials_authz(tenant_service, role_service, credentials_id, tenants, exclude_resources)
-	user_tenants = list(set(await tenant_service.get_tenants(credentials_id)).union(tenants))
+	if (show_tenant_list):
+		user_tenants = list(set(await tenant_service.get_tenants(credentials_id)).union(tenants))
+		return (
+			(Session.FN.Authorization.Authz, authz),
+			(Session.FN.Authorization.AssignedTenants, user_tenants),
+		)
 	return (
 		(Session.FN.Authorization.Authz, authz),
-		(Session.FN.Authorization.AssignedTenants, user_tenants),
+		(Session.FN.Authorization.AssignedTenants, []),
 	)
 
 

--- a/seacatauth/session/service.py
+++ b/seacatauth/session/service.py
@@ -738,6 +738,7 @@ class SessionService(asab.Service):
 		tenant_service = self.App.get_service("seacatauth.TenantService")
 		role_service = self.App.get_service("seacatauth.RoleService")
 		batman_service = self.App.get_service("seacatauth.BatmanService")
+		client_service = self.App.get_service("seacatauth.ClientService")
 
 		# TODO: Choose builders based on scope
 		# Make sure dangerous resources are removed from impersonated sessions
@@ -745,6 +746,9 @@ class SessionService(asab.Service):
 			exclude_resources = {ResourceId.SUPERUSER, ResourceId.IMPERSONATE}
 		else:
 			exclude_resources = set()
+		
+		client = await client_service.get(client_id)
+		show_tenant_list = client.get("tenant_list_in_jwt", False)
 
 		session_builders = [
 			await credentials_session_builder(credentials_service, root_session.Credentials.Id, scope),
@@ -754,6 +758,7 @@ class SessionService(asab.Service):
 				credentials_id=root_session.Credentials.Id,
 				tenants=tenants,
 				exclude_resources=exclude_resources,
+				show_tenant_list=show_tenant_list,
 			)
 		]
 


### PR DESCRIPTION
[Kickoff] Remove the tenant list from JWT to optimize the token size.

By default, the tenant list is removed for all clients, but it can be enabled for clients with `tenant_list_in_jwt=true` (e.g., `asab-webui-auth `needs the tenant list in JWT).

We also removed it from the anonymous token because it does not make sense to have it in when the tenant is not needed. 