### PR TITLE
Negative resource filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.26
 
 ### Pre-releases
+- v25.26-alpha8
 - v25.26-alpha7
 - v25.26-alpha6
 - v25.26-alpha5
@@ -23,6 +24,7 @@
 - Fix credentials search - Client provider error (#489, v25.26-alpha1)
 
 ### Features
+- Negative resource filtering (#509, v25.26-alpha8)
 - New resource ID `seacat:client:apikey:manage` for client API key management (#488, v25.26-alpha4)
 - Prefix client API with /admin (#488, v25.26-alpha4)
 - Prefix credentials API with /admin (#493, v25.26-alpha3)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -57,6 +57,13 @@ class ResourceHandler(object):
 			description: Filter string
 			schema:
 				type: string
+		-	name: a_id!
+			in: query
+			description: Resource IDs to exclude from the results (comma-separated).
+			required: false
+			explode: false
+			schema:
+				type: array
 		-	name: exclude
 			in: query
 			description:
@@ -99,6 +106,11 @@ class ResourceHandler(object):
 
 		if "globalonly" in exclude:
 			query_filter["global_only"]["ne"] = True
+
+		exclude_ids = request.query.get("a_id!")
+		if exclude_ids:
+			exclude_ids = exclude_ids.split(",")
+			query_filter["_id"] = {"$nin": [re.escape(id_) for id_ in exclude_ids]}
 
 		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -112,7 +112,7 @@ class ResourceHandler(object):
 			exclude_ids = exclude_ids.split(",")
 			if "_id" not in query_filter:
 				query_filter["_id"] = {}
-			query_filter["_id"]["$nin"] = [re.escape(id_) for id_ in exclude_ids]
+			query_filter["_id"]["$nin"] = exclude_ids
 
 		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -110,7 +110,9 @@ class ResourceHandler(object):
 		exclude_ids = request.query.get("a_id!")
 		if exclude_ids:
 			exclude_ids = exclude_ids.split(",")
-			query_filter["_id"] = {"$nin": [re.escape(id_) for id_ in exclude_ids]}
+			if "_id" not in query_filter:
+				query_filter["_id"] = {}
+			query_filter["_id"]["$nin"] = [re.escape(id_) for id_ in exclude_ids]
 
 		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)


### PR DESCRIPTION
Use query param `a_id!` to specify comma-separated resource IDs which should be excluded from the result, e.g. `GET /resource?a_id!=seacat:role:access,seacat:role:edit,seacat:role:assign`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added negative resource filtering to the list endpoint, allowing clients to exclude specific resources by ID via a new query parameter.

* **Documentation**
  * Updated CHANGELOG with v25.26-alpha8 pre-release entry highlighting the new negative resource filtering capability.

* **Tests**
  * No user-impacting test changes noted.

* **Chores**
  * No user-facing maintenance changes noted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->