### PR TITLE
Extend resource filtering API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.26
 
 ### Pre-releases
+- v25.26-alpha9
 - v25.26-alpha8
 - v25.26-alpha7
 - v25.26-alpha6
@@ -13,6 +14,7 @@
 - v25.26-alpha1
 
 ### Breaking changes
+- Resource list query parameters changed: `exclude` is no longer supported (#510, v25.26-alpha9)
 - Admin tenant invitation path changed to `/admin/tenant/{tenant}/invite`.
   Common user tenant invitation path changed to `/account/tenant/{tenant}/invite` (#501, v25.13-alpha5)
 
@@ -24,6 +26,7 @@
 - Fix credentials search - Client provider error (#489, v25.26-alpha1)
 
 ### Features
+- Extend resource filtering API (#510, v25.26-alpha9)
 - Negative resource filtering (#509, v25.26-alpha8)
 - New resource ID `seacat:client:apikey:manage` for client API key management (#488, v25.26-alpha4)
 - Prefix client API with /admin (#488, v25.26-alpha4)

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -208,7 +208,7 @@ class ResourceHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-def _build_resource_filter(query: dict = None) -> dict | False:
+def _build_resource_filter(query: dict = None) -> dict | bool:
 	"""
 	Build a filter for resources based on the current tenant and authorization context.
 

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -105,6 +105,10 @@ class ResourceHandler(object):
 			limit = int(limit)
 
 		query_filter = _build_resource_filter(request.query)
+		if query_filter is False:
+			# Empty result set
+			return asab.web.rest.json_response(request, {"count": 0, "data": []})
+
 		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)
 
@@ -204,9 +208,15 @@ class ResourceHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-def _build_resource_filter(query: dict = None) -> dict | bool:
+def _build_resource_filter(query: dict = None) -> dict | False:
 	"""
 	Build a filter for resources based on the current tenant and authorization context.
+
+	Args:
+		query (dict): The query parameters from the request.
+
+	Returns:
+		dict | False : A MongoDB filter dictionary, or False if the filter leads to empty result.
 	"""
 	query_filter = {}
 

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -225,10 +225,8 @@ def _build_resource_filter(query: dict = None) -> dict | False:
 	if name_filter:
 		generic.update_mongodb_filter(query_filter, "_id", {"$regex": re.escape(name_filter)})
 
-	if "adeleted" in query:
-		deleted = asab.utils.string_to_boolean(query.get("adeleted"))
-	else:
-		# Do not include deleted items by default
+	deleted = asab.utils.string_to_boolean(query.get("adeleted", False))
+	if deleted is False:
 		deleted = {"$in": [False, None]}
 	generic.update_mongodb_filter(query_filter, "deleted", deleted)
 

--- a/seacatauth/authz/resource/handler.py
+++ b/seacatauth/authz/resource/handler.py
@@ -1,13 +1,15 @@
 import logging
 import re
+
 import asab
 import asab.contextvars
 import asab.web.rest
 import asab.web.auth
 import asab.web.tenant
 import asab.exceptions
+import asab.utils
 
-from ... import exceptions
+from ... import exceptions, generic
 from ...models.const import ResourceId
 from . import schema
 
@@ -64,56 +66,45 @@ class ResourceHandler(object):
 			explode: false
 			schema:
 				type: array
-		-	name: exclude
+		-	name: a_id
 			in: query
-			description:
-				Exclude resources based on their type/status. If omitted, this parameter defaults
-				to `exclude=deleted`, which means the results include all active resources.
+			description: Resource IDs to search (comma-separated).
 			required: false
 			explode: false
 			schema:
 				type: array
-				items:
-					enum: ["active", "deleted", "globalonly"]
+		-	name: acontext
+			in: query
+			description:
+				Context in which the resource can be used. If set to "tenant", only resources that are not
+				global-only are returned. Defaults to "global", returning all resources.
+			required: false
+			schema:
+				type: string
+				enum: ["tenant", "global"]
+		-	name: aauthorized
+			in: query
+			description:
+				Filter to authorized or unauthorized resources. If set to "true", only resources that the user is
+				authorized to access are returned.
+			required: false
+			schema:
+				type: boolean
+		-	name: adeleted
+			in: query
+			description:
+				Filter to active or soft-deleted resources. If set to "true", only deleted resources are listed.
+				Defaults to "false", listing only active resources.
+			required: false
+			schema:
+				type: boolean
 		"""
 		page = int(request.query.get("p", 1)) - 1
 		limit = request.query.get("i", None)
 		if limit is not None:
 			limit = int(limit)
 
-		# Filter by ID.startswith()
-		query_filter = {}
-		name_filter = request.query.get("f")
-		if name_filter:
-			query_filter["_id"] = {"$regex": re.escape(name_filter)}
-
-		# Get the types of resources to exclude from the results
-		# By default, exclude only deleted resources
-		exclude = request.query.get("exclude", "")
-		if len(exclude) == 0:
-			exclude = "deleted"
-		exclude = exclude.split(",")
-		if "deleted" in exclude:
-			if "active" in exclude:
-				return asab.web.rest.json_response(request, {"data": [], "count": 0})
-			else:
-				query_filter["deleted"] = {"$in": [None, False]}
-		else:
-			if "active" in exclude:
-				query_filter["deleted"] = True
-			else:
-				pass
-
-		if "globalonly" in exclude:
-			query_filter["global_only"]["ne"] = True
-
-		exclude_ids = request.query.get("a_id!")
-		if exclude_ids:
-			exclude_ids = exclude_ids.split(",")
-			if "_id" not in query_filter:
-				query_filter["_id"] = {}
-			query_filter["_id"]["$nin"] = exclude_ids
-
+		query_filter = _build_resource_filter(request.query)
 		resources = await self.ResourceService.list(page, limit, query_filter)
 		return asab.web.rest.json_response(request, resources)
 
@@ -211,3 +202,61 @@ class ResourceHandler(object):
 		except exceptions.NotEditableError as e:
 			return e.json_response(request)
 		return asab.web.rest.json_response(request, {"result": "OK"})
+
+
+def _build_resource_filter(query: dict = None) -> dict | bool:
+	"""
+	Build a filter for resources based on the current tenant and authorization context.
+	"""
+	query_filter = {}
+
+	# Search in resource ID
+	name_filter = query.get("f")
+	if name_filter:
+		generic.update_mongodb_filter(query_filter, "_id", {"$regex": re.escape(name_filter)})
+
+	if "adeleted" in query:
+		deleted = asab.utils.string_to_boolean(query.get("adeleted"))
+	else:
+		# Do not include deleted items by default
+		deleted = {"$in": [False, None]}
+	generic.update_mongodb_filter(query_filter, "deleted", deleted)
+
+	if "acontext" in query:
+		context = query.get("acontext")
+		if context == "tenant":
+			# Exclude global-only resources
+			generic.update_mongodb_filter(query_filter, "global_only.$ne", True)
+		elif context == "global":
+			# Include all resources
+			pass
+		else:
+			# Unknown context, return empty result
+			return False
+
+	if "aauthorized" in query:
+		authz = asab.contextvars.Authz.get()
+
+		if asab.utils.string_to_boolean(query["aauthorized"]) is True:
+			# Filter to authorized resources only
+			if authz.has_superuser_access():
+				pass
+			else:
+				generic.update_mongodb_filter(query_filter, "_id.$in", authz._resources())
+		else:
+			# Filter to unauthorized resources only
+			if authz.has_superuser_access():
+				# There is nothing to filter, superuser can see all resources
+				return False
+			else:
+				generic.update_mongodb_filter(query_filter, "_id.$nin", authz._resources())
+
+	exclude_ids = query.get("a_id!")
+	if exclude_ids:
+		generic.update_mongodb_filter(query_filter, "_id.$nin", exclude_ids.split(","))
+
+	search_ids = query.get("a_id")
+	if search_ids:
+		generic.update_mongodb_filter(query_filter, "_id.$in", search_ids.split(","))
+
+	return query_filter

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -354,12 +354,13 @@ def datetime_from_relative_or_absolute_timestring(value: str) -> datetime.dateti
 def update_mongodb_filter(query_filter: dict, path: str | list, value: typing.Any) -> None:
 	"""
 	Update a MongoDB filter dictionary with a new value at the specified path.
-	Updates existing $in and $nin array fields by OR-combining their values with the new value.
+	For "$in" and "$nin", merge values (OR semantics).
+	For other fields, set the value if absent; raise if value is already set.
 
 	Args:
-		query_filter (dict): The MongoDB filter dictionary to update.
-		path (str | list): The path to the field to update. Can be a string with dot notation or a list of keys.
-		value (Any): The value to set at the specified path.
+		query_filter (dict): MongoDB-style filter to mutate.
+		path (str | list[str]): Dot path or list of keys.
+		value (Any): Value to set/merge.
 	"""
 	if isinstance(path, str):
 		path = path.split(".")


### PR DESCRIPTION
# Summary
- Added new advanced query filters to resource list:
    - `a_id` (comma-separated values) to search only specified resources IDs,
    - `aauthorized` (boolean) to filter for authorized or unauthorized resources only,
    - `adeleted` (boolean) to filter for deleted resources (defaults to False - showing only non-deleted resources),
    - `acontext` (`global` or `tenant`) to filter resources usable in global or tenant roles (defaults to `global` - showing all resources).
- Removed `exclude` filter parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enhanced resource listing with new query parameters for include IDs, tenant/global context, authorization state, deletion state, and regex filtering. Defaults exclude deleted items and apply context-based filtering.

- Documentation
  - Updated List endpoint docs to describe new parameters and revised behaviors.

- Refactor
  - Centralized filter builder for consistent, predictable listing behavior.

- Breaking Changes
  - Previous exclude semantics removed; API filtering semantics updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->