### PR TITLE
feat: cache anonymous credential

### DIFF
--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -216,7 +216,7 @@ class CookieHandler(object):
 
 		# Validate anonymous anonymous_cid
 		try:
-			await self.CredentialsService.get(anonymous_cid)
+			await self.CredentialsService.get_cached(anonymous_cid)
 		except KeyError:
 			L.error("Credentials for anonymous access not found.", struct_data={
 				"cid": anonymous_cid, "client_id": client_id})

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -38,6 +38,8 @@ class CredentialsService(asab.Service):
 
 		self.IdentFields = self._prepare_ident_fields(asab.Config.get("seacatauth:credentials", "ident_fields"))
 
+		self.Cache = {}
+
 		# Iterate over config and create all providers
 		relevant_sections = [s for s in asab.Config.sections() if s.startswith("seacatauth:credentials:")]
 		providers = []
@@ -284,6 +286,22 @@ class CredentialsService(asab.Service):
 		try:
 			provider = self.get_provider(credentials_id)
 			return await provider.get(credentials_id, include=include)
+		except KeyError:
+			raise exceptions.CredentialsNotFoundError(credentials_id=credentials_id)
+
+
+	async def get_cached(self, credentials_id, include=None) -> dict:
+		'''
+		Find detail of credentials for a credentials_id. Use cache if available.
+		'''
+		try:
+			if credentials_id not in self.Cache:
+				provider = self.get_provider(credentials_id)
+				credential = await provider.get(credentials_id, include=include)
+				self.Cache[credentials_id] = credential
+			else:
+				credential = self.Cache[credentials_id]
+			return credential
 		except KeyError:
 			raise exceptions.CredentialsNotFoundError(credentials_id=credentials_id)
 

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -497,7 +497,7 @@ class AuthorizeHandler(object):
 			# Validate the anonymous credentials
 			anonymous_cid = client_dict.get("anonymous_cid")
 			try:
-				await self.CredentialsService.get(anonymous_cid)
+				await self.CredentialsService.get_cached(anonymous_cid)
 			except KeyError:
 				L.error("Credentials for anonymous access not found.", struct_data={
 					"cid": anonymous_cid, "client_id": client_id})


### PR DESCRIPTION
- each request for creating anonymous session is calling database template-new.c to get still same credential
- get rid-off main pain points and reduce querying database about `50%`

Solves https://github.com/TeskaLabs/seacat-auth/issues/305

| before | after |
| ------ | ------ |
|  ![image](https://github.com/user-attachments/assets/ea5cd9ac-1af7-4b82-af79-6aa14c2c8ffa)     |  ![image](https://github.com/user-attachments/assets/ce657931-2004-4a7c-bc9d-f8587eb45189)     |