### PR TITLE
Standardize API key creation response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.26
 
 ### Pre-releases
+- v25.26-alpha12
 - v25.26-alpha11
 - v25.26-alpha10
 - v25.26-alpha9
@@ -29,6 +30,7 @@
 - Fix credentials search - Client provider error (#489, v25.26-alpha1)
 
 ### Features
+- Standardize API key creation response (#512, v25.26-alpha12)
 - Simpler API keys (#505, v25.26-alpha11)
 - Extend resource filtering API (#510, v25.26-alpha9)
 - Negative resource filtering (#509, v25.26-alpha8)

--- a/seacatauth/apikey/handler.py
+++ b/seacatauth/apikey/handler.py
@@ -107,13 +107,13 @@ class ApiKeyHandler(object):
 	@asab.web.tenant.allow_no_tenant
 	@asab.web.auth.require(ResourceId.APIKEY_MANAGE)
 	async def create_api_key(self, request, *, json_data):
-		result = await self.ApiKeyService.create_api_key(
+		response_data = await self.ApiKeyService.create_api_key(
 			expires_at=generic.datetime_from_relative_or_absolute_timestring(json_data["exp"]),
 			tenant=json_data.get("tenant"),
 			resources=json_data["resources"],
 			label=json_data["label"],
 		)
-		return asab.web.rest.json_response(request, result)
+		return asab.web.rest.json_response(request, {"result": "OK", "data": response_data}, status=201)
 
 
 	@asab.web.tenant.allow_no_tenant


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized the API key creation endpoint response to a structured JSON: {"result":"OK","data":...} with HTTP 201 Created, improving consistency for clients parsing results.

* **Documentation**
  * Updated changelog with v25.26-alpha12 as the latest pre-release.
  * Documented the new feature entry: “Standardize API key creation response (v25.26-alpha12)”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->