### PR TITLE
Remove version dirtiness

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-doc
-example
-.github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v26.15
 
 ### Pre-releases
+- v26.15-alpha12
 - v26.15-alpha11
 - ~~v26.15-alpha10~~
 - ~~v26.15-alpha9~~
@@ -17,6 +18,7 @@
 - v26.15-alpha
 
 ### Fixes
+- Remove version dirtiness (#583, v26.15-alpha12)
 - Fix failing docker image build (#582, v26.15-alpha11)
 - Move index management privilege from Kibana to ElasticSearch (#581, v26.15-alpha10)
 - Remove password reset script from the Docker container (#578, v26.15-alpha7)

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,10 @@ RUN apk add --no-cache  \
 RUN cat /venv/lib/python3.12/site-packages/asab/__version__.py
 
 RUN mkdir -p /app/seacat-auth
-RUN mkdir -p /app/seacat-auth/scripts
-WORKDIR /app/seacat-auth
+COPY . /app/seacat-auth
 
-# Create MANIFEST.json in the working directory
-# The manifest script requires git to be installed
-COPY ./.git /app/seacat-auth/.git
-RUN /venv/bin/asab-manifest.py ./MANIFEST.json
+# The manifest script needs the entire repo in a clean state (to avoid the -dirty tag)
+RUN (cd /app/seacat-auth && /venv/bin/asab-manifest.py ./MANIFEST.json)
 
 
 # ---- Runtime stage ----


### PR DESCRIPTION
# Issue
The service manifest reports version with the `-dirty` suffix even when built from a clean-tagged revision.

# Solution
Remove `.dockerignore` and update the Dockerfile to ensure the entire repo is copied in the `builder` stage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build process to copy the full project context before generating build metadata, improving image consistency.
  * Adjusted the Docker ignore rules so selected repository folders are included in the build context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->