### PR TITLE
Dedicated resource ID for tenant creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Handle FIDO MDS ClientConnectionError (#438, v25.05-alpha1)
 
 ### Features
+- Dedicated resource ID for tenant creation (#454, v25.05-alpha14)
 - Support ASAB Iris for sending emails (#442, v25.05-alpha5)
 - Configurable default tenant roles (#436, v25.05-alpha3)
 - Provisioning service initialization uses system Session object (#439, v25.05-alpha2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.05
 
 ### Pre-releases
+- v25.05-alpha14
 - v25.05-alpha13
 - v25.05-alpha12
 - v25.05-alpha11

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -56,9 +56,9 @@ class ResourceService(asab.Service):
 		ResourceId.TENANT_ACCESS: {
 			"description": "List tenants, view tenant detail and see tenant members.",
 		},
-		# "seacat:tenant:create": {  # Requires superuser for now
-		# 	"description": "Create new tenants.",
-		# },
+		ResourceId.TENANT_CREATE: {
+			"description": "Create new tenants.",
+		},
 		ResourceId.TENANT_EDIT: {
 			"description": "Edit tenant data.",
 		},
@@ -82,8 +82,11 @@ class ResourceService(asab.Service):
 	}
 	GlobalOnlyResources = frozenset({
 		ResourceId.SUPERUSER, ResourceId.IMPERSONATE, ResourceId.ACCESS_ALL_TENANTS,
-		ResourceId.SESSION_ACCESS, ResourceId.SESSION_TERMINATE, ResourceId.RESOURCE_ACCESS, ResourceId.RESOURCE_EDIT,
-		ResourceId.CLIENT_ACCESS, ResourceId.CLIENT_EDIT})
+		ResourceId.SESSION_ACCESS, ResourceId.SESSION_TERMINATE,
+		ResourceId.RESOURCE_ACCESS, ResourceId.RESOURCE_EDIT,
+		ResourceId.CLIENT_ACCESS, ResourceId.CLIENT_EDIT,
+		ResourceId.TENANT_CREATE
+	})
 
 
 	def __init__(self, app, service_name="seacatauth.ResourceService"):

--- a/seacatauth/models/const.py
+++ b/seacatauth/models/const.py
@@ -7,6 +7,7 @@ class ResourceId:
 	CREDENTIALS_EDIT = "seacat:credentials:edit"
 
 	TENANT_ACCESS = "seacat:tenant:access"
+	TENANT_CREATE = "seacat:tenant:create"
 	TENANT_EDIT = "seacat:tenant:edit"
 	TENANT_DELETE = "seacat:tenant:delete"
 	TENANT_ASSIGN = "seacat:tenant:assign"

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -5,9 +5,9 @@ import secrets
 import asab.exceptions
 import asab.storage.exceptions
 
-from ..client.service import CLIENT_TEMPLATES
+from ..client.schema import CLIENT_TEMPLATES
 from ..generic import SessionContext
-from ..models import build_system_session
+from ..models.session import build_system_session
 
 
 L = logging.getLogger(__name__)

--- a/seacatauth/tenant/handler.py
+++ b/seacatauth/tenant/handler.py
@@ -134,7 +134,7 @@ class TenantHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schema.CREATE_TENANT)
-	@access_control(ResourceId.SUPERUSER)  # TODO: "seacat:tenant:create"
+	@access_control(ResourceId.TENANT_CREATE)
 	async def create(self, request, *, credentials_id, json_data):
 		"""
 		Create a tenant


### PR DESCRIPTION
- Creating a tenant requires access to `seacat:tenant:create` instead of superuser privileges.
- Fixed provisioning imports.