### PR TITLE
 Introduce resources seacat:role:assign:global and seacat:role:edit:global for global role management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - v26.15-alpha
 
 ### Features
--  Introduce resources seacat:role:assign:global and seacat:role:edit:global for global role management (#567, v26.15-alpha2)
+- Introduce resources seacat:role:assign:global and seacat:role:edit:global for global role management (#567, v26.15-alpha2)
 - Redirect to login when external login initialization fails (#565, v26.15-alpha1)
 - Always include link in response if SMTP is not configured (#561, v26.15-alpha)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## v26.15
 
 ### Pre-releases
+- v26.15-alpha2
 - v26.15-alpha1
 - v26.15-alpha
 
 ### Features
+-  Introduce resources seacat:role:assign:global and seacat:role:edit:global for global role management (#567, v26.15-alpha2)
 - Redirect to login when external login initialization fails (#565, v26.15-alpha1)
 - Always include link in response if SMTP is not configured (#561, v26.15-alpha)
 

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -86,11 +86,11 @@ SEACAT_AUTH_RESOURCES = {
 		"description": "Assign and unassign tenant roles.",
 	},
 	ResourceId.ROLE_EDIT_GLOBAL: {
-		"description": "Create, edit and delete global roles.",
+		"description": "Create, edit and delete global and tenant roles.",
 		"global_only": True,
 	},
 	ResourceId.ROLE_ASSIGN_GLOBAL: {
-		"description": "Assign and unassign global roles.",
+		"description": "Assign and unassign global and tenant roles.",
 		"global_only": True,
 	},
 	ResourceId.APIKEY_ACCESS: {

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -80,12 +80,22 @@ SEACAT_AUTH_RESOURCES = {
 		"description": "Search tenant roles, view role detail and list role bearers.",
 	},
 	ResourceId.ROLE_EDIT: {
-		"description":
-			"Create, edit and delete tenant roles. "
-			"This does not enable the bearer to assign Seacat system resources.",
+		"description": "Create, edit and delete tenant roles.",
 	},
 	ResourceId.ROLE_ASSIGN: {
 		"description": "Assign and unassign tenant roles.",
+	},
+	ResourceId.ROLE_ACCESS_GLOBAL: {
+		"description": "Search global roles, view role detail and list role bearers.",
+		"global_only": True,
+	},
+	ResourceId.ROLE_EDIT_GLOBAL: {
+		"description": "Create, edit and delete global roles.",
+		"global_only": True,
+	},
+	ResourceId.ROLE_ASSIGN_GLOBAL: {
+		"description": "Assign and unassign global roles.",
+		"global_only": True,
 	},
 	ResourceId.APIKEY_ACCESS: {
 		"description": "View API keys.",

--- a/seacatauth/authz/resource/service.py
+++ b/seacatauth/authz/resource/service.py
@@ -85,10 +85,6 @@ SEACAT_AUTH_RESOURCES = {
 	ResourceId.ROLE_ASSIGN: {
 		"description": "Assign and unassign tenant roles.",
 	},
-	ResourceId.ROLE_ACCESS_GLOBAL: {
-		"description": "Search global roles, view role detail and list role bearers.",
-		"global_only": True,
-	},
 	ResourceId.ROLE_EDIT_GLOBAL: {
 		"description": "Create, edit and delete global roles.",
 		"global_only": True,

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -178,7 +178,6 @@ class RoleHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schema.CREATE_ROLE)
-	@asab.web.auth.require(ResourceId.ROLE_EDIT)
 	async def create_role(self, request, *, json_data):
 		"""
 		Create a new role
@@ -193,6 +192,10 @@ class RoleHandler(object):
 			schema:
 				type: string
 		"""
+		authz = asab.contextvars.Authz.get()
+		if not authz.has_resource_access(ResourceId.ROLE_EDIT_GLOBAL):
+			authz.require_resource_access(ResourceId.ROLE_EDIT)
+
 		tenant_id = asab.contextvars.Tenant.get()
 		role_id = "{}/{}".format(tenant_id, request.match_info["role_name"])
 		return await self._create_role(request, role_id, json_data)
@@ -220,11 +223,14 @@ class RoleHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schema.UPDATE_ROLE)
-	@asab.web.auth.require(ResourceId.ROLE_EDIT)
 	async def update_role(self, request, *, json_data):
 		"""
 		Edit role description and resources
 		"""
+		authz = asab.contextvars.Authz.get()
+		if not authz.has_resource_access(ResourceId.ROLE_EDIT_GLOBAL):
+			authz.require_resource_access(ResourceId.ROLE_EDIT)
+
 		tenant_id = asab.contextvars.Tenant.get()
 		role_id = "{}/{}".format(tenant_id, request.match_info["role_name"])
 		try:
@@ -255,11 +261,14 @@ class RoleHandler(object):
 			)
 
 
-	@asab.web.auth.require(ResourceId.ROLE_EDIT)
 	async def delete_role(self, request):
 		"""
 		Delete role
 		"""
+		authz = asab.contextvars.Authz.get()
+		if not authz.has_resource_access(ResourceId.ROLE_EDIT_GLOBAL):
+			authz.require_resource_access(ResourceId.ROLE_EDIT)
+
 		tenant_id = asab.contextvars.Tenant.get()
 		role_id = "{}/{}".format(tenant_id, request.match_info["role_name"])
 		return await self._delete_role(request, role_id)

--- a/seacatauth/authz/role/handler/role.py
+++ b/seacatauth/authz/role/handler/role.py
@@ -199,7 +199,7 @@ class RoleHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schema.CREATE_ROLE)
-	@asab.web.auth.require_superuser
+	@asab.web.auth.require(ResourceId.ROLE_EDIT_GLOBAL)
 	@asab.web.tenant.allow_no_tenant
 	async def create_global_role(self, request, *, json_data):
 		"""
@@ -238,7 +238,7 @@ class RoleHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schema.UPDATE_ROLE)
-	@asab.web.auth.require_superuser
+	@asab.web.auth.require(ResourceId.ROLE_EDIT_GLOBAL)
 	@asab.web.tenant.allow_no_tenant
 	async def update_global_role(self, request, *, json_data):
 		"""
@@ -265,7 +265,7 @@ class RoleHandler(object):
 		return await self._delete_role(request, role_id)
 
 
-	@asab.web.auth.require_superuser
+	@asab.web.auth.require(ResourceId.ROLE_EDIT_GLOBAL)
 	@asab.web.tenant.allow_no_tenant
 	async def delete_global_role(self, request):
 		"""

--- a/seacatauth/authz/role/handler/roles.py
+++ b/seacatauth/authz/role/handler/roles.py
@@ -334,7 +334,6 @@ class RolesHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schema.SET_CREDENTIALS_ROLES)
-	@asab.web.auth.require(ResourceId.ROLE_ASSIGN)
 	async def set_credentials_roles(self, request, *, json_data):
 		"""
 		Set credentials' roles
@@ -345,6 +344,9 @@ class RolesHandler(object):
 		Caller with access to ROLE_ASSIGN resource can set only tenant-specific roles.
 		"""
 		authz = asab.contextvars.Authz.get()
+		if not authz.has_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL):
+			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
+
 		tenant_id = asab.contextvars.Tenant.get()
 		credentials_id = request.match_info["credentials_id"]
 		requested_roles = json_data["roles"]
@@ -378,6 +380,10 @@ class RolesHandler(object):
 		"""
 		Assign role to credentials
 		"""
+		authz = asab.contextvars.Authz.get()
+		if not authz.has_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL):
+			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
+
 		tenant_id = asab.contextvars.Tenant.get()
 		role_id = "{}/{}".format(tenant_id, request.match_info["role_name"])
 		await self.RoleService.assign_role(
@@ -401,11 +407,14 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@asab.web.auth.require(ResourceId.ROLE_ASSIGN)
 	async def unassign_credentials_role(self, request):
 		"""
 		Unassign role from credentials
 		"""
+		authz = asab.contextvars.Authz.get()
+		if not authz.has_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL):
+			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
+
 		tenant_id = asab.contextvars.Tenant.get()
 		role_id = "{}/{}".format(tenant_id, request.match_info["role_name"])
 		await self.RoleService.unassign_role(

--- a/seacatauth/authz/role/handler/roles.py
+++ b/seacatauth/authz/role/handler/roles.py
@@ -341,8 +341,8 @@ class RolesHandler(object):
 
 		For given credentials ID, assign listed roles and unassign existing roles that are not in the list.
 		The scope is always a specific tenant + global roles.
-		Caller with superuser access can set both tenant-specific and global roles.
-		Caller without superuser access can set only tenant-specific roles.
+		Caller with access to ROLE_ASSIGN_GLOBAL resource can set both tenant-specific and global roles.
+		Caller with access to ROLE_ASSIGN resource can set only tenant-specific roles.
 		"""
 		authz = asab.contextvars.Authz.get()
 		tenant_id = asab.contextvars.Tenant.get()
@@ -350,7 +350,7 @@ class RolesHandler(object):
 		requested_roles = json_data["roles"]
 
 		# Determine whether global roles will be un/assigned
-		if authz.has_superuser_access():
+		if authz.has_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL):
 			include_global = True
 		else:
 			include_global = False
@@ -361,7 +361,7 @@ class RolesHandler(object):
 
 
 	@asab.web.rest.json_schema_handler(schema.SET_CREDENTIALS_ROLES)
-	@asab.web.auth.require_superuser
+	@asab.web.auth.require(ResourceId.ROLE_ASSIGN_GLOBAL)
 	@asab.web.tenant.allow_no_tenant
 	async def set_credentials_global_roles(self, request, *, json_data):
 		"""
@@ -387,7 +387,7 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@asab.web.auth.require_superuser
+	@asab.web.auth.require(ResourceId.ROLE_ASSIGN_GLOBAL)
 	@asab.web.tenant.allow_no_tenant
 	async def assign_credentials_global_role(self, request):
 		"""
@@ -415,7 +415,7 @@ class RolesHandler(object):
 		return asab.web.rest.json_response(request, data={"result": "OK"})
 
 
-	@asab.web.auth.require_superuser
+	@asab.web.auth.require(ResourceId.ROLE_ASSIGN_GLOBAL)
 	@asab.web.tenant.allow_no_tenant
 	async def unassign_credentials_global_role(self, request):
 		"""

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -807,7 +807,9 @@ class RoleService(asab.Service):
 		role_id = role["_id"]
 		tenant_id, role_name = self.parse_role_id(role_id)
 		if tenant_id:
-			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
+			# Require global or tenant permission
+			if not authz.has_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL):
+				authz.require_resource_access(ResourceId.ROLE_ASSIGN)
 		else:
 			authz.require_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL)
 

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -347,8 +347,7 @@ class RoleService(asab.Service):
 		if tenant_id:
 			authz.require_tenant_access()
 		else:
-			# Only superusers can create global roles
-			authz.require_superuser_access()
+			authz.require_resource_access(ResourceId.ROLE_EDIT_GLOBAL)
 
 		# Check existence before creating to prevent shadowing shared roles with tenant roles
 		try:

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -435,6 +435,7 @@ class RoleService(asab.Service):
 		with local_authz(
 			"RoleService",
 			resources=[ResourceId.ROLE_ASSIGN_GLOBAL],
+			tenant=role_current.get("tenant"),
 		):
 			await self.delete_role_assignments(role_current)
 

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -783,7 +783,9 @@ class RoleService(asab.Service):
 		authz = asab.contextvars.Authz.get()
 		tenant_id, _ = self.parse_role_id(role_id)
 		if tenant_id:
-			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
+			# Require global or tenant permission
+			if not authz.has_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL):
+				authz.require_resource_access(ResourceId.ROLE_ASSIGN)
 		else:
 			authz.require_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL)
 

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -176,8 +176,8 @@ class RoleService(asab.Service):
 		target_tenants = set(await self.TenantService.get_tenants(target_cid))
 
 		authz = asab.contextvars.Authz.get()
-		if authz.has_superuser_access():
-			# Superusers can assign roles in any tenant plus global roles
+		if authz.has_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL):
+			# Can assign roles in any tenant plus global roles
 			return {None, *target_tenants}
 
 		tenant = asab.contextvars.Tenant.get()
@@ -713,7 +713,7 @@ class RoleService(asab.Service):
 		if tenant_id:
 			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
 		else:
-			authz.require_superuser_access()
+			authz.require_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL)
 
 		if verify_role:
 			try:
@@ -777,7 +777,7 @@ class RoleService(asab.Service):
 		if tenant_id:
 			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
 		else:
-			authz.require_superuser_access()
+			authz.require_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL)
 
 		assignment_id = "{} {}".format(credentials_id, role_id)
 		await self.StorageService.delete(self.CredentialsRolesCollection, assignment_id)
@@ -799,7 +799,7 @@ class RoleService(asab.Service):
 		if tenant_id:
 			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
 		else:
-			authz.require_superuser_access()
+			authz.require_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL)
 
 		collection = await self.StorageService.collection(self.CredentialsRolesCollection)
 		result = await collection.delete_many({"r": role_id})

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -345,7 +345,8 @@ class RoleService(asab.Service):
 		tenant_id, role_name = self.parse_role_id(role_id)
 		self.validate_role_name(role_name)
 		if tenant_id:
-			authz.require_tenant_access()
+			if not authz.has_resource_access(ResourceId.ROLE_EDIT_GLOBAL):
+				authz.require_resource_access(ResourceId.ROLE_EDIT)
 		else:
 			authz.require_resource_access(ResourceId.ROLE_EDIT_GLOBAL)
 
@@ -711,7 +712,9 @@ class RoleService(asab.Service):
 		authz = asab.contextvars.Authz.get()
 		tenant_id, _ = self.parse_role_id(role_id)
 		if tenant_id:
-			authz.require_resource_access(ResourceId.ROLE_ASSIGN)
+			# Require global or tenant permission
+			if not authz.has_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL):
+				authz.require_resource_access(ResourceId.ROLE_ASSIGN)
 		else:
 			authz.require_resource_access(ResourceId.ROLE_ASSIGN_GLOBAL)
 
@@ -750,6 +753,7 @@ class RoleService(asab.Service):
 		upsertor.set("c", credentials_id)
 		upsertor.set("r", role_id)
 		if tenant != "*":
+			upsertor.set("t", tenant)
 			upsertor.set("t", tenant)
 
 		try:

--- a/seacatauth/authz/role/service.py
+++ b/seacatauth/authz/role/service.py
@@ -432,7 +432,11 @@ class RoleService(asab.Service):
 		_assert_role_is_editable(role_current)
 
 		# Unassign the role from all credentials
-		await self.delete_role_assignments(role_current)
+		with local_authz(
+			"RoleService",
+			resources=[ResourceId.ROLE_ASSIGN_GLOBAL],
+		):
+			await self.delete_role_assignments(role_current)
 
 		# Delete the role
 		await self.StorageService.delete(self.RoleCollection, role_id)

--- a/seacatauth/models/const.py
+++ b/seacatauth/models/const.py
@@ -19,7 +19,6 @@ class ResourceId(enum.StrEnum):
 	ROLE_ACCESS = "seacat:role:access"
 	ROLE_EDIT = "seacat:role:edit"
 	ROLE_ASSIGN = "seacat:role:assign"
-	ROLE_ACCESS_GLOBAL = "seacat:role:access:global"
 	ROLE_EDIT_GLOBAL = "seacat:role:edit:global"
 	ROLE_ASSIGN_GLOBAL = "seacat:role:assign:global"
 

--- a/seacatauth/models/const.py
+++ b/seacatauth/models/const.py
@@ -19,6 +19,9 @@ class ResourceId(enum.StrEnum):
 	ROLE_ACCESS = "seacat:role:access"
 	ROLE_EDIT = "seacat:role:edit"
 	ROLE_ASSIGN = "seacat:role:assign"
+	ROLE_ACCESS_GLOBAL = "seacat:role:access:global"
+	ROLE_EDIT_GLOBAL = "seacat:role:edit:global"
+	ROLE_ASSIGN_GLOBAL = "seacat:role:assign:global"
 
 	RESOURCE_ACCESS = "seacat:resource:access"
 	RESOURCE_EDIT = "seacat:resource:edit"


### PR DESCRIPTION
# Issue

Global roles can be created, updated, deleted and assigned by superusers only. We need lower admins/operators to be able to manage global roles.

# Summary

Introducing new dedicated resources for global role operations:
- `seacat:role:edit:global` for creating, editing and deleting, and
- `seacat:role:assign:global` for assigning and unassigning.

These resources also grant permission to manage tenant roles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced superuser-only checks with granular resource-based permissions for global and tenant role operations (create, edit, assign, delete), enabling finer delegation.
  * Added two new global role permissions: seacat:role:edit:global and seacat:role:assign:global to control global role management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->