### PR TITLE
Fix websocket authentication introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.26
 
 ### Pre-releases
+- v25.26-alpha12
 - v25.26-alpha11
 - v25.26-alpha10
 - v25.26-alpha9
@@ -21,6 +22,7 @@
   Common user tenant invitation path changed to `/account/tenant/{tenant}/invite` (#501, v25.13-alpha5)
 
 ### Fixes
+- Fix websocket authentication introspection (#513, v25.26-alpha12)
 - Remove a- prefix from resource list API parameters (#511, v25.26-alpha10)
 - Fix endpoint for obtaining global roles (#506, v25.26-alpha7)
 - Fix PKCE strength evaluation (#504, v25.26-alpha6)

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -133,19 +133,21 @@ def get_token_from_authorization_header(request) -> typing.Optional[typing.Tuple
 		request: aiohttp.web.Request object
 
 	Returns:
-		Token (type, value) tuple, ot None if the header is missing or malformed.
+		Token (type, value) tuple, or None if the header is missing or malformed.
 	"""
 	auth_header = request.headers.get(aiohttp.hdrs.AUTHORIZATION, None)
 	if auth_header is None:
 		L.debug("Request has no Authorization header.")
 		return None
+
 	parts = auth_header.split(" ", 1)
 	if len(parts) != 2:
 		L.warning("Malformed Authorization header.", struct_data={
 			"header_fingerprint": fingerprint(auth_header),
 		})
 		return None
-	return parts
+
+	return parts[0], parts[1]
 
 
 def get_access_token_value_from_websocket(request) -> typing.Optional[typing.Tuple[str, str]]:
@@ -156,10 +158,10 @@ def get_access_token_value_from_websocket(request) -> typing.Optional[typing.Tup
 		request: aiohttp.web.Request object
 
 	Returns:
-		Token (type, value) tuple, ot None if no token is found in the header.
+		Token (type, value) tuple, or None if no token is found in the header.
 	"""
 	token_prefix = "access_token_"
-	ws_protocol_header: str = request.headers.get(aiohttp.hdrs.SEC_WEBSOCKET_PROTOCOL)
+	ws_protocol_header = request.headers.get(aiohttp.hdrs.SEC_WEBSOCKET_PROTOCOL)
 	if ws_protocol_header is None:
 		L.debug("Request has no 'Sec-WebSocket-Protocol' header")
 		return None

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -125,29 +125,48 @@ def get_bearer_token_value(request):
 	return None
 
 
-def get_token_from_authorization_header(request):
+def get_token_from_authorization_header(request) -> typing.Optional[typing.Tuple[str, str]]:
+	"""
+	Parse the 'Authorization' header and return (type, value) tuple.
+
+	Args:
+		request: aiohttp.web.Request object
+
+	Returns:
+		Token (type, value) tuple, ot None if the header is missing or malformed.
+	"""
 	auth_header = request.headers.get(aiohttp.hdrs.AUTHORIZATION, None)
 	if auth_header is None:
 		L.info("Request has no Authorization header.")
-		return None, None
+		return None
 	parts = auth_header.split(" ", 1)
 	if len(parts) != 2:
 		L.warning("Malformed Authorization header.", struct_data={
 			"header_fingerprint": fingerprint(auth_header),
 		})
-		return None, None
+		return None
 	return parts
 
 
-def get_access_token_value_from_websocket(request):
+def get_access_token_value_from_websocket(request) -> typing.Optional[typing.Tuple[str, str]]:
+	"""
+	Extract access token from 'Sec-WebSocket-Protocol' header.
+
+	Args:
+		request: aiohttp.web.Request object
+
+	Returns:
+		Token (type, value) tuple, ot None if no token is found in the header.
+	"""
 	token_prefix = "access_token_"
 	ws_protocol_header: str = request.headers.get(aiohttp.hdrs.SEC_WEBSOCKET_PROTOCOL)
 	if ws_protocol_header is None:
 		L.info("Request has no 'Sec-WebSocket-Protocol' header")
 		return None
+
 	for value in ws_protocol_header.split(", "):
 		if value.startswith(token_prefix):
-			return value[len(token_prefix):]
+			return "Bearer", value[len(token_prefix):]
 
 	L.info("No access token in Sec-WebSocket-Protocol header")
 	return None

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -137,7 +137,7 @@ def get_token_from_authorization_header(request) -> typing.Optional[typing.Tuple
 	"""
 	auth_header = request.headers.get(aiohttp.hdrs.AUTHORIZATION, None)
 	if auth_header is None:
-		L.info("Request has no Authorization header.")
+		L.debug("Request has no Authorization header.")
 		return None
 	parts = auth_header.split(" ", 1)
 	if len(parts) != 2:
@@ -161,14 +161,14 @@ def get_access_token_value_from_websocket(request) -> typing.Optional[typing.Tup
 	token_prefix = "access_token_"
 	ws_protocol_header: str = request.headers.get(aiohttp.hdrs.SEC_WEBSOCKET_PROTOCOL)
 	if ws_protocol_header is None:
-		L.info("Request has no 'Sec-WebSocket-Protocol' header")
+		L.debug("Request has no 'Sec-WebSocket-Protocol' header")
 		return None
 
 	for value in ws_protocol_header.split(", "):
 		if value.startswith(token_prefix):
 			return "Bearer", value[len(token_prefix):]
 
-	L.info("No access token in Sec-WebSocket-Protocol header")
+	L.debug("No access token in Sec-WebSocket-Protocol header")
 	return None
 
 

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -13,7 +13,8 @@ from ... import exceptions
 from ...generic import (
 	nginx_introspection,
 	get_access_token_value_from_websocket,
-	get_token_from_authorization_header
+	get_token_from_authorization_header,
+	fingerprint,
 )
 
 
@@ -100,14 +101,16 @@ class TokenIntrospectionHandler(object):
 			try:
 				session = await self.OpenIdConnectService.get_session_by_access_token(token_value)
 			except exceptions.SessionNotFoundError as e:
-				L.log(asab.LOG_NOTICE, "Access token matched no session: {}".format(e))
+				L.log(asab.LOG_NOTICE, "Access token matched no session: {}".format(e), struct_data={
+					"token_fingerprint": fingerprint(token_value)})
 				return None
 
 		elif token_type == self.ApiKeyService.TOKEN_TYPE:
 			try:
 				session = await self.ApiKeyService.get_session_by_api_key(token_value)
 			except exceptions.SessionNotFoundError as e:
-				L.log(asab.LOG_NOTICE, "API key matched no session: {}".format(e))
+				L.log(asab.LOG_NOTICE, "API key matched no session: {}".format(e), struct_data={
+					"token_fingerprint": fingerprint(token_value)})
 				return None
 
 		else:

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -79,13 +79,23 @@ class TokenIntrospectionHandler(object):
 
 
 	async def _authenticate_request(self, request):
-		token_type, token_value = get_token_from_authorization_header(request)
-		if token_value is None:
-			token_value = get_access_token_value_from_websocket(request)
-		if token_value is None:
+		"""
+		Authenticate request using access token or API key from Authorization header or Sec-WebSocket-Protocol header.
+
+		Args:
+			request (aiohttp.web.Request): Incoming request.
+
+		Returns:
+			session (Session|None): Authenticated session or None if authentication failed.
+		"""
+		token = get_token_from_authorization_header(request)
+		if token is None:
+			token = get_access_token_value_from_websocket(request)
+		if token is None:
 			L.log(asab.LOG_NOTICE, "Access token not found in 'Authorization' nor 'Sec-WebSocket-Protocol' header")
 			return None
 
+		token_type, token_value = token
 		if token_type == "Bearer":
 			try:
 				session = await self.OpenIdConnectService.get_session_by_access_token(token_value)


### PR DESCRIPTION
# Issue
Websocket introspection fails with
```
ERROR seacatauth.openidconnect.handler.introspect Unsupported token type: None
```

# Solution
Unify the return types of get_access_token_value_from_websocket and get_token_from_authorization_header methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Fixes
  - WebSocket authentication introspection fixed so tokens sent via websocket are recognized and handled consistently.
- Refactor
  - Unified token extraction for HTTP and WebSocket flows to streamline authentication logic.
- Documentation
  - Added clear docstrings describing token parsing and authentication behavior.
- Style
  - Added type annotations to improve readability and tooling support.
- Logging
  - Enhanced logs with token fingerprints and clearer messages for missing, unsupported, or failed tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->