### PR TITLE
Redirect to login when external login initialization fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## v26.15
 
 ### Pre-releases
+- v26.15-alpha1
 - v26.15-alpha
 
 ### Features
+- Redirect to login when external login initialization fails (#565, v26.15-alpha1)
 - Always include link in response if SMTP is not configured (#561, v26.15-alpha)
 
 ---

--- a/seacatauth/external_login/authentication/providers/saml.py
+++ b/seacatauth/external_login/authentication/providers/saml.py
@@ -151,10 +151,16 @@ class SamlAuthProvider(ExternalAuthProviderABC):
 		if saml_client is None:
 			raise ExternalLoginError("SAML client is not properly initialized.")
 
-		saml_request_id, authn_request = saml_client.prepare_for_authenticate(
-			binding=saml2.BINDING_HTTP_REDIRECT,
-			relay_state=state["state_id"],
-		)
+		try:
+			saml_request_id, authn_request = saml_client.prepare_for_authenticate(
+				binding=saml2.BINDING_HTTP_REDIRECT,
+				relay_state=state["state_id"],
+			)
+		except Exception as e:
+			L.exception("Cannot prepare SAML authentication request.", struct_data={
+				"provider": self.Type,
+			})
+			raise ExternalLoginError("Failed to prepare SAML authentication request.") from e
 
 		headers = dict(authn_request.get("headers", []))
 		auth_uri = headers.get("Location")

--- a/seacatauth/external_login/authentication/service.py
+++ b/seacatauth/external_login/authentication/service.py
@@ -162,7 +162,6 @@ class ExternalAuthenticationService(asab.Service):
 		return response
 
 
-
 	async def initialize_pairing_with_ext_provider(
 		self,
 		provider_type: str,

--- a/seacatauth/external_login/authentication/service.py
+++ b/seacatauth/external_login/authentication/service.py
@@ -107,8 +107,21 @@ class ExternalAuthenticationService(asab.Service):
 		provider_type: str,
 		redirect_uri: typing.Optional[str]
 	) -> aiohttp.web.Response:
-		response = await self._prepare_external_auth_request(
-			provider_type, operation=AuthOperation.LogIn, redirect_uri=redirect_uri)
+		try:
+			response = await self._prepare_external_auth_request(
+				provider_type, operation=AuthOperation.LogIn, redirect_uri=redirect_uri)
+		except ExternalLoginError as e:
+			L.log(asab.LOG_NOTICE, "Failed to initialize login with external account.", struct_data={
+				"provider": provider_type,
+				"error": str(e),
+			})
+			return await self._error_redirect_response(
+				self.LoginUri,
+				result="login_failed",
+				delete_sso_cookie=True,
+				redirect_uri=redirect_uri or self.DefaultRedirectUri
+			)
+
 		L.log(asab.LOG_NOTICE, "Initialized login with external account.", struct_data={
 			"provider": provider_type})
 		return response
@@ -121,9 +134,28 @@ class ExternalAuthenticationService(asab.Service):
 	) -> aiohttp.web.Response:
 		if not self.can_sign_up_new_credentials(provider_type):
 			L.error("Signup with external account is not enabled.")
-			raise exceptions.RegistrationNotOpenError()
-		response = await self._prepare_external_auth_request(
-			provider_type, operation=AuthOperation.SignUp, redirect_uri=redirect_uri)
+			return await self._error_redirect_response(
+				self.LoginUri,
+				result="signup_disabled",
+				delete_sso_cookie=True,
+				redirect_uri=redirect_uri or self.DefaultRedirectUri
+			)
+
+		try:
+			response = await self._prepare_external_auth_request(
+				provider_type, operation=AuthOperation.SignUp, redirect_uri=redirect_uri)
+		except ExternalLoginError as e:
+			L.log(asab.LOG_NOTICE, "Failed to initialize sign-up with external account.", struct_data={
+				"provider": provider_type,
+				"error": str(e),
+			})
+			return await self._error_redirect_response(
+				self.LoginUri,
+				result="signup_failed",
+				delete_sso_cookie=True,
+				redirect_uri=redirect_uri or self.DefaultRedirectUri
+			)
+
 		L.log(asab.LOG_NOTICE, "Initialized sign-up with external account.", struct_data={
 			"provider": provider_type})
 		return response
@@ -135,8 +167,21 @@ class ExternalAuthenticationService(asab.Service):
 		provider_type: str,
 		redirect_uri: typing.Optional[str]
 	) -> aiohttp.web.Response:
-		response = await self._prepare_external_auth_request(
-			provider_type, operation=AuthOperation.PairAccount, redirect_uri=redirect_uri)
+		try:
+			response = await self._prepare_external_auth_request(
+				provider_type, operation=AuthOperation.PairAccount, redirect_uri=redirect_uri)
+		except ExternalLoginError as e:
+			L.log(asab.LOG_NOTICE, "Failed to initialize pairing external account.", struct_data={
+				"provider": provider_type,
+				"error": str(e),
+			})
+			return await self._error_redirect_response(
+				self.LoginUri,
+				result="pairing_failed",
+				delete_sso_cookie=True,
+				redirect_uri=redirect_uri or self.DefaultRedirectUri
+			)
+
 		L.log(asab.LOG_NOTICE, "Initialized pairing external account.", struct_data={
 			"provider": provider_type})
 		return response

--- a/seacatauth/external_login/authentication/service.py
+++ b/seacatauth/external_login/authentication/service.py
@@ -178,7 +178,6 @@ class ExternalAuthenticationService(asab.Service):
 			return await self._error_redirect_response(
 				self.LoginUri,
 				result=ExtLoginResult.PAIRING_FAILED,
-				delete_sso_cookie=True,
 				redirect_uri=redirect_uri or self.DefaultRedirectUri
 			)
 

--- a/seacatauth/external_login/authentication/service.py
+++ b/seacatauth/external_login/authentication/service.py
@@ -11,7 +11,7 @@ from ...last_activity import EventCode
 from ...models import Session
 from ...events import EventTypes
 from ...api import local_authz
-from .utils import AuthOperation
+from .utils import AuthOperation, ExtLoginResult, ExtLoginError
 from .providers.abc import ExternalAuthProviderABC
 from .providers import create_provider
 from ..exceptions import (
@@ -117,7 +117,7 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="login_failed",
+				result=ExtLoginResult.LOGIN_FAILED,
 				delete_sso_cookie=True,
 				redirect_uri=redirect_uri or self.DefaultRedirectUri
 			)
@@ -136,9 +136,10 @@ class ExternalAuthenticationService(asab.Service):
 			L.error("Signup with external account is not enabled.")
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="signup_disabled",
+				result=ExtLoginResult.SIGNUP_FAILED,
 				delete_sso_cookie=True,
-				redirect_uri=redirect_uri or self.DefaultRedirectUri
+				redirect_uri=redirect_uri or self.DefaultRedirectUri,
+				ext_login_error=ExtLoginError.REGISTRATION_DISABLED,
 			)
 
 		try:
@@ -151,7 +152,7 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="signup_failed",
+				result=ExtLoginResult.SIGNUP_FAILED,
 				delete_sso_cookie=True,
 				redirect_uri=redirect_uri or self.DefaultRedirectUri
 			)
@@ -177,7 +178,7 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="pairing_failed",
+				result=ExtLoginResult.PAIRING_FAILED,
 				delete_sso_cookie=True,
 				redirect_uri=redirect_uri or self.DefaultRedirectUri
 			)
@@ -271,10 +272,10 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="login_failed",
+				result=ExtLoginResult.LOGIN_FAILED,
 				delete_sso_cookie=True,
 				redirect_uri=self._get_final_redirect_uri(state),
-				ext_login_error="access_denied",
+				ext_login_error=ExtLoginError.ACCESS_DENIED,
 			)
 		except ExternalLoginError as e:
 			L.log(asab.LOG_NOTICE, "External authentication failed.", struct_data={
@@ -284,7 +285,7 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="login_failed",
+				result=ExtLoginResult.LOGIN_FAILED,
 				delete_sso_cookie=True,
 				redirect_uri=self._get_final_redirect_uri(state)
 			)
@@ -346,9 +347,9 @@ class ExternalAuthenticationService(asab.Service):
 			# Redirect to login page with error message, keep the original redirect uri in the query
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="login_failed",
+				result=ExtLoginResult.LOGIN_FAILED,
 				delete_sso_cookie=True,
-				ext_login_error="not_found",
+				ext_login_error=ExtLoginError.NOT_FOUND,
 				redirect_uri=self._get_final_redirect_uri(state)
 			)
 
@@ -361,7 +362,7 @@ class ExternalAuthenticationService(asab.Service):
 			)
 
 		return await self._success_redirect_response(
-			self._get_final_redirect_uri(state), "login_success", sso_session=new_sso_session)
+			self._get_final_redirect_uri(state), ExtLoginResult.LOGIN_SUCCESS, sso_session=new_sso_session)
 
 
 	async def _attempt_pair_credentials(self, provider_type: str, user_info: typing.Dict) -> typing.Optional[str]:
@@ -463,10 +464,10 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="signup_failed",
+				result=ExtLoginResult.SIGNUP_FAILED,
 				delete_sso_cookie=True,
 				redirect_uri=self._get_final_redirect_uri(state),
-				ext_login_error="access_denied",
+				ext_login_error=ExtLoginError.ACCESS_DENIED,
 			)
 		except ExternalLoginError as e:
 			L.log(asab.LOG_NOTICE, "External authentication failed.", struct_data={
@@ -476,7 +477,7 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="signup_failed",
+				result=ExtLoginResult.SIGNUP_FAILED,
 				delete_sso_cookie=True,
 				redirect_uri=self._get_final_redirect_uri(state)
 			)
@@ -485,7 +486,7 @@ class ExternalAuthenticationService(asab.Service):
 			L.error("Sign-up with external account not enabled.")
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="signup_failed",
+				result=ExtLoginResult.SIGNUP_FAILED,
 				delete_sso_cookie=True,
 				ext_login_error="registration_disabled",
 				redirect_uri=self._get_final_redirect_uri(state)
@@ -500,9 +501,9 @@ class ExternalAuthenticationService(asab.Service):
 				"provider": provider_type, "sub": user_info.get("sub")})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="signup_failed",
+				result=ExtLoginResult.SIGNUP_FAILED,
 				delete_sso_cookie=True,
-				ext_login_error="already_exists",
+				ext_login_error=ExtLoginError.ALREADY_EXISTS,
 				redirect_uri=self._get_final_redirect_uri(state)
 			)
 
@@ -518,7 +519,7 @@ class ExternalAuthenticationService(asab.Service):
 			L.error("Sign-up with external account failed: {}".format(e))
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="signup_failed",
+				result=ExtLoginResult.SIGNUP_FAILED,
 				delete_sso_cookie=True,
 				redirect_uri=self._get_final_redirect_uri(state)
 			)
@@ -531,7 +532,7 @@ class ExternalAuthenticationService(asab.Service):
 		)
 
 		return await self._success_redirect_response(
-			self._get_final_redirect_uri(state), "signup_success", sso_session=sso_session)
+			self._get_final_redirect_uri(state), ExtLoginResult.SIGNUP_SUCCESS, sso_session=sso_session)
 
 
 	async def _finalize_pairing_with_ext_provider(
@@ -564,9 +565,9 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="pairing_failed",
+				result=ExtLoginResult.PAIRING_FAILED,
 				redirect_uri=self._get_final_redirect_uri(state),
-				ext_login_error="access_denied",
+				ext_login_error=ExtLoginError.ACCESS_DENIED,
 			)
 		except ExternalLoginError as e:
 			L.log(asab.LOG_NOTICE, "External authentication failed.", struct_data={
@@ -576,7 +577,7 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self._get_final_redirect_uri(state),
-				result="pairing_failed",
+				result=ExtLoginResult.PAIRING_FAILED,
 			)
 
 		# Get current SSO session (if any) to determine if we are re-logging in or logging in anew
@@ -591,9 +592,9 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="pairing_failed",
+				result=ExtLoginResult.PAIRING_FAILED,
 				delete_sso_cookie=True,
-				ext_login_error="not_authenticated",
+				ext_login_error=ExtLoginError.NOT_AUTHENTICATED,
 				redirect_uri=self._get_final_redirect_uri(state)
 			)
 
@@ -605,9 +606,9 @@ class ExternalAuthenticationService(asab.Service):
 			})
 			return await self._error_redirect_response(
 				self.LoginUri,
-				result="pairing_failed",
+				result=ExtLoginResult.PAIRING_FAILED,
 				delete_sso_cookie=True,
-				ext_login_error="not_authenticated",
+				ext_login_error=ExtLoginError.NOT_AUTHENTICATED,
 				redirect_uri=self._get_final_redirect_uri(state)
 			)
 
@@ -629,12 +630,12 @@ class ExternalAuthenticationService(asab.Service):
 			)
 			return await self._error_redirect_response(
 				self._get_final_redirect_uri(state),
-				result="pairing_failed",
-				ext_login_error="already_exists"
+				result=ExtLoginResult.PAIRING_FAILED,
+				ext_login_error=ExtLoginError.ALREADY_EXISTS,
 			)
 
 		return await self._success_redirect_response(
-			self._get_final_redirect_uri(state), "pairing_success")
+			self._get_final_redirect_uri(state), ExtLoginResult.PAIRING_SUCCESS)
 
 
 	async def _login(

--- a/seacatauth/external_login/authentication/utils.py
+++ b/seacatauth/external_login/authentication/utils.py
@@ -16,3 +16,20 @@ class AuthOperation(enum.StrEnum):
 			return cls.SignUp
 		else:
 			raise KeyError(value)
+
+
+class ExtLoginResult(enum.StrEnum):
+	SIGNUP_SUCCESS = "signup_success"
+	PAIRING_SUCCESS = "pairing_success"
+	LOGIN_SUCCESS = "login_success"
+	LOGIN_FAILED = "login_failed"
+	SIGNUP_FAILED = "signup_failed"
+	PAIRING_FAILED = "pairing_failed"
+
+
+class ExtLoginError(enum.StrEnum):
+	REGISTRATION_DISABLED = "registration_disabled"
+	NOT_AUTHENTICATED = "not_authenticated"
+	ALREADY_EXISTS = "already_exists"
+	NOT_FOUND = "not_found"
+	ACCESS_DENIED = "access_denied"


### PR DESCRIPTION
# Issue
When external login initialization fails, the user gets stuck on an ugly bare error page.

# Fix
Catch the error and redirect the user back to the login page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External login, signup, and account-pairing flows now consistently redirect to the login page on initialization or finalization failures, clear SSO state, and avoid exposing error pages.
  * External auth failures are now logged and handled to prevent unhandled exceptions from surfacing to users.

* **New Features**
  * External auth flows now surface consistent outcome indicators so redirects reflect success or specific failure conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->