### PR TITLE
Use vendored kazoo for pesistent watcher support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Ensure LDAP script always includes memberOf attr (#588, v26.15-alpha13)
+- Ensure LDAP script always includes memberOf attr (#588, v26.15-alpha13)
 - Remove version dirtiness (#583, v26.15-alpha12)
 - Fix failing docker image build (#582, v26.15-alpha11)
 - Move index management privilege from Kibana to ElasticSearch (#581, v26.15-alpha10)
@@ -12,6 +13,7 @@
 - Update webauthn package (#572, v26.15-alpha3)
 
 ### Features
+- Use vendored kazoo for pesistent watcher support (#592, v26.15-alpha19)
 - Disabling resources (#590, v26.15-alpha18)
 - Improve audit logging (#589, v26.15-alpha17)
 - Accept ASAB internal auth tokens at userinfo endpoint (#591, v26.15-alpha16)
@@ -26,6 +28,7 @@
 - Always include link in response if SMTP is not configured (#561, v26.15-alpha)
 
 ### Pre-releases
+- v26.15-alpha19
 - v26.15-alpha18
 - v26.15-alpha17
 - v26.15-alpha16

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN apk add --no-cache  \
     pysaml2 \
     pymongo \
     sentry-sdk \
+    git+https://github.com/TeskaLabs/kazoo.git \
     "asab[encryption] @ git+https://github.com/TeskaLabs/asab.git"
 
 # This is for github CI/CD logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ RUN apk add --no-cache  \
     git+https://github.com/TeskaLabs/kazoo.git \
     "asab[encryption] @ git+https://github.com/TeskaLabs/asab.git"
 
+# ^^^ Use vendored Kazoo library till https://github.com/python-zk/kazoo/pull/715 is merged (persistent watcher support)
+
 # This is for github CI/CD logs
 RUN /venv/bin/python3 -c "import asab; print(asab.__version__)"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build process to install the latest `kazoo` package directly from its source repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->