### PR TITLE
Support for tls_certfile and tls_keyfile in LDAP credentials provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.13
 
 ### Pre-releases
+- v25.13-alpha6
 - v25.13-alpha5
 - v25.13-alpha4
 - v25.13-alpha3
@@ -13,6 +14,7 @@
 - Dropped Python 3.10 support (#465, v25.13-alpha4)
 
 ### Features
+- Support for `tls_certfile` and `tls_keyfile` in LDAP credentials provider (#468, v25.13-alpha6)
 - Only clients with `seacatauth_credentials: True` have credentials API (#467, v25.13-alpha5)
 - Implement max_age authorization parameter (#458, v25.13-alpha3)
 - Client credentials provider (#462, v25.13-alpha2)

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -486,7 +486,7 @@ def _enable_tls(ldap_client, config: typing.Mapping):
 		ldap_client.set_option(ldap.OPT_X_TLS_KEYFILE, tls_keyfile)
 
 	tls_certfile = config["tls_certfile"]
-	if tls_certfile != "":		
+	if tls_certfile != "":
 		ldap_client.set_option(ldap.OPT_X_TLS_CERTFILE, tls_certfile)
 
 	# Misc TLS options

--- a/seacatauth/credentials/providers/ldap.py
+++ b/seacatauth/credentials/providers/ldap.py
@@ -482,11 +482,11 @@ def _enable_tls(ldap_client, config: typing.Mapping):
 
 	# Add client certificate and key
 	tls_keyfile = config["tls_keyfile"]
-	tls_certfile = config["tls_certfile"]
-	if (tls_certfile == "") != (tls_keyfile == ""):
-		raise ValueError("'tls_keyfile' and 'tls_certfile' must be both set or both empty.")
-	if tls_certfile != "":
+	if tls_keyfile != "":
 		ldap_client.set_option(ldap.OPT_X_TLS_KEYFILE, tls_keyfile)
+
+	tls_certfile = config["tls_certfile"]
+	if tls_certfile != "":		
 		ldap_client.set_option(ldap.OPT_X_TLS_CERTFILE, tls_certfile)
 
 	# Misc TLS options


### PR DESCRIPTION
UNTESTED


# Config example
```ini
[seacatauth:credentials:ldap:thiscompany]
uri=ldaps://localhost:636
base=OU=Users,OU=Employees,DC=ThisCompany,DC=local
filter=(cn=*)
attrusername=sAMAccountName

# TLS settings
tls_cafile=/conf/cert/server-ca.pem
tls_certfile=/conf/cert/local-cert.pem
tls_keyfile=/conf/cert/local-key.pem
```