### PR TITLE
Unify regular password reset and new user password reset flow+response

### DIFF
--- a/seacatauth/credentials/change_password/handler.py
+++ b/seacatauth/credentials/change_password/handler.py
@@ -206,7 +206,6 @@ class ChangePasswordHandler(object):
 		If the reset link is created but cannot be delivered (neither emailed nor disclosed), the response will indicate failure.
 		The response includes multi-status details for both link creation and email delivery, as applicable.
 		"""
-		response_data = {}
 		authz = asab.contextvars.Authz.get()
 		credentials_id = json_data.get("credentials_id")
 		try:
@@ -228,84 +227,14 @@ class ChangePasswordHandler(object):
 				"error": "SeaCatAuthError|Credentials are suspended",
 			})
 
-		# Check if password reset link can be disclosed (in email or at least in the response)
-		password_reset_url = None
-		url_disclosed = False
-		email_service_enabled: bool | None = None  # None if status cannot be determined due to error
-		credentials_have_email: bool = credentials.get("email") not in (None, "")
-		try:
-			email_service_enabled = await self.ChangePasswordService.CommunicationService.is_channel_enabled("email")
-		except exceptions.ServerCommunicationError:
-			L.log(asab.LOG_NOTICE, "Cannot check email service availability: Communication error.", struct_data={
-				"cid": credentials_id})
+		response_data = await self.ChangePasswordService.admin_request_password_reset(
+			credentials,
+			requester_is_superuser=authz.has_superuser_access(),
+			expiration=json_data.get("expiration"),
+			new_user=False,
+		)
 
-		can_get_link_in_response: bool = authz.has_superuser_access() or email_service_enabled is False
-
-		# Superusers receive the password reset link in response
-		if can_get_link_in_response:
-			password_reset_url = await self.ChangePasswordService.init_password_reset(
-				credentials,
-				expiration=json_data.get("expiration"),
-			)
-			response_data["password_reset_url"] = password_reset_url
-			url_disclosed = True
-
-		# Check email communication availability and send email
-		if not email_service_enabled:
-			L.log(asab.LOG_NOTICE, "Cannot send password reset email: Email service not available.", struct_data={
-				"cid": credentials_id})
-			email_delivery_result = {
-				"result": "ERROR",
-				"tech_err": "Email service is not enabled.",
-				"error": "SeaCatAuthError|Email service is not enabled",
-			}
-		elif not credentials_have_email:
-			L.error("Cannot send password reset email: Credentials have no email address.", struct_data={
-				"cid": credentials_id})
-			email_delivery_result = {
-				"result": "ERROR",
-				"tech_err": "Credentials have no email address.",
-				"error": "SeaCatAuthError|Credentials have no email address",
-			}
-		else:
-			if not password_reset_url:
-				password_reset_url = await self.ChangePasswordService.init_password_reset(
-					credentials,
-					expiration=json_data.get("expiration"),
-				)
-			# Email the link to the user
-			try:
-				await self.ChangePasswordService.CommunicationService.password_reset(
-					credentials=credentials,
-					reset_url=password_reset_url,
-					new_user=False
-				)
-				url_disclosed = True
-				email_delivery_result = {"result": "OK"}
-			except exceptions.ServerCommunicationError:
-				L.error("Cannot send password reset email: Cannot connect to the email service.", struct_data={
-					"cid": credentials_id})
-				email_delivery_result = {
-					"result": "ERROR",
-					"tech_err": "Email service is temporarily unavailable.",
-					"error": "SeaCatAuthError|Email service is temporarily unavailable",
-				}
-			except exceptions.MessageDeliveryError as e:
-				L.error("Cannot send password reset email: {}".format(e), struct_data={
-					"cid": credentials_id})
-				email_delivery_result = {
-					"result": "ERROR",
-					"tech_err": "Email delivery error.",
-					"error": "SeaCatAuthError|Email delivery error",
-				}
-
-		response_data["email_sent"] = email_delivery_result
-		if url_disclosed:
-			response_data["result"] = "OK"
-			status = 200
-		else:
-			response_data.update(email_delivery_result)
-			status = 400
+		status = 200 if response_data.get("result") == "OK" else 400
 		return asab.web.rest.json_response(request, response_data, status=status)
 
 

--- a/seacatauth/credentials/change_password/service.py
+++ b/seacatauth/credentials/change_password/service.py
@@ -140,6 +140,139 @@ class ChangePasswordService(asab.Service):
 		return self.format_password_reset_url(password_reset_token)
 
 
+	async def admin_request_password_reset(
+		self,
+		credentials: dict,
+		*,
+		requester_is_superuser: bool,
+		expiration: float | None = None,
+		new_user: bool = False,
+	) -> dict:
+		"""
+		Create a password reset link and try to deliver it.
+
+		The operation is considered successful if either:
+		- the reset link is successfully sent via email, or
+		- the link is disclosed in the response (superuser or email service disabled).
+		"""
+		credentials_id = credentials.get("_id")
+		credentials_have_email: bool = credentials.get("email") not in (None, "")
+
+		# Determine whether email service is enabled (best-effort)
+		email_service_enabled: bool | None = None  # None if status cannot be determined due to error
+		try:
+			email_service_enabled = await self.CommunicationService.is_channel_enabled("email")
+		except exceptions.ServerCommunicationError:
+			L.log(asab.LOG_NOTICE, "Cannot check email service availability: Communication error.", struct_data={
+				"cid": credentials_id
+			})
+
+		can_disclose_link_in_response: bool = requester_is_superuser or (email_service_enabled is False)
+
+		# Determine whether we can send email (best-effort)
+		can_send_link: bool = False
+		if email_service_enabled is True and credentials_have_email:
+			try:
+				can_send_link = await self.CommunicationService.can_send_to_target(credentials, "email")
+			except exceptions.ServerCommunicationError:
+				L.log(asab.LOG_NOTICE, "Cannot check email target deliverability: Communication error.", struct_data={
+					"cid": credentials_id
+				})
+				can_send_link = False
+
+		# If we cannot disclose nor send, fail early without creating the link
+		if (not can_disclose_link_in_response) and (not can_send_link):
+			return {
+				"result": "ERROR",
+				"tech_err": "Password reset link cannot be delivered.",
+				"error": "SeaCatAuthError|Password reset link cannot be delivered",
+				"email_sent": {
+					"result": "ERROR",
+					"tech_err": "No communication channel available.",
+					"error": "SeaCatAuthError|No communication channel available",
+				},
+			}
+
+		# Create the password reset link (primary action)
+		try:
+			password_reset_url = await self.init_password_reset(credentials, expiration=expiration)
+		except exceptions.CredentialsSuspendedError:
+			return {
+				"result": "ERROR",
+				"tech_err": "Credentials are suspended.",
+				"error": "SeaCatAuthError|Credentials are suspended",
+				"email_sent": {"result": "SKIPPED"},
+			}
+		except Exception as e:
+			L.exception("Password reset link creation failed: {}".format(e))
+			return {
+				"result": "ERROR",
+				"tech_err": "Password reset link creation failed.",
+				"error": "SeaCatAuthError|Password reset link creation failed",
+				"email_sent": {"result": "SKIPPED"},
+			}
+
+		response: dict = {
+			"result": "OK",
+			"email_sent": {"result": "SKIPPED"},
+		}
+
+		if can_disclose_link_in_response:
+			response["password_reset_url"] = password_reset_url
+
+		# Attempt to send email if possible
+		if not can_send_link:
+			if email_service_enabled is False:
+				response["email_sent"] = {
+					"result": "ERROR",
+					"tech_err": "Email service is not enabled.",
+					"error": "SeaCatAuthError|Email service is not enabled",
+				}
+			elif not credentials_have_email:
+				response["email_sent"] = {
+					"result": "ERROR",
+					"tech_err": "Credentials have no email address.",
+					"error": "SeaCatAuthError|Credentials have no email address",
+				}
+			else:
+				response["email_sent"] = {
+					"result": "ERROR",
+					"tech_err": "Email delivery is not available.",
+					"error": "SeaCatAuthError|Email delivery is not available",
+				}
+		else:
+			try:
+				await self.CommunicationService.password_reset(
+					credentials=credentials,
+					reset_url=password_reset_url,
+					new_user=new_user,
+				)
+				response["email_sent"] = {"result": "OK"}
+			except exceptions.ServerCommunicationError:
+				response["email_sent"] = {
+					"result": "ERROR",
+					"tech_err": "Email service is temporarily unavailable.",
+					"error": "SeaCatAuthError|Email service is temporarily unavailable",
+				}
+			except exceptions.MessageDeliveryError as e:
+				L.error("Cannot send password reset email: {}".format(e), struct_data={
+					"cid": credentials_id
+				})
+				response["email_sent"] = {
+					"result": "ERROR",
+					"tech_err": "Email delivery error.",
+					"error": "SeaCatAuthError|Email delivery error",
+				}
+
+		# If link is neither disclosed nor emailed successfully, overall result is failure
+		email_ok = response["email_sent"].get("result") == "OK"
+		disclosed = "password_reset_url" in response
+		if (not disclosed) and (not email_ok):
+			response["result"] = "ERROR"
+
+		return response
+
+
 	def format_password_reset_url(self, password_reset_token):
 		reset_url = "{}{}?pwd_token={}".format(self.AuthWebUIBaseUrl, self.ResetPwdPath, password_reset_token)
 		return reset_url

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -355,15 +355,13 @@ class CredentialsHandler(object):
 		# Create credentials
 		result = await self.CredentialsService.create_credentials(provider_id, json_data)
 
-		if result["status"] != "OK":
-			result["result"] = result["status"]
+		if result["result"] != "OK":
 			return asab.web.rest.json_response(request, result, status=400)
 
 		credentials_id = result["credentials_id"]
 
 		response_data = {
 			"result": "OK",
-			"status": "OK",  # Backward compatibility
 			"_id": credentials_id,
 			"_type": provider.Type,
 			"_provider_id": provider.ProviderID,

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -347,6 +347,76 @@ class CredentialsHandler(object):
 	async def create_credentials(self, request, *, json_data):
 		"""
 		Create new credentials
+
+		---
+		tags: ["Users and credentials"]
+		responses:
+			200:
+				description:
+					Credentials created. With `passwordlink`, `password_reset` reports reset/email outcomes;
+					HTTP 200 means the record was created (even if the password reset might have failed).
+				schema:
+					type: object
+					required: [result, _id, _type, _provider_id]
+					properties:
+						result:
+							type: string
+							description: Overall outcome of credential creation (typically `OK`).
+						_id:
+							type: string
+							description: Identifier of the new credentials.
+						_type:
+							type: string
+							description: Provider type (e.g. human vs machine credentials).
+						_provider_id:
+							type: string
+							description: Credential provider id.
+						password_reset:
+							type: object
+							description: Present only when `passwordlink` was requested.
+							properties:
+								result:
+									type: string
+									description: Outcome of reset-link creation / disclosure policy.
+								password_reset_url:
+									type: string
+									description: Reset URL returned to the caller when policy allows (e.g. superuser).
+								tech_err:
+									type: string
+									description: Error message for the API
+								error:
+									type: string
+									description: Localizable error message for the UI
+								email_sent:
+									type: object
+									description: Email delivery attempt result and optional error details.
+									properties:
+										result:
+											type: string
+										tech_err:
+											type: string
+											description: Error message for the API
+										error:
+											type: string
+											description: Localizable error message for the UI
+									additionalProperties: true
+							additionalProperties: true
+					additionalProperties: true
+			400:
+				description: Credential creation failed (validation, provider, duplicate key, etc.).
+				schema:
+					type: object
+					description: Error payload; fields vary by failure mode.
+					properties:
+						result:
+							type: string
+						tech_err:
+							type: string
+							description: Error message for the API
+						error:
+							type: string
+							description: Localizable error message for the UI
+					additionalProperties: true
 		"""
 		reset_password = json_data.pop("passwordlink", False)
 		provider_id = request.match_info["provider"]

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -371,55 +371,18 @@ class CredentialsHandler(object):
 
 		if reset_password:
 			change_pwd_svc = self.App.get_service("seacatauth.ChangePasswordService")
-			comm_svc = self.App.get_service("seacatauth.CommunicationService")
 			credentials = await self.CredentialsService.get(credentials_id)
-
-			# Check if password reset link can be sent (in email or at least in the response)
 			authz = asab.contextvars.Authz.get()
-			if not (
-				authz.has_superuser_access()
-				or await comm_svc.can_send_to_target(credentials, "email")
-			):
-				L.error("Password reset denied: No way to communicate password reset link.", struct_data={
-					"cid": credentials_id})
-				password_reset_response = {
-					"result": "ERROR",
-					"tech_err": "Password reset link cannot be sent.",
-				}
-				response_data["password_reset"] = password_reset_response
-				return asab.web.rest.json_response(request, response_data)
 
-			password_reset_response = {}
-
-			# Create the password reset link
-			password_reset_url = await change_pwd_svc.init_password_reset(
+			password_reset_response = await change_pwd_svc.admin_request_password_reset(
 				credentials,
+				requester_is_superuser=authz.has_superuser_access(),
 				expiration=json_data.get("expiration"),
+				new_user=True,
 			)
 
-			# Superusers receive the password reset link in response
-			if authz.has_superuser_access():
-				password_reset_response["password_reset_url"] = password_reset_url
-
-			# Email the link to the user
-			try:
-				await comm_svc.password_reset(
-					credentials=credentials,
-					reset_url=password_reset_url,
-					new_user=True
-				)
-			except exceptions.ServerCommunicationError:
-				password_reset_response["result"] = "ERROR"
-				password_reset_response["tech_err"] = "Cannot connect to email service"
-				response_data["password_reset"] = password_reset_response
-				return asab.web.rest.json_response(request, response_data)
-			except exceptions.MessageDeliveryError:
-				password_reset_response["result"] = "ERROR"
-				password_reset_response["tech_err"] = "Failed to send password reset link."
-				response_data["password_reset"] = password_reset_response
-				return asab.web.rest.json_response(request, response_data)
-
-			password_reset_response["result"] = "OK"
+			# Ensure response structure:
+			# {"password_reset": {"result": ..., "password_reset_url": ..., "email_sent": {"result": ...}}}
 			response_data["password_reset"] = password_reset_response
 
 		return asab.web.rest.json_response(request, response_data)

--- a/seacatauth/credentials/handler.py
+++ b/seacatauth/credentials/handler.py
@@ -382,7 +382,16 @@ class CredentialsHandler(object):
 			)
 
 			# Ensure response structure:
-			# {"password_reset": {"result": ..., "password_reset_url": ..., "email_sent": {"result": ...}}}
+			# {
+			# 	"result": ...,
+			# 	"password_reset": {
+			# 		"result": ...,
+			# 		"password_reset_url": ...,
+			# 		"email_sent": {
+			# 			"result": ...
+			# 		}
+			# 	}
+			# }
 			response_data["password_reset"] = password_reset_response
 
 		return asab.web.rest.json_response(request, response_data)

--- a/seacatauth/credentials/service.py
+++ b/seacatauth/credentials/service.py
@@ -388,7 +388,7 @@ class CredentialsService(asab.Service):
 				}
 			)
 			return {
-				"status": "FAILED",
+				"result": "FAILED",
 				"message": "Provider does not support credentials creation",
 			}
 
@@ -403,8 +403,8 @@ class CredentialsService(asab.Service):
 				"by": agent_cid,
 			})
 			return {
-				"status": "FAILED",
-				"message": "Credentials data does not comply with creation policy",
+				"result": "FAILED",
+				"tech_err": "Credentials data does not comply with creation policy",
 			}
 
 		# Create in provider
@@ -413,15 +413,9 @@ class CredentialsService(asab.Service):
 		except asab.storage.exceptions.DuplicateError as e:
 			L.error("Cannot create credentials: {}".format(e))
 			return {
-				"status": "FAILED",
-				"message": "Cannot create credentials: Duplicate key",
-				"conflict": e.KeyValue
-			}
-		except Exception as e:
-			L.error("Cannot create credentials: {}".format(e))
-			return {
-				"status": "FAILED",
-				"message": "Cannot create credentials",
+				"result": "FAILED",
+				"tech_err": "Credentials already exist",
+				"error": "Credentials already exist",
 			}
 
 		AuditLogger.log(asab.LOG_NOTICE, "Credentials created", struct_data={
@@ -431,7 +425,7 @@ class CredentialsService(asab.Service):
 		self.App.PubSub.publish("Credentials.created!", credentials_id=credentials_id)
 
 		return {
-			"status": "OK",
+			"result": "OK",
 			"credentials_id": credentials_id,
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized password-reset handling into a single service; handlers now delegate reset/email/link logic for cleaner flow.
* **Chores**
  * Credential creation responses standardized to a "result" structure ("OK"/"FAILED") with clearer error fields.
* **Bug Fixes**
  * Password-reset responses now include explicit email delivery and link disclosure details and return appropriate HTTP status based on outcome.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeskaLabs/seacat-auth/pull/574)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->