### PR TITLE
Accept ASAB internal auth tokens at userinfo endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update webauthn package (#572, v26.15-alpha3)
 
 ### Features
+- Accept ASAB internal auth tokens at userinfo endpoint (#591, v26.15-alpha15)
 - Improve OpenAPI docs (#586, v26.15-alpha14)
 - Kibana index management resource (#580, v26.15-alpha9)
 - Resources for Kibana default space access (#579, v26.15-alpha8)
@@ -22,6 +23,7 @@
 - Always include link in response if SMTP is not configured (#561, v26.15-alpha)
 
 ### Pre-releases
+- v26.15-alpha15
 - v26.15-alpha14
 - v26.15-alpha13
 - v26.15-alpha12

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -53,9 +53,8 @@ class UserInfoHandler(object):
 				session = await self.OpenIdConnectService.get_session_by_id_token(token_value)
 				if session is None:
 					# Token is not a seacat-auth session ID token.
-					# Try to validate it as an internal ASAB auth token (e.g. from bs-query)
-					# via the AuthService's ID token provider, which has the cluster's
-					# internal auth public key registered via InternalAuth.
+					# Try to validate it as an internal ASAB auth token via the AuthService's ID token provider,
+					# which has the cluster's internal auth public key registered via InternalAuth.
 					userinfo = await self._build_userinfo_from_internal_token(request)
 					if userinfo is None:
 						L.log(asab.LOG_NOTICE, "Authentication required.")
@@ -102,10 +101,9 @@ class UserInfoHandler(object):
 		Validate the request's Bearer token using the ASAB AuthService's ID token provider
 		and build a userinfo response from the validated claims.
 
-		This handles internal cluster auth tokens (e.g. from bs-query) that are signed
-		with the cluster's internal private key.
-		These tokens are not associated with any seacat-auth session, so we build
-		the userinfo directly from the JWT claims.
+		This handles internal cluster auth tokens that are signed with the cluster's internal private key.
+		These tokens are not associated with any seacat-auth session, so we build the userinfo
+		directly from the JWT claims.
 		"""
 		auth_service = self.App.get_service("asab.AuthService")
 		if auth_service is None:
@@ -138,7 +136,7 @@ class UserInfoHandler(object):
 		else:
 			iat = datetime.datetime.now(datetime.timezone.utc)
 
-		# The internal token represents a service (e.g. bs-query), not a user session.
+		# The internal token represents a service (e.g. "asab-iris"), not a user session.
 		# We use the authorized party (azp) as the subject identifier.
 		service_id = claims.get("azp", "internal:unknown")
 
@@ -156,10 +154,10 @@ class UserInfoHandler(object):
 			"sub": claims.get("sub") or service_id,
 			"iat": iat,
 			"exp": exp,
-			"sid": "internal:{}".format(service_id),
+			"sid": service_id,
 			# Include username fields needed by the web application
-			"username": "internal:{}".format(service_id),
-			"preferred_username": "internal:{}".format(service_id),
+			"username": service_id,
+			"preferred_username": service_id,
 		}
 
 		if claims.get("azp") is not None:

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -1,5 +1,4 @@
 import logging
-import datetime
 
 import asab
 import asab.web.rest

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -142,16 +142,25 @@ class UserInfoHandler(object):
 		# We use the authorized party (azp) as the subject identifier.
 		service_id = claims.get("azp", "internal:unknown")
 
+		# Expiration
+		exp_ts = claims.get("exp")
+		if exp_ts is not None:
+			exp = datetime.datetime.fromtimestamp(int(exp_ts), datetime.timezone.utc)
+		else:
+			# Default expiry: 30 minutes from now (matching the internal auth token lifetime)
+			exp = iat + datetime.timedelta(minutes=30)
+
 		# Build a minimal userinfo response from the internal auth token claims.
 		userinfo = {
 			"iss": self.OpenIdConnectService.Issuer,
 			"sub": claims.get("sub") or service_id,
 			"iat": iat,
+			"exp": exp,
 			"sid": "internal:{}".format(service_id),
+			# Include username fields needed by the web application
+			"username": "internal:{}".format(service_id),
+			"preferred_username": "internal:{}".format(service_id),
 		}
-
-		if claims.get("exp") is not None:
-			userinfo["exp"] = claims["exp"]
 
 		if claims.get("azp") is not None:
 			userinfo["azp"] = claims["azp"]

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -129,31 +129,16 @@ class UserInfoHandler(object):
 			"azp": claims.get("azp"),
 		})
 
-		# Determine issued-at timestamp
-		iat_ts = claims.get("iat")
-		if iat_ts is not None:
-			iat = datetime.datetime.fromtimestamp(int(iat_ts), datetime.timezone.utc)
-		else:
-			iat = datetime.datetime.now(datetime.timezone.utc)
-
 		# The internal token represents a service (e.g. "asab-iris"), not a user session.
 		# We use the authorized party (azp) as the subject identifier.
 		service_id = claims.get("azp", "internal:unknown")
-
-		# Expiration
-		exp_ts = claims.get("exp")
-		if exp_ts is not None:
-			exp = datetime.datetime.fromtimestamp(int(exp_ts), datetime.timezone.utc)
-		else:
-			# Default expiry: 30 minutes from now (matching the internal auth token lifetime)
-			exp = iat + datetime.timedelta(minutes=30)
 
 		# Build a minimal userinfo response from the internal auth token claims.
 		userinfo = {
 			"iss": self.OpenIdConnectService.Issuer,
 			"sub": claims.get("sub") or service_id,
-			"iat": iat,
-			"exp": exp,
+			"iat": claims.get("iat"),
+			"exp": claims.get("exp"),
 			"sid": service_id,
 			# Include username fields needed by the web application
 			"username": service_id,

--- a/seacatauth/openidconnect/handler/userinfo.py
+++ b/seacatauth/openidconnect/handler/userinfo.py
@@ -1,4 +1,6 @@
 import logging
+import datetime
+
 import asab
 import asab.web.rest
 import asab.web.auth
@@ -21,6 +23,7 @@ class UserInfoHandler(object):
 	"""
 
 	def __init__(self, app, oidc_svc):
+		self.App = app
 		self.OpenIdConnectService = oidc_svc
 		self.CookieService = app.get_service("seacatauth.CookieService")
 
@@ -49,13 +52,20 @@ class UserInfoHandler(object):
 				# Non-canonical
 				session = await self.OpenIdConnectService.get_session_by_id_token(token_value)
 				if session is None:
-					L.log(asab.LOG_NOTICE, "Authentication required.")
-					return asab.exceptions.NotAuthenticatedError(
-						error="invalid_token",
-						error_description="Invalid ID token.",
-						realm="asab",
-						scope=["openid"],
-					)
+					# Token is not a seacat-auth session ID token.
+					# Try to validate it as an internal ASAB auth token (e.g. from bs-query)
+					# via the AuthService's ID token provider, which has the cluster's
+					# internal auth public key registered via InternalAuth.
+					userinfo = await self._build_userinfo_from_internal_token(request)
+					if userinfo is None:
+						L.log(asab.LOG_NOTICE, "Authentication required.")
+						return asab.exceptions.NotAuthenticatedError(
+							error="invalid_token",
+							error_description="Invalid ID token.",
+							realm="asab",
+							scope=["openid"],
+						)
+					return asab.web.rest.json_response(request, userinfo)
 			except ValueError:
 				try:
 					# Canonical
@@ -85,3 +95,73 @@ class UserInfoHandler(object):
 		userinfo = await self.OpenIdConnectService.build_userinfo(session)
 
 		return asab.web.rest.json_response(request, userinfo)
+
+
+	async def _build_userinfo_from_internal_token(self, request):
+		"""
+		Validate the request's Bearer token using the ASAB AuthService's ID token provider
+		and build a userinfo response from the validated claims.
+
+		This handles internal cluster auth tokens (e.g. from bs-query) that are signed
+		with the cluster's internal private key.
+		These tokens are not associated with any seacat-auth session, so we build
+		the userinfo directly from the JWT claims.
+		"""
+		auth_service = self.App.get_service("asab.AuthService")
+		if auth_service is None:
+			L.warning("AuthService not available; cannot validate internal auth token.")
+			return None
+
+		try:
+			authz = await auth_service.authorize_request(request)
+		except asab.exceptions.NotAuthenticatedError:
+			return None
+		except Exception as e:
+			L.warning("Unexpected error during internal auth token validation.", struct_data={
+				"error": str(e),
+			})
+			return None
+
+		if authz is None:
+			return None
+
+		claims = authz._Claims
+		L.log(asab.LOG_NOTICE, "Request authenticated via internal auth token.", struct_data={
+			"iss": claims.get("iss"),
+			"azp": claims.get("azp"),
+		})
+
+		# Determine issued-at timestamp
+		iat_ts = claims.get("iat")
+		if iat_ts is not None:
+			iat = datetime.datetime.fromtimestamp(int(iat_ts), datetime.timezone.utc)
+		else:
+			iat = datetime.datetime.now(datetime.timezone.utc)
+
+		# The internal token represents a service (e.g. bs-query), not a user session.
+		# We use the authorized party (azp) as the subject identifier.
+		service_id = claims.get("azp", "internal:unknown")
+
+		# Build a minimal userinfo response from the internal auth token claims.
+		userinfo = {
+			"iss": self.OpenIdConnectService.Issuer,
+			"sub": claims.get("sub") or service_id,
+			"iat": iat,
+			"sid": "internal:{}".format(service_id),
+		}
+
+		if claims.get("exp") is not None:
+			userinfo["exp"] = claims["exp"]
+
+		if claims.get("azp") is not None:
+			userinfo["azp"] = claims["azp"]
+
+		if claims.get("aud") is not None:
+			userinfo["aud"] = claims["aud"]
+
+		# Include resource authorization info so the web app knows
+		# this token carries superuser privileges
+		if claims.get("resources") is not None:
+			userinfo["resources"] = claims["resources"]
+
+		return userinfo


### PR DESCRIPTION
# Issue

LogMan.io context:

When bs-query (or other services) call pyppeteer with auth='internal', the internal auth JWT gets injected into the browser session and is sent to the userinfo endpoint as a Bearer token. The old code only looked up seacat-auth session ID tokens and access tokens, rejecting the internal auth token with 401 because it's signed with the cluster's shared internal private key, not seacat-auth's own OIDC key.

# Changes

This adds a fallback: when get_session_by_id_token() returns None (the token is not a seacat-auth session ID token), validate the token via AuthService.authorize_request(). The IdTokenAuthProvider has the cluster's internal auth public key registered (via InternalAuth), so it can verify the signature. If valid, build a minimal userinfo response from the JWT claims (sub=azp, resources=superuser, etc.).

This is needed for export PDF generation where bs-query uses internal auth tokens to render pages via pyppeteer.