### PR TITLE
Fix Dockerfile with venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         pip install bson
         pip install pymongo
         pip install bcrypt
-        pip install argon2
+        pip install argon2-cffi
         pip install jwcrypto
         pip install "asab[encryption] @ git+https://github.com/TeskaLabs/asab.git"
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v25.13
 
 ### Pre-releases
-- v25.13-alpha10
+- v25.13-alpha11
+- ~~v25.13-alpha10~~
 - v25.13-alpha9
 - v25.13-alpha8
 - v25.13-alpha7
@@ -19,6 +20,7 @@
 - Dropped Python 3.10 support (#465, v25.13-alpha4)
 
 ### Fix
+- Fix Dockerfile with venv (#480, v25.13-alpha11)
 - Fix external login attribute error (#476, v25.13-alpha8)
 - Respond with HTTP 200 when new user is created but the password reset email fails (#477, v25.13-alpha7)
 - Update Batman after successful credentials registration (#472, v25.16-alpha)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.13
 
 ### Pre-releases
+- v25.13-alpha10
 - v25.13-alpha9
 - v25.13-alpha8
 - v25.13-alpha7
@@ -23,6 +24,7 @@
 - Update Batman after successful credentials registration (#472, v25.16-alpha)
 
 ### Features
+- Upgrade python to 3.12 and alpine to 3.21 (#479, v25.13-alpha10)
 - Make ES role monitoring_user available via resource elasticsearch:monitoring (#478, v25.13-alpha9)
 - Support for `tls_certfile` and `tls_keyfile` in LDAP credentials provider (#468, v25.13-alpha6)
 - Only clients with `seacatauth_credentials: True` have credentials API (#467, v25.13-alpha5)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apk add --no-cache  \
     openldap-dev \
     rust \
     cargo \
+&& python3 -m venv /venv \
+&& . /venv/bin/activate \
 && pip3 install --upgrade pip \
 && pip3 install --no-cache-dir \
     aiohttp \
@@ -49,7 +51,7 @@ RUN apk add --no-cache  \
 # There is a broken pydantic dependency in webauthn.
 # Remove the version lock once this is fixed.
 
-RUN cat /usr/lib/python3.12/site-packages/asab/__version__.py
+RUN cat /venv/lib/python3.12/site-packages/asab/__version__.py
 
 RUN mkdir -p /app/seacat-auth
 WORKDIR /app/seacat-auth
@@ -57,7 +59,7 @@ WORKDIR /app/seacat-auth
 # Create MANIFEST.json in the working directory
 # The manifest script requires git to be installed
 COPY ./.git /app/seacat-auth/.git
-RUN asab-manifest.py ./MANIFEST.json
+RUN /venv/bin/asab-manifest.py ./MANIFEST.json
 
 
 FROM alpine:3.21
@@ -67,7 +69,8 @@ RUN apk add --no-cache \
   openssl \
   openldap
 
-COPY --from=stage1 /usr/lib/python3.12/site-packages /usr/lib/python3.12/site-packages
+COPY --from=stage1 /venv /venv
+ENV PATH="/venv/bin:$PATH"
 
 COPY ./seacatauth            /app/seacat-auth/seacatauth
 COPY ./seacatauth.py         /app/seacat-auth/seacatauth.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 AS stage1
+FROM alpine:3.21 AS stage1
 LABEL maintainer="TeskaLabs Ltd (support@teskalabs.com)"
 
 ENV LANG=C.UTF-8
@@ -49,7 +49,7 @@ RUN apk add --no-cache  \
 # There is a broken pydantic dependency in webauthn.
 # Remove the version lock once this is fixed.
 
-RUN cat /usr/lib/python3.11/site-packages/asab/__version__.py
+RUN cat /usr/lib/python3.12/site-packages/asab/__version__.py
 
 RUN mkdir -p /app/seacat-auth
 WORKDIR /app/seacat-auth
@@ -60,14 +60,14 @@ COPY ./.git /app/seacat-auth/.git
 RUN asab-manifest.py ./MANIFEST.json
 
 
-FROM alpine:3.18
+FROM alpine:3.21
 
 RUN apk add --no-cache \
   python3 \
   openssl \
   openldap
 
-COPY --from=stage1 /usr/lib/python3.11/site-packages /usr/lib/python3.11/site-packages
+COPY --from=stage1 /usr/lib/python3.12/site-packages /usr/lib/python3.12/site-packages
 
 COPY ./seacatauth            /app/seacat-auth/seacatauth
 COPY ./seacatauth.py         /app/seacat-auth/seacatauth.py


### PR DESCRIPTION
System default Python3.12+ does not allow installing packages because of PEP 668. This replaces the default python with venv python.