### PR TITLE
Fix endpoint for obtaining global roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.26
 
 ### Pre-releases
+- v25.26-alpha7
 - v25.26-alpha6
 - v25.26-alpha5
 - v25.26-alpha4
@@ -15,6 +16,7 @@
   Common user tenant invitation path changed to `/account/tenant/{tenant}/invite` (#501, v25.13-alpha5)
 
 ### Fixes
+- Fix endpoint for obtaining global roles (#506, v25.26-alpha7)
 - Fix PKCE strength evaluation (#504, v25.26-alpha6)
 - Add default value for passwordlink in credentials creation (#494, v25.26-alpha2)
 - Fix ASAB version printer (#492, v25.26-alpha1)

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -6,6 +6,7 @@ import asab.web.auth
 import asab.web.tenant
 import asab.storage.exceptions
 import asab.exceptions
+import asab.utils
 
 from .... import exceptions
 from .... import generic
@@ -66,9 +67,7 @@ class RoleHandler(object):
 			in: query
 			description: Show only proper tenant roles, without globals.
 			schema:
-				type: string
-				enum:
-				- true
+				type: boolean
 		"""
 		tenant_id = asab.contextvars.Tenant.get()
 		return await self._list(request, tenant_id=tenant_id)
@@ -77,7 +76,7 @@ class RoleHandler(object):
 	@asab.web.tenant.allow_no_tenant
 	async def list_global_roles(self, request):
 		"""
-		List roles from all tenants
+		List global roles
 
 		---
 		parameters:
@@ -224,6 +223,7 @@ class RoleHandler(object):
 			limit=search.ItemsPerPage,
 			name_filter=search.SimpleFilter,
 			resource_filter=search.get("resource"),
+			exclude_global=asab.utils.string_to_boolean(request.query.get("exclude_global", "false"))
 		)
 		return asab.web.rest.json_response(request, result)
 

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -28,7 +28,7 @@ class RoleHandler(object):
 		self.RoleService = role_svc
 
 		web_app = app.WebContainer.WebApp
-		web_app.router.add_get("/role", self.list_all_roles)
+		web_app.router.add_get("/role/*", self.list_global_roles)
 		web_app.router.add_get("/role/*/{role_name}", self.get_global_role)
 		web_app.router.add_post("/role/*/{role_name}", self.create_global_role)
 		web_app.router.add_put("/role/*/{role_name}", self.update_global_role)
@@ -39,33 +39,6 @@ class RoleHandler(object):
 		web_app.router.add_post("/role/{tenant}/{role_name}", self.create_role)
 		web_app.router.add_put("/role/{tenant}/{role_name}", self.update_role)
 		web_app.router.add_delete("/role/{tenant}/{role_name}", self.delete_role)
-
-
-	@asab.web.auth.require_superuser
-	@asab.web.tenant.allow_no_tenant
-	async def list_all_roles(self, request):
-		"""
-		List roles from all tenants
-
-		---
-		parameters:
-		-	name: p
-			in: query
-			description: Page number
-			schema:
-				type: integer
-		-	name: i
-			in: query
-			description: Items per page
-			schema:
-				type: integer
-		-	name: resource
-			in: query
-			description: Show only roles that contain the specified resource
-			schema:
-				type: string
-		"""
-		return await self._list(request, tenant_id=None)
 
 
 	async def list_roles(self, request):
@@ -99,6 +72,32 @@ class RoleHandler(object):
 		"""
 		tenant_id = asab.contextvars.Tenant.get()
 		return await self._list(request, tenant_id=tenant_id)
+
+
+	@asab.web.tenant.allow_no_tenant
+	async def list_global_roles(self, request):
+		"""
+		List roles from all tenants
+
+		---
+		parameters:
+		-	name: p
+			in: query
+			description: Page number
+			schema:
+				type: integer
+		-	name: i
+			in: query
+			description: Items per page
+			schema:
+				type: integer
+		-	name: resource
+			in: query
+			description: Show only roles that contain the specified resource
+			schema:
+				type: string
+		"""
+		return await self._list(request, tenant_id=None)
 
 
 	async def get_role(self, request):


### PR DESCRIPTION
- Fixed `GET /role/*` (getting only global roles)
- Removed unused `GET /role` (getting all tenant and global roles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Separate role listing endpoints: tenant-scoped and global.
  * Added ability to delete global roles.
* **Refactor**
  * Tenant listing now derives tenant from request context; global listing supports tenant-less access.
* **Documentation**
  * Updated endpoint descriptions and added exclude_global query parameter for tenant role listing.
* **Bug Fixes**
  * Fixed global roles endpoint routing in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->