### PR TITLE
Define and use OAuth2 constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.10"]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.10"]
+        python-version: ["3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - v25.13-alpha2
 - v25.13-alpha1
 
+### Breaking changes
+- Dropped Python 3.10 support (#465, v25.13-alpha4)
+
 ### Features
 - Implement max_age authorization parameter (#458, v25.13-alpha3)
 - Client credentials provider (#462, v25.13-alpha2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.13
 
 ### Pre-releases
+- v25.13-alpha4
 - v25.13-alpha3
 - v25.13-alpha2
 - v25.13-alpha1
@@ -12,6 +13,7 @@
 - Client credentials provider (#462, v25.13-alpha2)
 
 ### Refactoring
+- Define and use OAuth2 constants (#465, v25.13-alpha4)
 - Common method for converting credentials ID to inner database ID (#461, v25.13-alpha1)
 
 ---

--- a/seacatauth/client/schema.py
+++ b/seacatauth/client/schema.py
@@ -1,36 +1,8 @@
+from ..models.const import OAuth2
+
+
 # https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
 # TODO: Supported OAuth/OIDC param values should be managed by the OpenIdConnect module, not Client.
-GRANT_TYPES = [
-	"authorization_code",
-	# "implicit",
-	# "refresh_token"
-]
-
-RESPONSE_TYPES = [
-	"code",
-	# "id_token",
-	# "token"
-]
-
-APPLICATION_TYPES = [
-	"web",
-	# "native"
-]
-
-TOKEN_ENDPOINT_AUTH_METHODS = [
-	"none",
-	"client_secret_basic",
-	"client_secret_post",
-	# "client_secret_jwt",
-	# "private_key_jwt"
-]
-
-REDIRECT_URI_VALIDATION_METHODS = [
-	"full_match",
-	"prefix_match",
-	"none",
-]
-
 CLIENT_METADATA_SCHEMA = {
 	# The order of the properties is preserved in the UI form
 	"preferred_client_id": {
@@ -77,7 +49,7 @@ CLIENT_METADATA_SCHEMA = {
 	"application_type": {
 		"type": "string",
 		"description": "Kind of the application. The default, if omitted, is `web`.",
-		"enum": APPLICATION_TYPES
+		"enum": [str(v) for v in OAuth2.ApplicationType]
 	},
 	"response_types": {
 		"type": "array",
@@ -87,7 +59,7 @@ CLIENT_METADATA_SCHEMA = {
 			"If omitted, the default is that the Client will use only the `code` Response Type.",
 		"items": {
 			"type": "string",
-			"enum": RESPONSE_TYPES
+			"enum": [str(v) for v in OAuth2.ResponseType]
 		}
 	},
 	"grant_types": {
@@ -98,7 +70,7 @@ CLIENT_METADATA_SCHEMA = {
 			"If omitted, the default is that the Client will use only the `authorization_code` Grant Type.",
 		"items": {
 			"type": "string",
-			"enum": GRANT_TYPES
+			"enum": [str(v) for v in OAuth2.GrantType]
 		}
 	},
 	# "logo_uri": {},  # Can have language tags
@@ -122,7 +94,7 @@ CLIENT_METADATA_SCHEMA = {
 		"description":
 			"Requested Client Authentication method for the Token Endpoint. "
 			"If omitted, the default is `none`.",
-		"enum": TOKEN_ENDPOINT_AUTH_METHODS
+		"enum": [str(v) for v in OAuth2.TokenEndpointAuthMethod]
 	},
 	# "token_endpoint_auth_signing_alg": {},
 	"default_max_age": {
@@ -173,7 +145,7 @@ CLIENT_METADATA_SCHEMA = {
 			"Specifies the method how the redirect URI used in authorization requests is validated. "
 			"The default value is 'full_match', in which the requested redirect URI must fully match "
 			"one of the registered URIs.",
-		"enum": REDIRECT_URI_VALIDATION_METHODS
+		"enum": [str(v) for v in OAuth2.RedirectUriValidationMethod]
 	},
 }
 

--- a/seacatauth/client/schema.py
+++ b/seacatauth/client/schema.py
@@ -172,10 +172,10 @@ UPDATE_CLIENT = {
 
 CLIENT_TEMPLATES = {
 	"Public web application": {
-		"application_type": "web",
-		"token_endpoint_auth_method": "none",
-		"grant_types": ["authorization_code"],
-		"response_types": ["code"]
+		"application_type": OAuth2.ApplicationType.WEB,
+		"token_endpoint_auth_method": OAuth2.TokenEndpointAuthMethod.NONE,
+		"grant_types": [OAuth2.GrantType.AUTHORIZATION_CODE],
+		"response_types": [OAuth2.ResponseType.CODE],
 	},
 	# "Public mobile application": {
 	# 	"application_type": "native",

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -14,10 +14,24 @@ import asab.utils
 from .. import exceptions
 from .. import generic
 from ..events import EventTypes
+from ..models.const import OAuth2
 from . import schema
 
 
 L = logging.getLogger(__name__)
+
+
+CLIENT_DEFAULTS = {
+	# TODO: According to spec the default should be "CLIENT_SECRET_BASIC".
+	"token_endpoint_auth_method": OAuth2.TokenEndpointAuthMethod.NONE,
+	"response_types": [OAuth2.ResponseType.CODE],
+	"grant_types": [OAuth2.GrantType.AUTHORIZATION_CODE],
+	"application_type": OAuth2.ApplicationType.WEB,
+	"redirect_uri_validation_method": OAuth2.RedirectUriValidationMethod.FULL_MATCH,
+	"code_challenge_method": OAuth2.CodeChallengeMethod.NONE,
+}
+
+TIME_ATTRIBUTES = {"default_max_age", "session_expiration"}
 
 
 class ClientService(asab.Service):
@@ -135,54 +149,37 @@ class ClientService(asab.Service):
 		return await collection.count_documents(query_filter)
 
 
-	async def get(self, client_id: str):
+	async def get(self, client_id: str, normalize: bool = True):
 		"""
 		Get client metadata
-
-		@param client_id:
-		@return:
 		"""
 		# Try to get client from cache
 		client = self._get_from_cache(client_id)
 		if client:
-			return client
+			if normalize:
+				return self._normalize_client(client)
+			else:
+				return client
 
 		# Get from the database
 		client = await self.StorageService.get(self.ClientCollection, client_id)
-		client = self._normalize_client(client)
-
 		self._store_in_cache(client_id, client)
 
-		return client
+		if normalize:
+			return self._normalize_client(client)
+		else:
+			return client
 
 
 	async def register(
 		self, *,
-		redirect_uris: list,
 		_custom_client_id: str = None,
 		**kwargs
 	):
 		"""
 		Register a new OpenID Connect client
 		https://openid.net/specs/openid-connect-registration-1_0.html#ClientRegistration
-
-		:param redirect_uris: Array of Redirection URI values used by the Client.
-		:type redirect_uris: list
-		:param _custom_client_id: NON-CANONICAL. Request a specific ID for the client.
-		:type _custom_client_id: str
-		:return: Dict containing the issued client_id and client_secret.
 		"""
-		response_types = kwargs.get("response_types", {"code"})
-		for v in response_types:
-			assert v in schema.RESPONSE_TYPES
-
-		grant_types = kwargs.get("grant_types", {"authorization_code"})
-		for v in grant_types:
-			assert v in schema.GRANT_TYPES
-
-		application_type = kwargs.get("application_type", "web")
-		assert application_type in schema.APPLICATION_TYPES
-
 		if _custom_client_id is not None:
 			client_id = _custom_client_id
 			L.warning("Creating a client with custom ID.", struct_data={"client_id": client_id})
@@ -190,53 +187,25 @@ class ClientService(asab.Service):
 			client_id = secrets.token_urlsafe(self.ClientIdLength)
 		upsertor = self.StorageService.upsertor(self.ClientCollection, obj_id=client_id)
 
-		# TODO: The default should be "client_secret_basic".
-		token_endpoint_auth_method = kwargs.get("token_endpoint_auth_method", "none")
-		assert token_endpoint_auth_method in schema.TOKEN_ENDPOINT_AUTH_METHODS
-		upsertor.set("token_endpoint_auth_method", token_endpoint_auth_method)
+		client_metadata = {**CLIENT_DEFAULTS, **kwargs}
+		self._check_redirect_uris(**client_metadata)
+		self._check_grant_types(**client_metadata)
 
-		self._check_redirect_uris(redirect_uris, application_type, grant_types)
-		upsertor.set("redirect_uris", list(redirect_uris))
-
-		self._check_grant_types(grant_types, response_types)
-		upsertor.set("grant_types", list(grant_types))
-		upsertor.set("response_types", list(response_types))
-
-		upsertor.set("application_type", application_type)
-
-		# Register allowed PKCE Code Challenge Methods
-		code_challenge_method = kwargs.get("code_challenge_method", "none")
-		self.OIDCService.PKCE.validate_code_challenge_method_registration(code_challenge_method)
-		upsertor.set("code_challenge_method", code_challenge_method)
-
-		redirect_uri_validation_method = kwargs.get("redirect_uri_validation_method", "full_match")
-		assert redirect_uri_validation_method in schema.REDIRECT_URI_VALIDATION_METHODS
-		upsertor.set("redirect_uri_validation_method", redirect_uri_validation_method)
-
-		session_expiration = kwargs.get("session_expiration")
-		if session_expiration is not None:
-			if isinstance(session_expiration, str):
-				session_expiration = asab.utils.convert_to_seconds(session_expiration)
-			upsertor.set("session_expiration", session_expiration)
-
-		default_max_age = kwargs.get("default_max_age")
-		if default_max_age:
-			if isinstance(default_max_age, str):
-				default_max_age = asab.utils.convert_to_seconds(default_max_age)
-			upsertor.set("default_max_age", default_max_age)
-
-		# Optional client metadata
-		for k in {
-			"client_name", "client_uri", "logout_uri",
-			"cookie_domain", "custom_data", "login_uri", "authorize_anonymous_users", "authorize_uri",
-			"cookie_webhook_uri", "cookie_entry_uri", "anonymous_cid",
-		}:
-			v = kwargs.get(k)
-			if v is not None and not (isinstance(v, str) and len(v) == 0):
-				upsertor.set(k, v)
+		for k in schema.CLIENT_METADATA_SCHEMA:
+			v = client_metadata.get(k)
+			if v is None or (isinstance(v, str) and len(v) == 0):
+				continue
+			if k in TIME_ATTRIBUTES:
+				try:
+					v = asab.utils.convert_to_seconds(v)
+				except ValueError as e:
+					raise asab.exceptions.ValidationError(
+						"{!r} must be either a number or a duration string.".format(k)) from e
+			upsertor.set(k, v)
 
 		try:
 			await upsertor.execute(event_type=EventTypes.CLIENT_REGISTERED)
+
 		except asab.storage.exceptions.DuplicateError:
 			raise asab.exceptions.Conflict(key="client_id", value=client_id)
 
@@ -266,42 +235,38 @@ class ClientService(asab.Service):
 
 
 	async def update(self, client_id: str, **kwargs):
-		client = await self.get(client_id)
+		client = await self.get(client_id, normalize=False)
 		assert_client_is_editable(client)
-		client_update = {}
-		for k, v in kwargs.items():
-			if k not in schema.CLIENT_METADATA_SCHEMA:
-				raise asab.exceptions.ValidationError("Unexpected argument: {}".format(k))
-			client_update[k] = v
+		client_update = {
+			k: v
+			for k, v in client.items()
+			if (
+				k in schema.CLIENT_METADATA_SCHEMA
+				and not k.startswith("_")
+			)
+		}
+		client_update.update(kwargs)
 
-		self._check_redirect_uris(
-			redirect_uris=client_update.get("redirect_uris", client["redirect_uris"]),
-			application_type=client_update.get("application_type", client["application_type"]),
-			grant_types=client_update.get("grant_types", client["grant_types"]),
-			client_uri=client_update.get("client_uri", client.get("client_uri")))
-
-		self._check_grant_types(
-			grant_types=client_update.get("grant_types", client["grant_types"]),
-			response_types=client_update.get("response_types", client["response_types"]))
+		self._check_redirect_uris(**client_update)
+		self._check_grant_types(**client_update)
 
 		upsertor = self.StorageService.upsertor(self.ClientCollection, obj_id=client_id, version=client["_v"])
 
-		# Register allowed PKCE Code Challenge Methods
-		if "code_challenge_method" in kwargs:
-			self.OIDCService.PKCE.validate_code_challenge_method_registration(kwargs["code_challenge_method"])
-
 		for k, v in client_update.items():
-			if v is None or (isinstance(v, str) and len(v) == 0):
-				upsertor.unset(k)
-			else:
-				if k in {"default_max_age", "session_expiration"} and isinstance(v, str):
-					try:
-						v = asab.utils.convert_to_seconds(v)
-					except ValueError as e:
-						raise asab.exceptions.ValidationError(
-							"{!r} must be either a number or a duration string.".format(k)) from e
+			if k not in schema.CLIENT_METADATA_SCHEMA:
+				raise asab.exceptions.ValidationError("Unexpected argument: {}".format(k))
 
-				upsertor.set(k, v)
+			if v is None or (isinstance(v, str) and len(v) == 0):
+				upsertor.unset(k,)
+				continue
+
+			if k in TIME_ATTRIBUTES:
+				try:
+					v = asab.utils.convert_to_seconds(v)
+				except ValueError as e:
+					raise asab.exceptions.ValidationError(
+						"{!r} must be either a number or a duration string.".format(k)) from e
+			upsertor.set(k, v)
 
 		await upsertor.execute(event_type=EventTypes.CLIENT_UPDATED)
 		self._delete_from_cache(client_id)
@@ -440,7 +405,12 @@ class ClientService(asab.Service):
 		return post_data.get("client_id"), post_data.get("client_secret")
 
 
-	def _check_grant_types(self, grant_types, response_types):
+	def _check_grant_types(
+		self,
+		grant_types,
+		response_types,
+		**kwargs
+	):
 		# https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
 		# The following table lists the correspondence between response_type values that the Client will use
 		# and grant_type values that MUST be included in the registered grant_types list:
@@ -462,7 +432,13 @@ class ClientService(asab.Service):
 
 
 	def _check_redirect_uris(
-		self, redirect_uris: list, application_type: str, grant_types: list, client_uri: str = None):
+		self,
+		redirect_uris: list,
+		application_type: str,
+		grant_types: list,
+		client_uri: str = None,
+		**kwargs
+	):
 		"""
 		Check if the redirect URIs can be registered for the given application type
 
@@ -555,6 +531,7 @@ class ClientService(asab.Service):
 
 
 	def _normalize_client(self, client: dict):
+		client = {**client}  # Do not modify the original client
 		client["client_id"] = client["_id"]
 		if client.get("managed_by"):
 			client["read_only"] = True
@@ -605,3 +582,34 @@ def assert_client_is_editable(client: dict):
 		L.log(asab.LOG_NOTICE, "Client is not editable.", struct_data={"client_id": client["_id"]})
 		raise exceptions.NotEditableError("Client is not editable.")
 	return True
+
+
+def _validate_client_attributes(client_dict: dict):
+	"""
+	Validate client attributes.
+	"""
+	for k, v in client_dict.items():
+		if k not in schema.CLIENT_METADATA_SCHEMA:
+			raise asab.exceptions.ValidationError("Unexpected attribute: {!r}".format(k))
+
+		if k == "grant_types":
+			for grant_type in v:
+				if grant_type not in OAuth2.GrantType:
+					raise asab.exceptions.ValidationError("Invalid grant_type: {!r}".format(grant_type))
+
+		elif k == "response_types":
+			for response_type in v:
+				if response_type not in OAuth2.ResponseType:
+					raise asab.exceptions.ValidationError("Invalid response_type: {!r}".format(response_type))
+
+		elif k == "application_type":
+			if v not in OAuth2.ApplicationType:
+				raise asab.exceptions.ValidationError("Invalid application_type: {!r}".format(v))
+
+		elif k == "token_endpoint_auth_method":
+			if v not in OAuth2.TokenEndpointAuthMethod:
+				raise asab.exceptions.ValidationError("Invalid token_endpoint_auth_method: {!r}".format(v))
+
+		elif k == "redirect_uri_validation_method":
+			if v not in OAuth2.RedirectUriValidationMethod:
+				raise asab.exceptions.ValidationError("Invalid redirect_uri_validation_method: {!r}".format(v))

--- a/seacatauth/client/service.py
+++ b/seacatauth/client/service.py
@@ -572,7 +572,7 @@ def validate_redirect_uri(redirect_uri: str, registered_uris: list, validation_m
 
 def is_client_confidential(client: dict):
 	token_endpoint_auth_method = client.get("token_endpoint_auth_method", OAuth2.TokenEndpointAuthMethod.NONE)
-	if not token_endpoint_auth_method in OAuth2.TokenEndpointAuthMethod:
+	if token_endpoint_auth_method not in OAuth2.TokenEndpointAuthMethod:
 		raise NotImplementedError("Unsupported token_endpoint_auth_method: {!r}".format(token_endpoint_auth_method))
 
 	if token_endpoint_auth_method == OAuth2.TokenEndpointAuthMethod.NONE:

--- a/seacatauth/cookie/handler.py
+++ b/seacatauth/cookie/handler.py
@@ -11,6 +11,7 @@ import asab.exceptions
 
 from .. import exceptions, AuditLogger
 from .. import generic
+from ..models.const import OAuth2
 from ..openidconnect.utils import TokenRequestErrorResponseCode
 
 
@@ -389,7 +390,7 @@ class CookieHandler(object):
 				request, {"error": TokenRequestErrorResponseCode.InvalidClient}, status=400)
 
 		grant_type = parameters.get("grant_type")
-		if grant_type != "authorization_code":
+		if grant_type != OAuth2.GrantType.AUTHORIZATION_CODE:
 			AuditLogger.log(
 				asab.LOG_NOTICE,
 				"Cookie request denied: Unsupported grant type",

--- a/seacatauth/models/const.py
+++ b/seacatauth/models/const.py
@@ -42,7 +42,7 @@ class OAuth2:
 
 	class GrantType(enum.StrEnum):
 		AUTHORIZATION_CODE = "authorization_code"
-		CLIENT_CREDENTIALS = "client_credentials"
+		# CLIENT_CREDENTIALS = "client_credentials"
 		# IMPLICIT = "implicit"
 		REFRESH_TOKEN = "refresh_token"
 
@@ -68,3 +68,26 @@ class OAuth2:
 		NONE = "none"
 		PLAIN = "plain"
 		S256 = "S256"
+
+
+	class IdTokenSigningAlg(enum.StrEnum):
+		ES256 = "ES256"
+
+
+	class SubjectType(enum.StrEnum):
+		PUBLIC = "public"
+		# pairwise = "pairwise"
+
+
+	class Prompt(enum.StrEnum):
+		NONE = "none"
+		LOGIN = "login"
+		SELECT_ACCOUNT = "select_account"
+		# CONSENT = "consent"
+		# CREATE = "create"
+
+
+	class ClaimType(enum.StrEnum):
+		NORMAL = "normal"
+		# aggregated = "aggregated"
+		# distributed = "distributed"

--- a/seacatauth/models/const.py
+++ b/seacatauth/models/const.py
@@ -1,7 +1,8 @@
+import enum
 import asab.web.auth
 
 
-class ResourceId:
+class ResourceId(enum.StrEnum):
 	SUPERUSER = asab.web.auth.SUPERUSER_RESOURCE_ID
 	IMPERSONATE = "authz:impersonate"
 	ACCESS_ALL_TENANTS = "authz:tenant:access"
@@ -27,3 +28,43 @@ class ResourceId:
 
 	SESSION_ACCESS = "seacat:session:access"
 	SESSION_TERMINATE = "seacat:session:terminate"
+
+
+class OAuth2:
+
+	class TokenEndpointAuthMethod(enum.StrEnum):
+		NONE = "none"
+		CLIENT_SECRET_BASIC = "client_secret_basic"
+		CLIENT_SECRET_POST = "client_secret_post"
+		# CLIENT_SECRET_JWT = "client_secret_jwt"
+		# PRIVATE_KEY_JWT = "client_secret_post"
+
+
+	class GrantType(enum.StrEnum):
+		AUTHORIZATION_CODE = "authorization_code"
+		CLIENT_CREDENTIALS = "client_credentials"
+		# IMPLICIT = "implicit"
+		REFRESH_TOKEN = "refresh_token"
+
+
+	class ResponseType(enum.StrEnum):
+		CODE = "code"
+		# ID_TOKEN = "id_token"
+		# TOKEN = "token"
+
+
+	class ApplicationType(enum.StrEnum):
+		WEB = "web"
+		# NATIVE = "native"
+
+
+	class RedirectUriValidationMethod(enum.StrEnum):
+		FULL_MATCH = "full_match"
+		PREFIX_MATCH = "prefix_match"
+		NONE = "none"
+
+
+	class CodeChallengeMethod(enum.StrEnum):
+		NONE = "none"
+		PLAIN = "plain"
+		S256 = "S256"

--- a/seacatauth/openidconnect/handler/authorize.py
+++ b/seacatauth/openidconnect/handler/authorize.py
@@ -657,7 +657,7 @@ class AuthorizeHandler(object):
 				cookie_entry_uri,
 				urllib.parse.urlencode([
 					("client_id", client_dict["_id"]),  # TODO: Remove, this should be a client responsibility
-					("grant_type", "authorization_code"),  # TODO: Remove, this should be a client responsibility
+					("grant_type", const.OAuth2.GrantType.AUTHORIZATION_CODE),  # TODO: Remove, this should be a client responsibility
 					("redirect_uri", redirect_uri)],
 				)
 			)

--- a/seacatauth/openidconnect/handler/discovery.py
+++ b/seacatauth/openidconnect/handler/discovery.py
@@ -4,6 +4,7 @@ import asab.web.auth
 import asab.web.tenant
 
 from .. import OpenIdConnectService
+from ...models.const import OAuth2
 
 
 L = logging.getLogger(__name__)
@@ -54,11 +55,11 @@ class DiscoveryHandler(object):
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.TokenPath.lstrip("/")),
 			# TODO: The algorithm RS256 MUST be included.
 			#  (https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata)
-			"id_token_signing_alg_values_supported": ["ES256"],
+			"id_token_signing_alg_values_supported": list(OAuth2.IdTokenSigningAlg),
 			"jwks_uri": "{}{}".format(
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.JwksPath.lstrip("/")),
-			"response_types_supported": ["code"],
-			"subject_types_supported": ["public"],
+			"response_types_supported": list(OAuth2.ResponseType),
+			"subject_types_supported": list(OAuth2.SubjectType),
 
 			# RECOMMENDED
 			"userinfo_endpoint": "{}{}".format(
@@ -78,15 +79,15 @@ class DiscoveryHandler(object):
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.EndSessionPath),
 			"revocation_endpoint": "{}{}".format(
 				self.OpenIdConnectService.PublicApiBaseUrl, self.OpenIdConnectService.TokenRevokePath),
-			"grant_types_supported": ["authorization_code"],
-			"token_endpoint_auth_methods_supported": ["none"],
-			"prompt_values_supported": ["none", "login", "select_account"],
-			"claim_types_supported": ["normal"],
+			"grant_types_supported": list(OAuth2.GrantType),
+			"token_endpoint_auth_methods_supported": list(OAuth2.TokenEndpointAuthMethod),
+			"prompt_values_supported": list(OAuth2.Prompt),
+			"claim_types_supported": list(OAuth2.ClaimType),
 			"service_documentation": "https://docs.teskalabs.com/seacat-auth",
 			"ui_locales_supported": ["en-US", "cs-CZ"],
 
 			# PKCE
-			"code_challenge_methods_supported": ["plain", "S256"],
+			"code_challenge_methods_supported": list(OAuth2.CodeChallengeMethod),
 		}
 
 		return asab.web.rest.json_response(request, data)

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -16,6 +16,7 @@ from ..utils import TokenRequestErrorResponseCode
 from ... import exceptions, AuditLogger
 from ... import generic
 from . import schema
+from ...models import const
 
 
 L = logging.getLogger(__name__)
@@ -95,9 +96,9 @@ class TokenHandler(object):
 
 		# 3.1.3.2.  Token Request Validation
 		grant_type = form_data.get("grant_type")
-		if grant_type == "authorization_code":
+		if grant_type == const.OAuth2.GrantType.AUTHORIZATION_CODE:
 			return await self._authorization_code_grant(request, from_ip)
-		elif grant_type == "refresh_token":
+		elif grant_type == const.OAuth2.GrantType.REFRESH_TOKEN:
 			return await self._refresh_token_grant(request, from_ip)
 		else:
 			AuditLogger.log(asab.LOG_NOTICE, "Token request denied: Unsupported grant type.", struct_data={
@@ -125,7 +126,7 @@ class TokenHandler(object):
 				"Token request denied: Invalid or expired authorization code.",
 				struct_data={
 					"from_ip": from_ip,
-					"grant_type": "authorization_code",
+					"grant_type": const.OAuth2.GrantType.AUTHORIZATION_CODE,
 					"client_id": client_id,
 					"redirect_uri": form_data.get("redirect_uri"),
 				}
@@ -138,7 +139,7 @@ class TokenHandler(object):
 				"Token request denied: Code challenge failed.",
 				struct_data={
 					"from_ip": from_ip,
-					"grant_type": "authorization_code",
+					"grant_type": const.OAuth2.GrantType.AUTHORIZATION_CODE,
 					"client_id": client_id,
 					"redirect_uri": form_data.get("redirect_uri"),
 				}
@@ -148,7 +149,7 @@ class TokenHandler(object):
 		except exceptions.ClientAuthenticationError as e:
 			AuditLogger.log(asab.LOG_NOTICE, "Token request denied: Cannot verify client ({}).".format(e), struct_data={
 				"from_ip": from_ip,
-				"grant_type": "authorization_code",
+				"grant_type": const.OAuth2.GrantType.AUTHORIZATION_CODE,
 				"client_id": e.ClientID,
 				"redirect_uri": form_data.get("redirect_uri"),
 			})
@@ -157,7 +158,7 @@ class TokenHandler(object):
 		except exceptions.URLValidationError:
 			AuditLogger.log(asab.LOG_NOTICE, "Token request denied: Redirect URI mismatch.", struct_data={
 				"from_ip": from_ip,
-				"grant_type": "authorization_code",
+				"grant_type": const.OAuth2.GrantType.AUTHORIZATION_CODE,
 				"client_id": client_id,
 				"redirect_uri": form_data.get("redirect_uri"),
 			})
@@ -171,7 +172,7 @@ class TokenHandler(object):
 			"cid": session.Credentials.Id,
 			"sid": session.Id,
 			"client_id": session.OAuth2.ClientId,
-			"grant_type": "authorization_code",
+			"grant_type": const.OAuth2.GrantType.AUTHORIZATION_CODE,
 			"from_ip": from_ip
 		})
 
@@ -214,7 +215,7 @@ class TokenHandler(object):
 				"Token request denied: Invalid or expired refresh token.",
 				struct_data={
 					"from_ip": from_ip,
-					"grant_type": "refresh_token",
+					"grant_type": const.OAuth2.GrantType.REFRESH_TOKEN,
 					"client_id": client_id,
 				}
 			)
@@ -223,7 +224,7 @@ class TokenHandler(object):
 		except exceptions.ClientAuthenticationError as e:
 			AuditLogger.log(asab.LOG_NOTICE, "Token request denied: Cannot verify client.", struct_data={
 				"from_ip": from_ip,
-				"grant_type": "refresh_token",
+				"grant_type": const.OAuth2.GrantType.REFRESH_TOKEN,
 				"client_id": e.ClientID,
 			})
 			return self.token_error_response(request, TokenRequestErrorResponseCode.InvalidClient)
@@ -239,7 +240,7 @@ class TokenHandler(object):
 			"cid": session.Credentials.Id,
 			"sid": session.Id,
 			"client_id": session.OAuth2.ClientId,
-			"grant_type": "refresh_token",
+			"grant_type": const.OAuth2.GrantType.REFRESH_TOKEN,
 			"from_ip": from_ip,
 		})
 

--- a/seacatauth/openidconnect/pkce.py
+++ b/seacatauth/openidconnect/pkce.py
@@ -4,6 +4,8 @@ import re
 import logging
 import asab.exceptions
 
+from ..models.const import OAuth2
+
 
 L = logging.getLogger(__name__)
 
@@ -36,7 +38,6 @@ class PKCE:
 	"""
 
 	CodeVerifierPattern = re.compile("^[A-Za-z0-9._~-]{43,128}$")
-	SupportedCodeChallengeMethods = frozenset(["none", "plain", "S256"])  # TODO: Configurable
 	DefaultCodeChallengeMethod = "plain"
 
 	@classmethod
@@ -44,7 +45,7 @@ class PKCE:
 		"""
 		Validate whether (any) client can register the requested methods
 		"""
-		if code_challenge_method not in cls.SupportedCodeChallengeMethods:
+		if code_challenge_method not in OAuth2.CodeChallengeMethod:
 			raise asab.exceptions.ValidationError(
 				"Unsupported Code Challenge Method: {!r}.".format(code_challenge_method))
 

--- a/seacatauth/provisioning/service.py
+++ b/seacatauth/provisioning/service.py
@@ -160,7 +160,7 @@ class ProvisioningService(asab.Service):
 		update = {
 			k: v
 			for k, v in CLIENT_TEMPLATES["Public web application"].items()
-			if client is None or client.get(k) != v}
+		}
 
 		# Check if the client has the correct redirect URI
 		if client is None:


### PR DESCRIPTION
- Replace OAuth2 value strings with constants. They are placed in `seacatauth.models.const.OAuth2`.
- **`BREAKING`** Dropping Python 3.10 support because there is no `StrEnum` in the core library