### PR TITLE
Treat HTTP authentication scheme as case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v26.15
 
 ### Pre-releases
+- v26.15-alpha5
 - v26.15-alpha4
 - v26.15-alpha3
 - v26.15-alpha2
@@ -10,6 +11,7 @@
 - v26.15-alpha
 
 ### Fixes
+- Treat HTTP authentication scheme as case-insensitive (#575, v26.15-alpha5)
 - Update webauthn package (#572, v26.15-alpha3)
 
 ### Features

--- a/seacatauth/api/auth.py
+++ b/seacatauth/api/auth.py
@@ -60,7 +60,7 @@ class AsabAuthProvider(asab.web.auth.providers.IdTokenAuthProvider):
 			Valid asab.web.auth.Authorization object
 		"""
 		token_type, token_value = token
-		if token_type.casefold() != "bearer":
+		if token_type != "bearer":
 			L.warning("Unsupported Authorization header type: {!r}".format(token_type))
 			raise asab.exceptions.NotAuthenticatedError()
 

--- a/seacatauth/api/auth.py
+++ b/seacatauth/api/auth.py
@@ -44,33 +44,38 @@ class AsabAuthProvider(asab.web.auth.providers.IdTokenAuthProvider):
 
 
 	async def authorize(self, request: aiohttp.web.Request) -> Authorization:
-		bearer_token = asab.web.auth.utils.get_bearer_token_from_authorization_header(request)
-		authz = await self._build_authorization(bearer_token)
+		token = asab.web.auth.utils.get_bearer_token_from_authorization_header(request)
+		authz = await self._build_authorization(token)
 		return authz
 
 
-	async def _build_authorization(self, id_token: str) -> Authorization:
+	async def _build_authorization(self, token: typing.Tuple[str, str]) -> Authorization:
 		"""
 		Build authorization from ID token.
 
 		Args:
-			id_token: Base64-encoded JWToken from Authorization header
+			token: Tuple of token type (must be "Bearer") and token value (Base64-encoded ID token)
 
 		Returns:
 			Valid asab.web.auth.Authorization object
 		"""
+		token_type, token_value = token
+		if token_type.casefold() != "bearer":
+			L.warning("Unsupported Authorization header type: {!r}".format(token_type))
+			raise asab.exceptions.NotAuthenticatedError()
+
 		# Try if the object already exists
-		authz = self.Authorizations.get(id_token)
+		authz = self.Authorizations.get(token)
 		if authz is not None:
 			try:
 				authz.require_valid()
 			except asab.exceptions.NotAuthenticatedError as e:
-				del self.Authorizations[id_token]
+				del self.Authorizations[token]
 				raise e
 			return authz
 
 		# Create a new Authorization object and store it
-		claims = await self._get_claims_from_id_token(id_token)
+		claims = await self._get_claims_from_id_token(token_value)
 
 		# Pair authorization with Seacat Auth session
 		try:
@@ -87,7 +92,7 @@ class AsabAuthProvider(asab.web.auth.providers.IdTokenAuthProvider):
 
 		authz = Authorization(claims, session)
 
-		self.Authorizations[id_token] = authz
+		self.Authorizations[token] = authz
 		return authz
 
 

--- a/seacatauth/generic.py
+++ b/seacatauth/generic.py
@@ -25,7 +25,7 @@ def get_bearer_token_value(request):
 		return None
 
 	token_type, token_value = token
-	if token_type != "Bearer":
+	if token_type.casefold() != "bearer":
 		L.debug("No Bearer token in Authorization header")
 		return
 

--- a/seacatauth/openidconnect/handler/introspect.py
+++ b/seacatauth/openidconnect/handler/introspect.py
@@ -99,7 +99,7 @@ class TokenIntrospectionHandler(object):
 			return None
 
 		token_type, token_value = token
-		if token_type == "Bearer":
+		if token_type.casefold() == "bearer":
 			try:
 				session = await self.OpenIdConnectService.get_session_by_access_token(token_value)
 			except exceptions.SessionNotFoundError as e:
@@ -107,7 +107,7 @@ class TokenIntrospectionHandler(object):
 					"token_fingerprint": fingerprint(token_value)})
 				return None
 
-		elif token_type == self.ApiKeyService.TOKEN_TYPE:
+		elif token_type.casefold() == self.ApiKeyService.TOKEN_TYPE.casefold():
 			try:
 				session = await self.ApiKeyService.get_session_by_api_key(token_value)
 			except exceptions.SessionNotFoundError as e:

--- a/seacatauth/openidconnect/handler/token.py
+++ b/seacatauth/openidconnect/handler/token.py
@@ -525,7 +525,7 @@ class TokenHandler(object):
 		auth_header: str = request.headers.get("Authorization", "")
 		if len(body) > 0:
 			token_string = body.decode("ascii")
-		elif auth_header.startswith("Bearer "):
+		elif auth_header.casefold().startswith("bearer "):
 			token_string = request.headers["Authorization"][len("Bearer "):]
 		else:
 			raise asab.exceptions.ValidationError("No ID token found in request body or Authorization header.")


### PR DESCRIPTION
As per [RFC 7235 Section 2](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1) the authentication scheme part in HTTP Authorization header must be treated as case-insensitive.

This change requires https://github.com/TeskaLabs/asab/pull/759 to be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bearer token authentication now accepts authorization headers with "Bearer" scheme in any case variation across all endpoints, improving compatibility with diverse client implementations.
  * Enhanced authorization token validation and caching mechanisms with automatic cleanup of failed authorization attempts for improved system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeskaLabs/seacat-auth/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->