### PR TITLE
Prefix credentials API with /admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,17 @@
 ## v25.26
 
 ### Pre-releases
+- v25.26-alpha3
 - v25.26-alpha2
 - v25.26-alpha1
 
-### Fix
+### Fixes
 - Add default value for passwordlink in credentials creation (#494, v25.26-alpha2)
 - Fix ASAB version printer (#492, v25.26-alpha1)
 - Fix credentials search - Client provider error (#489, v25.26-alpha1)
+
+### Features
+- Prefix credentials API with /admin (#493, v25.26-alpha3)
 
 ---
 


### PR DESCRIPTION
- Credentials API is now prefixed with `/admin`, some paths changed to make the API more RESTful. Old endpoints kept for backward compatibility.
- Added `GET /account/credentials` endpoint.