### PR TITLE
Add default value for passwordlink in credentials creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## v25.26
 
 ### Pre-releases
+- v25.26-alpha2
 - v25.26-alpha1
 
 ### Fix
+- Add default value for passwordlink in credentials creation (#494, v25.26-alpha2)
 - Fix ASAB version printer (#492, v25.26-alpha1)
 - Fix credentials search - Client provider error (#489, v25.26-alpha1)
 

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -299,7 +299,7 @@ class CredentialsHandler(object):
 		"""
 		Create new credentials
 		"""
-		reset_password = json_data.pop("passwordlink")
+		reset_password = json_data.pop("passwordlink", False)
 		provider_id = request.match_info["provider"]
 		provider = self.CredentialsService.CredentialProviders[provider_id]
 


### PR DESCRIPTION
# Issue
Cannot create M2M credentials from the UI.

# Cause
UI does not send passwordlink with M2M credentials while the backend requires it.

# Solution
Add default value for passwordlink (False) in credentials creation.