### PR TITLE
TOTP and WebAuthn admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.13
 
 ### Pre-releases
+- v25.13-alpha15
 - v25.13-alpha14
 - v25.13-alpha13
 - v25.13-alpha12
@@ -31,6 +32,7 @@
 - Update Batman after successful credentials registration (#472, v25.16-alpha)
 
 ### Features
+- Admin API for managing TOTP and WebAuthn credentials (#486, v25.13-alpha15)
 - Make `global_only` a persistent resource attribute (#483, v25.13-alpha14)
 - API key support (#469, v25.13-alpha13)
 - OAuth 2.0 Client credentials flow (#469, v25.13-alpha13)

--- a/seacatauth/api/tenant.py
+++ b/seacatauth/api/tenant.py
@@ -4,7 +4,7 @@ import typing
 import asab.web.tenant.providers.abc
 import asab.exceptions
 
-from seacatauth.exceptions import TenantNotFoundError
+from ..exceptions import TenantNotFoundError
 
 
 L = logging.getLogger(__name__)

--- a/seacatauth/app.py
+++ b/seacatauth/app.py
@@ -129,9 +129,10 @@ class SeaCatAuthApplication(asab.Application):
 		self.BatmanService = BatmanService(self)
 		self.BatmanHandler = BatmanHandler(self, self.BatmanService)
 
-		from .authn.webauthn import WebAuthnService, WebAuthnHandler
+		from .authn.webauthn import WebAuthnService, WebAuthnAdminHandler, WebAuthnAccountHandler
 		self.WebAuthnService = WebAuthnService(self)
-		self.WebAuthnHandler = WebAuthnHandler(self, self.WebAuthnService)
+		self.WebAuthnAdminHandler = WebAuthnAdminHandler(self, self.WebAuthnService)
+		self.WebAuthnAccountHandler = WebAuthnAccountHandler(self, self.WebAuthnService)
 
 		# Init Login service
 		# depends on: ResourceService, TenantService, RoleService, CredentialService, BatmanService

--- a/seacatauth/authn/webauthn/__init__.py
+++ b/seacatauth/authn/webauthn/__init__.py
@@ -1,7 +1,9 @@
 from .service import WebAuthnService
-from .handler import WebAuthnHandler
+from .handler.account import WebAuthnAccountHandler
+from .handler.admin import WebAuthnAdminHandler
 
 __all__ = [
 	"WebAuthnService",
-	"WebAuthnHandler",
+	"WebAuthnAccountHandler",
+	"WebAuthnAdminHandler",
 ]

--- a/seacatauth/authn/webauthn/handler/account.py
+++ b/seacatauth/authn/webauthn/handler/account.py
@@ -68,7 +68,8 @@ class WebAuthnAccountHandler(object):
 		List current user's registered WebAuthn credentials
 		"""
 		authz = asab.contextvars.Authz.get()
-		wa_credentials = await self.WebAuthnService.list_webauthn_credentials(authz.CredentialsId)
+		wa_credentials = await self.WebAuthnService.list_webauthn_credentials(
+			authz.CredentialsId, rest_normalize=True)
 		return asab.web.rest.json_response(request, {
 			"data": wa_credentials,
 			"count": len(wa_credentials),
@@ -87,7 +88,8 @@ class WebAuthnAccountHandler(object):
 			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
 
 		try:
-			wa_credential = await self.WebAuthnService.get_webauthn_credential(authz.CredentialsId, wacid)
+			wa_credential = await self.WebAuthnService.get_webauthn_credential(
+				authz.CredentialsId, wacid, rest_normalize=True)
 		except KeyError:
 			raise KeyError("WebAuthn credential not found", {
 				"wacid": wacid,

--- a/seacatauth/authn/webauthn/handler/account.py
+++ b/seacatauth/authn/webauthn/handler/account.py
@@ -1,0 +1,137 @@
+import base64
+import logging
+import aiohttp.web
+import asab.web
+import asab.web.rest
+import asab.web.tenant
+import asab.contextvars
+
+from seacatauth import exceptions
+from seacatauth.authn.webauthn import schema
+
+
+L = logging.getLogger(__name__)
+
+
+class WebAuthnAccountHandler(object):
+	"""
+	Manage FIDO2 Web Authentication
+
+	---
+	tags: ["FIDO2/WebAuthn"]
+	"""
+
+	def __init__(self, app, webauthn_svc):
+		self.CredentialsService = app.get_service("seacatauth.CredentialsService")
+		self.WebAuthnService = webauthn_svc
+
+		web_app = app.WebContainer.WebApp
+		web_app.router.add_get("/account/webauthn/register-options", self.get_registration_options)
+		web_app.router.add_put("/account/webauthn/register", self.register_credential)
+		web_app.router.add_delete("/account/webauthn/{wacid}", self.remove_credential)
+		web_app.router.add_put("/account/webauthn/{wacid}", self.update_credential)
+		web_app.router.add_get("/account/webauthn", self.list_credentials)
+
+
+	@asab.web.tenant.allow_no_tenant
+	async def get_registration_options(self, request):
+		"""
+		Get WebAuthn registration options
+		"""
+		authz = asab.contextvars.Authz.get()
+		try:
+			options = await self.WebAuthnService.get_registration_options(authz.Session)
+		except exceptions.AccessDeniedError:
+			return asab.web.rest.json_response(request, data={"status": "FAILED"}, status=400)
+		return aiohttp.web.Response(body=options, content_type="application/json")
+
+
+
+	@asab.web.rest.json_schema_handler(schema.REGISTER_WEBAUTHN_CREDENTIAL)
+	@asab.web.tenant.allow_no_tenant
+	async def register_credential(self, request, *, json_data):
+		"""
+		Register a new WebAuthn credential for the current user
+		"""
+		authz = asab.contextvars.Authz.get()
+		response = await self.WebAuthnService.register_credential(authz.Session, public_key_credential=json_data)
+		return asab.web.rest.json_response(
+			request, response,
+			status=200 if response["result"] == "OK" else 400
+		)
+
+
+	@asab.web.tenant.allow_no_tenant
+	async def list_credentials(self, request):
+		"""
+		List current user's registered WebAuthn credentials
+		"""
+		authz = asab.contextvars.Authz.get()
+		wa_credentials = []
+		for credential in await self.WebAuthnService.list_webauthn_credentials(authz.CredentialsId):
+			wa_credential = {
+				"id": base64.urlsafe_b64encode(credential["_id"]).decode("ascii").rstrip("="),
+				"name": credential["name"],
+				"sign_count": credential["sc"],
+				"created": credential["_c"],
+			}
+			if "ll" in credential:
+				wa_credential["last_login"] = credential["ll"]
+			wa_credentials.append(wa_credential)
+
+		return asab.web.rest.json_response(request, {
+			"result": "OK",
+			"data": wa_credentials,
+			"count": len(wa_credentials),
+		})
+
+	@asab.web.rest.json_schema_handler(schema.UPDATE_WEBAUTHN_CREDENTIAL)
+	@asab.web.tenant.allow_no_tenant
+	async def update_credential(self, request, *, json_data):
+		"""
+		Update current user's registered WebAuthn credential's metadata
+		"""
+		authz = asab.contextvars.Authz.get()
+		try:
+			wacid = base64.urlsafe_b64decode(request.match_info["wacid"].encode("ascii") + b"==")
+		except ValueError:
+			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
+
+		try:
+			await self.WebAuthnService.update_webauthn_credential(
+				wacid,
+				name=json_data["name"],
+				credentials_id=authz.CredentialsId
+			)
+		except KeyError:
+			raise KeyError("WebAuthn credential not found", {
+				"wacid": wacid,
+				"cid": authz.CredentialsId,
+			})
+		return asab.web.rest.json_response(
+			request, {"result": "OK"}
+		)
+
+
+	@asab.web.tenant.allow_no_tenant
+	async def remove_credential(self, request):
+		"""
+		Remove current user's registered WebAuthn credential
+		"""
+		authz = asab.contextvars.Authz.get()
+		try:
+			wacid = base64.urlsafe_b64decode(request.match_info["wacid"].encode("ascii") + b"==")
+		except ValueError:
+			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
+
+		try:
+			await self.WebAuthnService.delete_webauthn_credential(wacid, authz.CredentialsId)
+		except KeyError:
+			raise KeyError("WebAuthn credential not found", {
+				"wacid": wacid,
+				"cid": authz.CredentialsId,
+			})
+
+		return asab.web.rest.json_response(
+			request, {"result": "OK"}
+		)

--- a/seacatauth/authn/webauthn/handler/account.py
+++ b/seacatauth/authn/webauthn/handler/account.py
@@ -28,9 +28,9 @@ class WebAuthnAccountHandler(object):
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/account/webauthn/register-options", self.get_registration_options)
 		web_app.router.add_put("/account/webauthn/register", self.register_credential)
-		web_app.router.add_get("/account/webauthn/{wacid}", self.get_credential)
-		web_app.router.add_delete("/account/webauthn/{wacid}", self.remove_credential)
-		web_app.router.add_put("/account/webauthn/{wacid}", self.update_credential)
+		web_app.router.add_get("/account/webauthn/{passkey_id}", self.get_credential)
+		web_app.router.add_delete("/account/webauthn/{passkey_id}", self.remove_credential)
+		web_app.router.add_put("/account/webauthn/{passkey_id}", self.update_credential)
 		web_app.router.add_get("/account/webauthn", self.list_credentials)
 
 
@@ -83,16 +83,16 @@ class WebAuthnAccountHandler(object):
 		"""
 		authz = asab.contextvars.Authz.get()
 		try:
-			wacid = base64.urlsafe_b64decode(request.match_info["wacid"].encode("ascii") + b"==")
+			passkey_id = base64.urlsafe_b64decode(request.match_info["passkey_id"].encode("ascii") + b"==")
 		except ValueError:
-			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
+			raise KeyError("WebAuthn credential not found", {"passkey_id": request.match_info["passkey_id"]})
 
 		try:
 			wa_credential = await self.WebAuthnService.get_webauthn_credential(
-				authz.CredentialsId, wacid, rest_normalize=True)
+				authz.CredentialsId, passkey_id, rest_normalize=True)
 		except KeyError:
 			raise KeyError("WebAuthn credential not found", {
-				"wacid": wacid,
+				"passkey_id": passkey_id,
 				"cid": authz.CredentialsId,
 			})
 		return asab.web.rest.json_response(request, wa_credential)
@@ -105,19 +105,19 @@ class WebAuthnAccountHandler(object):
 		"""
 		authz = asab.contextvars.Authz.get()
 		try:
-			wacid = base64.urlsafe_b64decode(request.match_info["wacid"].encode("ascii") + b"==")
+			passkey_id = base64.urlsafe_b64decode(request.match_info["passkey_id"].encode("ascii") + b"==")
 		except ValueError:
-			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
+			raise KeyError("WebAuthn credential not found", {"passkey_id": request.match_info["passkey_id"]})
 
 		try:
 			await self.WebAuthnService.update_webauthn_credential(
-				wacid,
+				passkey_id,
 				name=json_data["name"],
 				credentials_id=authz.CredentialsId
 			)
 		except KeyError:
 			raise KeyError("WebAuthn credential not found", {
-				"wacid": wacid,
+				"passkey_id": passkey_id,
 				"cid": authz.CredentialsId,
 			})
 		return asab.web.rest.json_response(
@@ -132,15 +132,15 @@ class WebAuthnAccountHandler(object):
 		"""
 		authz = asab.contextvars.Authz.get()
 		try:
-			wacid = base64.urlsafe_b64decode(request.match_info["wacid"].encode("ascii") + b"==")
+			passkey_id = base64.urlsafe_b64decode(request.match_info["passkey_id"].encode("ascii") + b"==")
 		except ValueError:
-			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
+			raise KeyError("WebAuthn credential not found", {"passkey_id": request.match_info["passkey_id"]})
 
 		try:
-			await self.WebAuthnService.delete_webauthn_credential(wacid, authz.CredentialsId)
+			await self.WebAuthnService.delete_webauthn_credential(passkey_id, authz.CredentialsId)
 		except KeyError:
 			raise KeyError("WebAuthn credential not found", {
-				"wacid": wacid,
+				"passkey_id": passkey_id,
 				"cid": authz.CredentialsId,
 			})
 

--- a/seacatauth/authn/webauthn/handler/account.py
+++ b/seacatauth/authn/webauthn/handler/account.py
@@ -6,8 +6,8 @@ import asab.web.rest
 import asab.web.tenant
 import asab.contextvars
 
-from seacatauth import exceptions
-from seacatauth.authn.webauthn import schema
+from .... import exceptions
+from .. import schema
 
 
 L = logging.getLogger(__name__)

--- a/seacatauth/authn/webauthn/handler/admin.py
+++ b/seacatauth/authn/webauthn/handler/admin.py
@@ -1,14 +1,12 @@
 import base64
 import logging
-import aiohttp.web
 import asab.web
 import asab.web.auth
 import asab.web.rest
 import asab.web.tenant
 import asab.contextvars
 
-from seacatauth import exceptions
-from seacatauth.authn.webauthn import schema
+from .. import schema
 
 
 L = logging.getLogger(__name__)

--- a/seacatauth/authn/webauthn/handler/admin.py
+++ b/seacatauth/authn/webauthn/handler/admin.py
@@ -39,7 +39,7 @@ class WebAuthnAdminHandler(object):
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		wa_credentials = []
-		for credential in await self.WebAuthnService.list_webauthn_credentials(credentials_id):
+		for credential in await self.WebAuthnService.list_webauthn_credentials(credentials_id, rest_normalize=True):
 			wa_credential = {
 				"id": base64.urlsafe_b64encode(credential["_id"]).decode("ascii").rstrip("="),
 				"name": credential["name"],
@@ -60,7 +60,7 @@ class WebAuthnAdminHandler(object):
 	@asab.web.tenant.allow_no_tenant
 	async def admin_get_credential(self, request):
 		"""
-		Update current user's registered WebAuthn credential's metadata
+		Get target user's WebAuthn credential's metadata
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		try:
@@ -69,7 +69,8 @@ class WebAuthnAdminHandler(object):
 			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
 
 		try:
-			wa_credential = await self.WebAuthnService.get_webauthn_credential(credentials_id, wacid)
+			wa_credential = await self.WebAuthnService.get_webauthn_credential(
+				credentials_id, wacid, rest_normalize=True)
 		except KeyError:
 			raise KeyError("WebAuthn credential not found", {
 				"wacid": wacid,
@@ -83,7 +84,7 @@ class WebAuthnAdminHandler(object):
 	@asab.web.tenant.allow_no_tenant
 	async def admin_update_credential(self, request, *, json_data):
 		"""
-		Update current user's registered WebAuthn credential's metadata
+		Update target user's WebAuthn credential's metadata
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		try:
@@ -111,7 +112,7 @@ class WebAuthnAdminHandler(object):
 	@asab.web.tenant.allow_no_tenant
 	async def admin_remove_credential(self, request):
 		"""
-		Remove current user's registered WebAuthn credential
+		Delete target user's WebAuthn credential
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		try:

--- a/seacatauth/authn/webauthn/handler/admin.py
+++ b/seacatauth/authn/webauthn/handler/admin.py
@@ -50,7 +50,6 @@ class WebAuthnAdminHandler(object):
 			wa_credentials.append(wa_credential)
 
 		return asab.web.rest.json_response(request, {
-			"result": "OK",
 			"data": wa_credentials,
 			"count": len(wa_credentials),
 		})

--- a/seacatauth/authn/webauthn/handler/admin.py
+++ b/seacatauth/authn/webauthn/handler/admin.py
@@ -25,10 +25,10 @@ class WebAuthnAdminHandler(object):
 		self.WebAuthnService = webauthn_svc
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_get("/admin/credentials/{credentials_id}/webauthn", self.admin_list_credentials)
-		web_app.router.add_get("/admin/credentials/{credentials_id}/webauthn/{wacid}", self.admin_get_credential)
-		web_app.router.add_put("/admin/credentials/{credentials_id}/webauthn/{wacid}", self.admin_update_credential)
-		web_app.router.add_delete("/admin/credentials/{credentials_id}/webauthn/{wacid}", self.admin_remove_credential)
+		web_app.router.add_get("/admin/credentials/{credentials_id}/authn/webauthn", self.admin_list_credentials)
+		web_app.router.add_get("/admin/credentials/{credentials_id}/authn/webauthn/{passkey_id}", self.admin_get_credential)
+		web_app.router.add_put("/admin/credentials/{credentials_id}/authn/webauthn/{passkey_id}", self.admin_update_credential)
+		web_app.router.add_delete("/admin/credentials/{credentials_id}/authn/webauthn/{passkey_id}", self.admin_remove_credential)
 
 
 	@asab.web.auth.require_superuser
@@ -64,16 +64,16 @@ class WebAuthnAdminHandler(object):
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		try:
-			wacid = base64.urlsafe_b64decode(request.match_info["wacid"].encode("ascii") + b"==")
+			passkey_id = base64.urlsafe_b64decode(request.match_info["passkey_id"].encode("ascii") + b"==")
 		except ValueError:
-			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
+			raise KeyError("WebAuthn credential not found", {"passkey_id": request.match_info["passkey_id"]})
 
 		try:
 			wa_credential = await self.WebAuthnService.get_webauthn_credential(
-				credentials_id, wacid, rest_normalize=True)
+				credentials_id, passkey_id, rest_normalize=True)
 		except KeyError:
 			raise KeyError("WebAuthn credential not found", {
-				"wacid": wacid,
+				"passkey_id": passkey_id,
 				"cid": credentials_id,
 			})
 		return asab.web.rest.json_response(request, wa_credential)
@@ -88,19 +88,19 @@ class WebAuthnAdminHandler(object):
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		try:
-			wacid = base64.urlsafe_b64decode(request.match_info["wacid"].encode("ascii") + b"==")
+			passkey_id = base64.urlsafe_b64decode(request.match_info["passkey_id"].encode("ascii") + b"==")
 		except ValueError:
-			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
+			raise KeyError("WebAuthn credential not found", {"passkey_id": request.match_info["passkey_id"]})
 
 		try:
 			await self.WebAuthnService.update_webauthn_credential(
-				wacid,
+				passkey_id,
 				name=json_data["name"],
 				credentials_id=credentials_id
 			)
 		except KeyError:
 			raise KeyError("WebAuthn credential not found", {
-				"wacid": wacid,
+				"passkey_id": passkey_id,
 				"cid": credentials_id,
 			})
 		return asab.web.rest.json_response(
@@ -116,15 +116,15 @@ class WebAuthnAdminHandler(object):
 		"""
 		credentials_id = request.match_info["credentials_id"]
 		try:
-			wacid = base64.urlsafe_b64decode(request.match_info["wacid"].encode("ascii") + b"==")
+			passkey_id = base64.urlsafe_b64decode(request.match_info["passkey_id"].encode("ascii") + b"==")
 		except ValueError:
-			raise KeyError("WebAuthn credential not found", {"wacid": request.match_info["wacid"]})
+			raise KeyError("WebAuthn credential not found", {"passkey_id": request.match_info["passkey_id"]})
 
 		try:
-			await self.WebAuthnService.delete_webauthn_credential(wacid, credentials_id)
+			await self.WebAuthnService.delete_webauthn_credential(passkey_id, credentials_id)
 		except KeyError:
 			raise KeyError("WebAuthn credential not found", {
-				"wacid": wacid,
+				"passkey_id": passkey_id,
 				"cid": credentials_id,
 			})
 

--- a/seacatauth/authn/webauthn/service.py
+++ b/seacatauth/authn/webauthn/service.py
@@ -196,8 +196,8 @@ class WebAuthnService(asab.Service):
 		upsertor.set("rpid", self.RelyingPartyId)
 		upsertor.set("name", name)
 
-		wacid = await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_CREATED)
-		L.log(asab.LOG_NOTICE, "WebAuthn credential created", struct_data={"wacid": wacid.hex()})
+		passkey_id = await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_CREATED)
+		L.log(asab.LOG_NOTICE, "WebAuthn credential created.", struct_data={"passkey_id": passkey_id.hex()})
 
 	async def _get_authenticator_metadata(self, verified_registration):
 		aaguid = bytes.fromhex(verified_registration.aaguid.replace("-", ""))
@@ -227,7 +227,7 @@ class WebAuthnService(asab.Service):
 		wa_credential = await self._get_webauthn_credential(webauthn_credential_id)
 		if credentials_id != wa_credential["cid"]:
 			raise KeyError("WebAuthn credential not found", {
-				"wacid": webauthn_credential_id,
+				"passkey_id": webauthn_credential_id,
 				"cid": credentials_id
 			})
 		if rest_normalize:
@@ -296,7 +296,7 @@ class WebAuthnService(asab.Service):
 		if credentials_id is not None:
 			if credentials_id != wa_credential["cid"]:
 				raise KeyError("WebAuthn credential not found", {
-					"wacid": webauthn_credential_id,
+					"passkey_id": webauthn_credential_id,
 					"cid": credentials_id
 				})
 
@@ -316,8 +316,8 @@ class WebAuthnService(asab.Service):
 			upsertor.set("ll", last_login)
 
 		await upsertor.execute(event_type=EventTypes.WEBAUTHN_CREDENTIALS_UPDATED)
-		L.log(asab.LOG_NOTICE, "WebAuthn credential updated", struct_data={
-			"wacid": webauthn_credential_id.hex(),
+		L.log(asab.LOG_NOTICE, "WebAuthn credential updated.", struct_data={
+			"passkey_id": webauthn_credential_id.hex(),
 		})
 
 
@@ -336,12 +336,12 @@ class WebAuthnService(asab.Service):
 			wa_credential = await self._get_webauthn_credential(webauthn_credential_id)
 			if credentials_id != wa_credential["cid"]:
 				raise KeyError("WebAuthn credential not found", {
-					"wacid": webauthn_credential_id,
+					"passkey_id": webauthn_credential_id,
 					"cid": credentials_id
 				})
 
 		await self.StorageService.delete(self.WebAuthnCredentialCollection, webauthn_credential_id)
-		L.log(asab.LOG_NOTICE, "WebAuthn credential deleted", struct_data={"wacid": webauthn_credential_id.hex()})
+		L.log(asab.LOG_NOTICE, "WebAuthn credential deleted.", struct_data={"passkey_id": webauthn_credential_id.hex()})
 
 
 	async def delete_all_webauthn_credentials(self, credentials_id: str):
@@ -355,7 +355,7 @@ class WebAuthnService(asab.Service):
 
 		query_filter = {"cid": credentials_id}
 		result = await collection.delete_many(query_filter)
-		L.log(asab.LOG_NOTICE, "WebAuthn credentials deleted", struct_data={
+		L.log(asab.LOG_NOTICE, "WebAuthn credentials deleted.", struct_data={
 			"cid": credentials_id,
 			"count": result.deleted_count
 		})
@@ -381,7 +381,7 @@ class WebAuthnService(asab.Service):
 		upsertor.set("ch", challenge)
 
 		await upsertor.execute(event_type=EventTypes.WEBAUTHN_REG_CHALLENGE_CREATED)
-		L.log(asab.LOG_NOTICE, "WebAuthn challenge created", struct_data={"sid": session_id})
+		L.log(asab.LOG_NOTICE, "WebAuthn challenge created.", struct_data={"sid": session_id})
 
 		return challenge
 
@@ -400,7 +400,7 @@ class WebAuthnService(asab.Service):
 		Delete existing WebAuthn registration challenge for the current session
 		"""
 		await self.StorageService.delete(self.WebAuthnRegistrationChallengeCollection, session_id)
-		L.info("WebAuthn challenge deleted", struct_data={
+		L.info("WebAuthn challenge deleted.", struct_data={
 			"sid": session_id
 		})
 
@@ -556,9 +556,9 @@ class WebAuthnService(asab.Service):
 		sign_count = wa_credential["sc"]
 
 		if credentials_id != wa_credential["cid"]:
-			L.error("WebAuthn login failed: Credentials ID does not match", struct_data={
+			L.error("WebAuthn login failed: Credentials ID does not match.", struct_data={
 				"cid": credentials_id,
-				"wacid": wa_credential["_id"],
+				"passkey_id": wa_credential["_id"],
 			})
 			return False
 
@@ -573,7 +573,7 @@ class WebAuthnService(asab.Service):
 				require_user_verification=False,
 			)
 		except Exception as e:
-			L.warning("WebAuthn login failed with {}: {}".format(type(e).__name__, str(e)))
+			L.warning("WebAuthn login failed with {}: {}.".format(type(e).__name__, str(e)))
 			return False
 
 		# Update sign count in storage

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -92,7 +92,6 @@ class RoleService(asab.Service):
 
 
 	async def _ensure_preset_role(self, role_id: str, properties: dict, update: bool = True):
-		L.debug("Checking preset role.", struct_data={"role_id": role_id})
 		try:
 			existing_role = await self.get(role_id)
 		except KeyError:

--- a/seacatauth/otp/handler.py
+++ b/seacatauth/otp/handler.py
@@ -26,8 +26,15 @@ class OTPHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/account/totp", self.prepare_totp_if_not_active)
+		web_app.router.add_put("/account/totp", self.activate_totp)
+		web_app.router.add_delete("/account/totp", self.deactivate_totp)
+		web_app.router.add_delete("/admin/credentials/{credentials_id}/totp", self.admin_deactivate_totp)
+
+		# DEPRECATED
+		# >>>
 		web_app.router.add_put("/account/set-totp", self.activate_totp)
 		web_app.router.add_put("/account/unset-totp", self.deactivate_totp)
+		# <<<
 
 
 	@asab.web.tenant.allow_no_tenant
@@ -79,6 +86,21 @@ class OTPHandler(object):
 		authz = asab.contextvars.Authz.get()
 		try:
 			await self.OTPService.deactivate_totp(authz.CredentialsId)
+		except exceptions.TOTPDeactivationError:
+			return asab.web.rest.json_response(request, {"result": "FAILED"}, status=400)
+
+		return asab.web.rest.json_response(request, {"result": "OK"})
+
+
+	@asab.web.auth.require_superuser
+	@asab.web.tenant.allow_no_tenant
+	async def admin_deactivate_totp(self, request):
+		"""
+		Deactivate TOTP for target credentials
+		"""
+		credentials_id = request.match_info["credentials_id"]
+		try:
+			await self.OTPService.deactivate_totp(credentials_id)
 		except exceptions.TOTPDeactivationError:
 			return asab.web.rest.json_response(request, {"result": "FAILED"}, status=400)
 

--- a/seacatauth/otp/handler.py
+++ b/seacatauth/otp/handler.py
@@ -28,8 +28,8 @@ class OTPHandler(object):
 		web_app.router.add_get("/account/totp", self.prepare_totp_if_not_active)
 		web_app.router.add_put("/account/totp", self.activate_totp)
 		web_app.router.add_delete("/account/totp", self.deactivate_totp)
-		web_app.router.add_get("/admin/credentials/{credentials_id}/totp", self.admin_get_totp_status)
-		web_app.router.add_delete("/admin/credentials/{credentials_id}/totp", self.admin_deactivate_totp)
+		web_app.router.add_get("/admin/credentials/{credentials_id}/authn/totp", self.admin_get_totp_status)
+		web_app.router.add_delete("/admin/credentials/{credentials_id}/authn/totp", self.admin_deactivate_totp)
 
 		# DEPRECATED
 		# >>>

--- a/seacatauth/otp/handler.py
+++ b/seacatauth/otp/handler.py
@@ -28,6 +28,7 @@ class OTPHandler(object):
 		web_app.router.add_get("/account/totp", self.prepare_totp_if_not_active)
 		web_app.router.add_put("/account/totp", self.activate_totp)
 		web_app.router.add_delete("/account/totp", self.deactivate_totp)
+		web_app.router.add_get("/admin/credentials/{credentials_id}/totp", self.admin_get_totp_status)
 		web_app.router.add_delete("/admin/credentials/{credentials_id}/totp", self.admin_deactivate_totp)
 
 		# DEPRECATED
@@ -90,6 +91,19 @@ class OTPHandler(object):
 			return asab.web.rest.json_response(request, {"result": "FAILED"}, status=400)
 
 		return asab.web.rest.json_response(request, {"result": "OK"})
+
+
+	@asab.web.auth.require_superuser
+	@asab.web.tenant.allow_no_tenant
+	async def admin_get_totp_status(self, request):
+		"""
+		See if target credentials have TOTP activated
+		"""
+		credentials_id = request.match_info["credentials_id"]
+		if await self.OTPService.has_activated_totp(credentials_id):
+			return asab.web.rest.json_response(request, {"active": True})
+		else:
+			return asab.web.rest.json_response(request, {"active": False})
 
 
 	@asab.web.auth.require_superuser


### PR DESCRIPTION
# Summary
- Introduced admin API for managing TOTP and WebAuthn credentials.

# TOTP admin API

### Get target credentials' TOTP status
`GET /admin/credentials/{credentials_id}/authn/totp`

Response:
```json
{"active": true|false}
```

### Deactivate target credentials' TOTP
`DELETE /admin/credentials/{credentials_id}/authn/totp`

# WebAuthn admin API

### List passkeys
`GET /admin/credentials/{credentials_id}/authn/webauthn`

### Passkey detail
`GET /admin/credentials/{credentials_id}/authn/webauthn/{passkey_id}`

### Update passkey label
`PUT /admin/credentials/{credentials_id}/authn/webauthn/{passkey_id}`

### Deactivate passkey
`DELETE /admin/credentials/{credentials_id}/authn/webauthn/{passkey_id}`
