### PR TITLE
Make `global_only` a persistent resource attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Dropped Python 3.10 support (#465, v25.13-alpha4)
 
 ### Fix
+- Do not sync deleted credentials with Elasticsearch/Kibana (#483, v25.13-alpha14)
 - Fix attribute error in webauthn error log (#481, v25.13-alpha12)
 - Fix Dockerfile with venv (#480, v25.13-alpha11)
 - Fix external login attribute error (#476, v25.13-alpha8)
@@ -30,7 +31,7 @@
 - Update Batman after successful credentials registration (#472, v25.16-alpha)
 
 ### Features
-- Make `global_only` a true resource attribute (#483, v25.13-alpha14)
+- Make `global_only` a persistent resource attribute (#483, v25.13-alpha14)
 - API key support (#469, v25.13-alpha13)
 - OAuth 2.0 Client credentials flow (#469, v25.13-alpha13)
 - Upgrade python to 3.12 and alpine to 3.21 (#479, v25.13-alpha10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v25.13
 
 ### Pre-releases
+- v25.13-alpha14
+- v25.13-alpha13
 - v25.13-alpha12
 - v25.13-alpha11
 - ~~v25.13-alpha10~~
@@ -28,6 +30,7 @@
 - Update Batman after successful credentials registration (#472, v25.16-alpha)
 
 ### Features
+- Make `global_only` a true resource attribute (#483, v25.13-alpha14)
 - API key support (#469, v25.13-alpha13)
 - OAuth 2.0 Client credentials flow (#469, v25.13-alpha13)
 - Upgrade python to 3.12 and alpine to 3.21 (#479, v25.13-alpha10)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -10,7 +10,6 @@ import asab.exceptions
 from ... import exceptions
 from ...models.const import ResourceId
 from . import schema
-from .service import GLOBAL_ONLY_RESOURCES
 
 
 L = logging.getLogger(__name__)
@@ -99,9 +98,7 @@ class ResourceHandler(object):
 				pass
 
 		if "globalonly" in exclude:
-			if "_id" not in query_filter:
-				query_filter["_id"] = {}
-			query_filter["_id"]["$nin"] = list(GLOBAL_ONLY_RESOURCES)
+			query_filter["global_only"]["ne"] = True
 
 		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)
@@ -140,7 +137,7 @@ class ResourceHandler(object):
 		if undelete:
 			await self.ResourceService.undelete(resource_id)
 		else:
-			await self.ResourceService.create(resource_id, json_data.get("description"))
+			await self.ResourceService.create(resource_id, **json_data)
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 

--- a/seacatauth/authz/resource/schema.py
+++ b/seacatauth/authz/resource/schema.py
@@ -2,7 +2,15 @@ CREATE_OR_UNDELETE_RESOURCE = {
 	"type": "object",
 	"additionalProperties": False,
 	"properties": {
-		"description": {"type": "string"}}
+		"description": {"type": "string"},
+		"global_only": {
+			"type": "boolean",
+			"description":
+				"If set to true, the resource has a global scope and cannot be granted via tenant-specific roles. "
+				"This attribute cannot be changed later.",
+			"default": False,
+		},
+	}
 }
 
 UPDATE_RESOURCE = {

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -16,12 +16,15 @@ L = logging.getLogger(__name__)
 SEACAT_AUTH_RESOURCES = {
 	ResourceId.SUPERUSER: {
 		"description": "Grants superuser access, including the access to all tenants.",
+		"global_only": True,
 	},
 	ResourceId.IMPERSONATE: {
 		"description": "Open a session as a different user.",
+		"global_only": True,
 	},
 	ResourceId.ACCESS_ALL_TENANTS: {
 		"description": "Grants access to all tenants.",
+		"global_only": True,
 	},
 	ResourceId.CREDENTIALS_ACCESS: {
 		"description": "List credentials and view credentials details.",
@@ -31,27 +34,34 @@ SEACAT_AUTH_RESOURCES = {
 	},
 	ResourceId.SESSION_ACCESS: {
 		"description": "List sessions and view session details.",
+		"global_only": True,
 	},
 	ResourceId.SESSION_TERMINATE: {
 		"description": "Terminate sessions.",
+		"global_only": True,
 	},
 	ResourceId.RESOURCE_ACCESS: {
 		"description": "List resources and view resource details.",
+		"global_only": True,
 	},
 	ResourceId.RESOURCE_EDIT: {
 		"description": "Edit and delete resources.",
+		"global_only": True,
 	},
 	ResourceId.CLIENT_ACCESS: {
 		"description": "List clients and view client details.",
+		"global_only": True,
 	},
 	ResourceId.CLIENT_EDIT: {
 		"description": "Edit and delete clients.",
+		"global_only": True,
 	},
 	ResourceId.TENANT_ACCESS: {
 		"description": "List tenants, view tenant detail and see tenant members.",
 	},
 	ResourceId.TENANT_CREATE: {
 		"description": "Create new tenants.",
+		"global_only": True,
 	},
 	ResourceId.TENANT_EDIT: {
 		"description": "Edit tenant data.",
@@ -74,18 +84,6 @@ SEACAT_AUTH_RESOURCES = {
 		"description": "Assign and unassign tenant roles.",
 	},
 }
-GLOBAL_ONLY_RESOURCES = frozenset({
-	ResourceId.SUPERUSER,
-	ResourceId.IMPERSONATE,
-	ResourceId.ACCESS_ALL_TENANTS,
-	ResourceId.SESSION_ACCESS,
-	ResourceId.SESSION_TERMINATE,
-	ResourceId.RESOURCE_ACCESS,
-	ResourceId.RESOURCE_EDIT,
-	ResourceId.CLIENT_ACCESS,
-	ResourceId.CLIENT_EDIT,
-	ResourceId.TENANT_CREATE,
-})
 
 
 class ResourceService(asab.Service):
@@ -106,9 +104,9 @@ class ResourceService(asab.Service):
 			await self._ensure_builtin_resources()
 
 
-	@staticmethod
-	def is_global_only_resource(resource_id):
-		return resource_id in GLOBAL_ONLY_RESOURCES
+	async def is_global_only_resource(self, resource_id):
+		resource = await self.get(resource_id)
+		return resource.get("global_only", False)
 
 
 	async def _ensure_builtin_resources(self):
@@ -117,20 +115,16 @@ class ResourceService(asab.Service):
 		Update their descriptions if they are outdated.
 		"""
 		for resource_id, resource_config in SEACAT_AUTH_RESOURCES.items():
-			description = resource_config.get("description")
-
-			L.debug("Checking for built-in resource {!r}".format(resource_id))
 			try:
 				db_resource = await self.get(resource_id)
 			except KeyError:
-				await self.create(resource_id, description, is_managed_by_seacat_auth=True)
+				await self.create(resource_id, **resource_config, is_managed_by_seacat_auth=True)
 				continue
 
-			if (
-				(db_resource.get("managed_by") != "seacat-auth")
-				or (description is not None and db_resource.get("description") != description)
-			):
-				await self._update(db_resource, description, is_managed_by_seacat_auth=True)
+			for k, v in resource_config.items():
+				if db_resource.get(k) != v:
+					await self._update(db_resource, **resource_config, is_managed_by_seacat_auth=True)
+					continue
 
 
 	async def list(self, page: int = 0, limit: int = None, query_filter: dict = None):
@@ -164,7 +158,13 @@ class ResourceService(asab.Service):
 		return self.normalize_resource(resource)
 
 
-	async def create(self, resource_id: str, description: str = None, is_managed_by_seacat_auth=False):
+	async def create(
+		self,
+		resource_id: str,
+		description: str = None,
+		global_only: bool = None,
+		is_managed_by_seacat_auth: bool = False
+	):
 		if self.ResourceIdRegex.match(resource_id) is None:
 			raise asab.exceptions.ValidationError(
 				"Resource ID must consist only of characters 'a-z0-9.:_-', "
@@ -174,6 +174,9 @@ class ResourceService(asab.Service):
 
 		if description is not None:
 			upsertor.set("description", description)
+
+		if global_only is True:
+			upsertor.set("global_only", True)
 
 		if is_managed_by_seacat_auth:
 			upsertor.set("managed_by", "seacat-auth")
@@ -196,17 +199,33 @@ class ResourceService(asab.Service):
 		await self._update(resource, description)
 
 
-	async def _update(self, resource: dict, description: str, is_managed_by_seacat_auth=False):
+	async def _update(
+		self,
+		resource: dict,
+		description: str = None,
+		global_only: bool = None,
+		is_managed_by_seacat_auth: bool = False
+	):
 		upsertor = self.StorageService.upsertor(
 			self.ResourceCollection,
 			obj_id=resource["_id"],
 			version=resource["_v"])
 
-		assert description is not None
-		if description == "":
+		if description is None:
+			pass
+		elif description == "":
 			upsertor.unset("description")
 		else:
 			upsertor.set("description", description)
+
+		if global_only is None:
+			pass
+		elif global_only is False:
+			upsertor.unset("global_only")
+		elif global_only is True:
+			upsertor.set("global_only", True)
+		else:
+			raise ValueError("global_only must be a boolean value.")
 
 		if is_managed_by_seacat_auth:
 			upsertor.set("managed_by", "seacat-auth")
@@ -299,8 +318,6 @@ class ResourceService(asab.Service):
 	def normalize_resource(self, resource: dict):
 		if resource["_id"] in SEACAT_AUTH_RESOURCES or resource.get("managed_by"):
 			resource["read_only"] = True
-		if self.is_global_only_resource(resource["_id"]):
-			resource["global_only"] = True
 		return resource
 
 

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -169,7 +169,14 @@ class RoleHandler(object):
 		"""
 		tenant_id = asab.contextvars.Tenant.get()
 		role_id = "{}/{}".format(tenant_id, request.match_info["role_name"])
-		return await self._update_role(request, role_id, json_data)
+		try:
+			return await self._update_role(request, role_id, json_data)
+		except asab.exceptions.ValidationError as e:
+			return asab.web.rest.json_response(
+				request,
+				{"result": "ERROR", "tech_err": str(e)},
+				status=400,
+			)
 
 
 	@asab.web.rest.json_schema_handler(schema.UPDATE_ROLE)
@@ -180,7 +187,14 @@ class RoleHandler(object):
 		Edit global role description and resources
 		"""
 		role_id = "*/{}".format(request.match_info["role_name"])
-		return await self._update_role(request, role_id, json_data)
+		try:
+			return await self._update_role(request, role_id, json_data)
+		except asab.exceptions.ValidationError as e:
+			return asab.web.rest.json_response(
+				request,
+				{"result": "ERROR", "tech_err": str(e)},
+				status=400,
+			)
 
 
 	@asab.web.auth.require(ResourceId.ROLE_EDIT)

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -274,7 +274,7 @@ class RoleService(asab.Service):
 					# Tenant and propagated roles cannot access global-only resources
 					resources = [
 						resource_id for resource_id in source_role.get("resources")
-						if not self.ResourceService.is_global_only_resource(resource_id)
+						if not await self.ResourceService.is_global_only_resource(resource_id)
 					]
 				else:
 					resources = source_role.get("resources")
@@ -428,7 +428,7 @@ class RoleService(asab.Service):
 
 			if (
 				(tenant_id is not None or propagated is True)
-				and self.ResourceService.is_global_only_resource(resource_id)
+				and await self.ResourceService.is_global_only_resource(resource_id)
 			):
 				# Global-only resources cannot be assigned to tenant roles or globally defined tenant roles
 				message = "Cannot assign global-only resources to tenant roles or to propagated global roles."


### PR DESCRIPTION
# Summary
- Resources can now be created with attribute `global_only: True`. (Until now this attribute was only transient and was reserved for Seacat Auth system resources.)
- The `global_only` attribute is not editable once the role has been created.
- Global-only resources can only be added to global roles (without propagation) and cannot be added to tenant-scoped roles.
- Marked resources that correspond to cluster level Elasticsearch/Kibana roles as global-only.
- Skip Elasticsearch sync of deleted credentials.