### PR TITLE
Fix access check for creating tenant

### DIFF
--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -142,6 +142,7 @@ class RoleHandler(object):
 
 	@asab.web.rest.json_schema_handler(schema.CREATE_ROLE)
 	@asab.web.auth.require_superuser
+	@asab.web.tenant.allow_no_tenant
 	async def create_global_role(self, request, *, json_data):
 		"""
 		Create a new global role


### PR DESCRIPTION
# Issue
- When creating a new tenant, the side-effect of assigning the tenant and the admin role fails because of missing permissions.

# Summary
- The assignment is made in a temporary auth and tenant context.
- Adde the "no tenant" decorator to the "create global role" endpoint.