### PR TITLE
Opaque external credential IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v25.38
 
 ### Pre-releases
+- v25.38-alpha6
 - v25.38-alpha5
 - v25.38-alpha4
 - v25.38-alpha3
@@ -10,6 +11,7 @@
 - v25.38-alpha1
 
 ### Fixes
+- Opaque external credential IDs (#521, v25.38-alpha6)
 - Fix pysaml2 dependency (#518, v25.38-alpha4)
 
 ### Features

--- a/seacatauth/external_login/authentication/service.py
+++ b/seacatauth/external_login/authentication/service.py
@@ -247,12 +247,11 @@ class ExternalAuthenticationService(asab.Service):
 		# Find the external account and its associated Seacat credentials ID
 		try:
 			with local_authz(self.Name, resources={ResourceId.CREDENTIALS_ACCESS}):
-				account = await self.ExternalCredentialsService.get_ext_credentials(
+				account = await self.ExternalCredentialsService.get_ext_credentials_by_type_and_sub(
 					provider_type, subject_id=user_info["sub"])
 			credentials_id = account["cid"]
 		except ExternalAccountNotFoundError as e:
-			L.log(asab.LOG_NOTICE, "External account not found.", struct_data={
-				"type": e.ProviderType, "sub": e.SubjectId})
+			L.log(asab.LOG_NOTICE, "External account not found.", struct_data={"query": e.Query})
 			if not self.can_sign_up_new_credentials(provider_type):
 				# Redirect to login page with error message, keep the original redirect uri in the query
 				return self._error_redirect_response(
@@ -371,7 +370,7 @@ class ExternalAuthenticationService(asab.Service):
 		# Verify that the external account is not registered already
 		try:
 			with local_authz(self.Name, resources={ResourceId.CREDENTIALS_ACCESS}):
-				await self.ExternalCredentialsService.get_ext_credentials(
+				await self.ExternalCredentialsService.get_ext_credentials_by_type_and_sub(
 					provider_type, subject_id=user_info["sub"])
 			L.log(asab.LOG_NOTICE, "Cannot sign up with external account: Account already paired.", struct_data={
 				"provider": provider_type, "sub": user_info.get("sub")})

--- a/seacatauth/external_login/credentials/handler/account.py
+++ b/seacatauth/external_login/credentials/handler/account.py
@@ -25,8 +25,8 @@ class ExternalLoginAccountHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/account/ext-login", self.list_my_ext_credentials)
-		web_app.router.add_get("/account/ext-login/{provider_type}/{subject_id}", self.get_my_ext_credentials)
-		web_app.router.add_delete("/account/ext-login/{provider_type}/{subject_id}", self.remove_my_ext_credentials)
+		web_app.router.add_get("/account/ext-login/{ext_credentials_id}", self.get_my_ext_credentials)
+		web_app.router.add_delete("/account/ext-login/{ext_credentials_id}", self.remove_my_ext_credentials)
 
 
 	@asab.web.tenant.allow_no_tenant
@@ -47,11 +47,9 @@ class ExternalLoginAccountHandler(object):
 		"""
 		Get the current user's external login credentials detail
 		"""
-		provider_type = request.match_info["provider_type"]
-		subject_id = request.match_info["subject_id"]
+		ext_credentials_id = request.match_info["ext_credentials_id"]
 		try:
-			data = await self.ExternalCredentialsService.get_ext_credentials(
-				provider_type, subject_id)
+			data = await self.ExternalCredentialsService.get_ext_credentials(ext_credentials_id)
 			return asab.web.rest.json_response(request, data)
 		except ExternalAccountNotFoundError:
 			return asab.web.rest.json_response(request, {"result": "NOT-FOUND"}, status=404)
@@ -62,11 +60,9 @@ class ExternalLoginAccountHandler(object):
 		"""
 		Remove the current user's external login account
 		"""
-		provider_type = request.match_info["provider_type"]
-		subject_id = request.match_info["subject_id"]
+		ext_credentials_id = request.match_info["ext_credentials_id"]
 		try:
-			await self.ExternalCredentialsService.delete_ext_credentials(
-				provider_type, subject_id)
+			await self.ExternalCredentialsService.delete_ext_credentials(ext_credentials_id)
 			return asab.web.rest.json_response(request, {"result": "OK"})
 		except ExternalAccountNotFoundError:
 			return asab.web.rest.json_response(request, {"result": "NOT-FOUND"}, status=404)

--- a/seacatauth/external_login/credentials/handler/admin.py
+++ b/seacatauth/external_login/credentials/handler/admin.py
@@ -26,8 +26,8 @@ class ExternalCredentialsAdminHandler(object):
 
 		web_app = app.WebContainer.WebApp
 		web_app.router.add_get("/admin/ext-login/{credentials_id}", self.list_ext_credentials)
-		web_app.router.add_get("/admin/ext-login/{provider_type}/{sub}", self.get_ext_credentials)
-		web_app.router.add_delete("/admin/ext-login/{provider_type}/{sub}", self.remove_ext_credentials)
+		web_app.router.add_get("/admin/ext-login/{ext_credentials_id}", self.get_ext_credentials)
+		web_app.router.add_delete("/admin/ext-login/{ext_credentials_id}", self.remove_ext_credentials)
 
 
 	@asab.web.tenant.allow_no_tenant
@@ -50,10 +50,9 @@ class ExternalCredentialsAdminHandler(object):
 		"""
 		Get external login account detail
 		"""
-		provider_type = request.match_info["provider_type"]
-		subject = request.match_info["sub"]
+		ext_credentials_id = request.match_info["ext_credentials_id"]
 		try:
-			data = await self.ExternalCredentialsService.get_ext_credentials(provider_type, subject)
+			data = await self.ExternalCredentialsService.get_ext_credentials(ext_credentials_id)
 			return asab.web.rest.json_response(request, data)
 		except ExternalAccountNotFoundError:
 			return asab.web.rest.json_response(request, {"result": "NOT-FOUND"}, status=404)
@@ -65,10 +64,9 @@ class ExternalCredentialsAdminHandler(object):
 		"""
 		Remove external login account
 		"""
-		provider_type = request.match_info["provider_type"]
-		subject = request.match_info["sub"]
+		ext_credentials_id = request.match_info["ext_credentials_id"]
 		try:
-			await self.ExternalCredentialsService.delete_ext_credentials(provider_type, subject)
+			await self.ExternalCredentialsService.delete_ext_credentials(ext_credentials_id)
 		except ExternalAccountNotFoundError:
 			return asab.web.rest.json_response(request, {"result": "NOT-FOUND"}, status=404)
 		return asab.web.rest.json_response(request, {"result": "OK"})

--- a/seacatauth/external_login/credentials/service.py
+++ b/seacatauth/external_login/credentials/service.py
@@ -291,10 +291,6 @@ class ExternalCredentialsService(asab.Service):
 		return credentials_id
 
 
-def _make_id(provider_type: str, subject_id: str):
-	return "{} {}".format(provider_type, subject_id)
-
-
 def _normalize_ext_credentials(account: dict):
 	# Normalize old field names
 	if "e" in account and "email" not in account:

--- a/seacatauth/external_login/credentials/service.py
+++ b/seacatauth/external_login/credentials/service.py
@@ -166,9 +166,9 @@ class ExternalCredentialsService(asab.Service):
 		coll = await self.StorageService.collection(self.ExternalCredentialsCollection)
 		try:
 			ext_credentials = await coll.find_one({
-			"type": provider_type,
-			"sub": subject_id,
-		})
+				"type": provider_type,
+				"sub": subject_id,
+			})
 		except KeyError:
 			raise ExternalAccountNotFoundError(type=provider_type, sub=subject_id)
 

--- a/seacatauth/external_login/credentials/service.py
+++ b/seacatauth/external_login/credentials/service.py
@@ -164,13 +164,13 @@ class ExternalCredentialsService(asab.Service):
 			A dictionary containing the external credentials information.
 		"""
 		coll = await self.StorageService.collection(self.ExternalCredentialsCollection)
-		try:
-			ext_credentials = await coll.find_one({
-				"type": provider_type,
-				"sub": subject_id,
-			})
-		except KeyError:
-			raise ExternalAccountNotFoundError(type=provider_type, sub=subject_id)
+		ext_credentials = await coll.find_one({
+			"type": provider_type,
+			"sub": subject_id,
+		})
+
+		if ext_credentials is None:
+			raise ExternalAccountNotFoundError(query={"type": provider_type, "sub": subject_id})
 
 		ext_credentials = _normalize_ext_credentials(ext_credentials)
 
@@ -192,7 +192,7 @@ class ExternalCredentialsService(asab.Service):
 		try:
 			ext_credentials = await self.StorageService.get(self.ExternalCredentialsCollection, ext_credentials_id)
 		except KeyError:
-			raise ExternalAccountNotFoundError(_id=ext_credentials_id)
+			raise ExternalAccountNotFoundError(query={"_id": ext_credentials_id})
 
 		ext_credentials = _normalize_ext_credentials(ext_credentials)
 
@@ -239,7 +239,7 @@ class ExternalCredentialsService(asab.Service):
 		try:
 			ext_credentials = await self.StorageService.get(self.ExternalCredentialsCollection, ext_credentials_id)
 		except KeyError:
-			raise ExternalAccountNotFoundError(_id=ext_credentials_id)
+			raise ExternalAccountNotFoundError(query={"_id": ext_credentials_id})
 
 		ensure_edit_permissions(ext_credentials["cid"])
 

--- a/seacatauth/external_login/exceptions.py
+++ b/seacatauth/external_login/exceptions.py
@@ -5,11 +5,9 @@ class ExternalAccountNotFoundError(SeacatAuthError, KeyError):
 	"""
 	External login account not found
 	"""
-	def __init__(self, provider_type: str, subject_id: str, *args):
-		self.ProviderType = provider_type
-		self.SubjectId = subject_id
-		super().__init__("External login account {!r} not found in provider {!r}".format(
-			self.SubjectId, self.ProviderType), *args)
+	def __init__(self, *args, query, **kwargs):
+		self.Query = query
+		super().__init__("No external credentials matched the query {!r}".format(self.Query), *args)
 
 
 class ExternalLoginError(SeacatAuthError):


### PR DESCRIPTION
# Issue
External credential ID is composed of provider type and subject_id. However subject_id can be an email address or other sensitive info, which is not suitable to be used in URLs.

# Solution
Random opaque ID is generated upon creating new external credentials.

# Breaking change
The account and admin API for ext credentials management changed:
-  `GET /admin/ext-login/{provider_type}/{subject_id}` -> `GET /admin/ext-login/{ext_credentials_id}`.
-  `GET /account/ext-login/{provider_type}/{subject_id}` -> `GET /account/ext-login/{ext_credentials_id}`.
- [x] Seacat Account UI needs to be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External credentials can be retrieved and deleted using a single opaque credentials ID.
  * "Not found" errors now reference the query used to locate external credentials for clearer diagnostics.

* **Refactor**
  * Account and admin endpoints now use a single ext_credentials_id path parameter instead of provider/sub identifiers.
  * Backend lookup and deletion flows moved to ID-based operations; login/signup user-facing behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->