### PR TITLE
Remove password reset script from the Docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v26.15
 
 ### Pre-releases
+- v26.15-alpha7
 - v26.15-alpha6
 - v26.15-alpha5
 - v26.15-alpha4
@@ -12,6 +13,7 @@
 - v26.15-alpha
 
 ### Fixes
+- Remove password reset script from the Docker container (#578, v26.15-alpha7)
 - Treat HTTP authentication scheme as case-insensitive (#575, v26.15-alpha5)
 - Update webauthn package (#572, v26.15-alpha3)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN apk add --no-cache  \
 RUN cat /venv/lib/python3.12/site-packages/asab/__version__.py
 
 RUN mkdir -p /app/seacat-auth
+RUN mkdir -p /app/seacat-auth/scripts
 WORKDIR /app/seacat-auth
 
 # Create MANIFEST.json in the working directory
@@ -74,7 +75,7 @@ RUN apk add --no-cache \
 COPY --from=builder /venv /venv
 
 COPY ./seacatauth            /app/seacat-auth/seacatauth
-COPY ./scripts               /app/seacat-auth/scripts
+COPY ./seacatauth/scripts/ldap-access-sync.py  /app/seacat-auth/seacatauth/scripts/ldap-access-sync.py
 COPY ./seacatauth.py         /app/seacat-auth/seacatauth.py
 COPY ./CHANGELOG.md          /app/seacat-auth/CHANGELOG.md
 COPY --from=builder /app/seacat-auth/MANIFEST.json /app/seacat-auth/MANIFEST.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN apk add --no-cache \
 COPY --from=builder /venv /venv
 
 COPY ./seacatauth            /app/seacat-auth/seacatauth
-COPY ./seacatauth/scripts/ldap-access-sync.py  /app/seacat-auth/seacatauth/scripts/ldap-access-sync.py
+COPY ./seacatauth/scripts/ldap-access-sync.py  /app/seacat-auth/scripts/ldap-access-sync.py
 COPY ./seacatauth.py         /app/seacat-auth/seacatauth.py
 COPY ./CHANGELOG.md          /app/seacat-auth/CHANGELOG.md
 COPY --from=builder /app/seacat-auth/MANIFEST.json /app/seacat-auth/MANIFEST.json

--- a/docs/en/docs/admin/reset-password.md
+++ b/docs/en/docs/admin/reset-password.md
@@ -16,19 +16,35 @@ The `reset-password.py` script allows administrators to reset a user's password 
 
 ## Running in Docker
 
-The recommended way to run this script is from within the SeaCat Auth Docker container.
+The script is not included in the SeaCat Auth Docker image. To run it, you need to download the script and copy it into a running container.
 
 ### Prerequisites
 
 - A running SeaCat Auth container (in the examples below, the container is named `seacat-auth`)
 - Access to the same MongoDB database that SeaCat Auth is configured to use
 
-### Basic usage
+### Step 1: Download the script
 
-Run the script using `docker exec`:
+Download the script from the GitHub repository:
 
 ```bash
-docker exec -it seacat-auth reset-password.py
+curl -O https://raw.githubusercontent.com/TeskaLabs/seacat-auth/main/scripts/reset-password.py
+```
+
+### Step 2: Copy the script into the container
+
+Copy the downloaded script into the running SeaCat Auth container:
+
+```bash
+docker cp reset-password.py seacat-auth:/tmp/reset-password.py
+```
+
+### Step 3: Execute the script
+
+Run the script inside the container using `docker exec`:
+
+```bash
+docker exec -it seacat-auth python3 /tmp/reset-password.py
 ```
 
 The script will:
@@ -39,10 +55,20 @@ The script will:
 4. Ask for the new password (entered twice for verification)
 5. Update the password hash in the database
 
+### Step 4: Clean up (optional)
+
+Remove the script from the container when done:
+
+```bash
+docker exec seacat-auth rm /tmp/reset-password.py
+```
+
 ### Example session
 
 ```
-$ docker exec -it seacat-auth reset-password.py
+$ curl -O https://raw.githubusercontent.com/TeskaLabs/seacat-auth/main/scripts/reset-password.py
+$ docker cp reset-password.py seacat-auth:/tmp/reset-password.py
+$ docker exec -it seacat-auth python3 /tmp/reset-password.py
 Enter username to reset password for: jsmith
 
 User found:

--- a/scripts/reset-password.py
+++ b/scripts/reset-password.py
@@ -10,11 +10,6 @@ Run from the repository root (or pass absolute path)::
 
 The config path is optional and defaults to ``/conf/seacatauth.conf``,
 the same default config path used by the main SeaCat Auth application.
-
-Run inside a Docker container::
-
-    docker exec -it seacat-auth reset-password.py
-
 """
 
 import argparse


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker image optimized: the password-reset utility is no longer bundled; changelog updated with a new pre-release entry noting this change.

* **Documentation**
  * Admin docs revised: password-reset workflow now describes manual download, copying into a running container, execution, and optional cleanup instead of in-container bundling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->